### PR TITLE
Setup Thicket for PyPI hosting and Pip Installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,10 @@ build-backend = "setuptools.build_meta"
 #     "pydot",
 #     "matplotlib",
 #     "numpy",
-#     "pandas",
+#     "pandas >= 1.1",
 #     "llnl-hatchet"
 # ]
-# requires-python = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+# requires-python = ">=3.6.1"
 # license = { file = "LICENSE" }
 # keywords = []
 # classifiers = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,34 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+# TODO uncomment once tool.setuptools is no longer in beta
+# [project]
+# name = "llnl-thicket"
+# dynamic = ["version"]
+# description = "Toolkit for exploratory data analysis of ensemble performance data"
+# readme = { file = "README.md", content-type = "text/markdown" }
+# dependencies = [
+#     "scipy",
+#     "seaborn",
+#     "pydot",
+#     "matplotlib",
+#     "numpy",
+#     "pandas",
+#     "llnl-hatchet"
+# ]
+# requires-python = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+# license = { file = "LICENSE" }
+# keywords = []
+# classifiers = []
+#
+# [project.urls]
+# documentation = "https://thicket.readthedocs.io/"
+# repository = "https://github.com/LLNL/thicket"
+#
+# [tool.setuptools.dynamic]
+# version = { attr = "thicket.version.__version__" }
+
 [tool.poetry]
 name = "llnl-thicket"
 version = "2023.1.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,25 @@
+[metadata]
+name = llnl-thicket
+version =  attr: thicket.version.__version__
+description = Toolkit for exploratory data analysis of ensemble performance data
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = MIT
+# url =
+# keywords = []
+# classifiers = []
+
+[options]
+packages =
+    thicket
+    thicket.stats
+    thicket.vis
+install_requires =
+    scipy
+    seaborn
+    pydot
+    matplotlib
+    numpy
+    pandas
+    llnl-hatchet
+python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,6 @@ install_requires =
     pydot
     matplotlib
     numpy
-    pandas
+    pandas >= 1.1
     llnl-hatchet
-python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
+python_requires = >=3.6.1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     long_description_content_type="text/markdown",
     keywords="",
     url="",
-    python_requires = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*",
+    python_requires=">=3.6.1",
     packages=[
         "thicket",
         "thicket.stats",
@@ -42,7 +42,7 @@ setup(
         "pydot",
         "matplotlib",
         "numpy",
-        "pandas",
+        "pandas >= 1.1",
         "llnl-hatchet",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     long_description_content_type="text/markdown",
     keywords="",
     url="",
+    python_requires = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*",
     packages=[
         "thicket",
         "thicket.stats",

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,6 @@ setup(
         "matplotlib",
         "numpy",
         "pandas",
+        "llnl-hatchet",
     ],
 )


### PR DESCRIPTION
This PR will tweak the build, setup, and configuration files for Thicket so that Thicket will be able to be uploaded to PyPI and installed using `pip`.

Currently, this PR does the following:
* Adds build system info to `pyproject.toml` (see [PEP 517](https://peps.python.org/pep-0517/) for more info). This is the recommended way to configure a modern Python project for building. Additionally, in the (possibly not-too-distant) future, this will be required for any `pip`-installable package.
* Adds a `setup.cfg` file to configure `setuptools` when running `pip` in its PEP 517-compliant mode. This can be fully migrated into `pyproject.toml` once certain features of `setuptools` move out of beta.
* Adds a `python_requires` argument in `setup.py` since Hatchet (and, by extension, Thicket) only support Python 2.7 and Python 3.5+.

Additional information and details will be added through comments on this PR as they become available.