### PR TITLE
Adds new GitHub Action to publish to PyPI on GitHub Release

### DIFF
--- a/.github/workflows/pypi_build_and_upload.yaml
+++ b/.github/workflows/pypi_build_and_upload.yaml
@@ -1,0 +1,26 @@
+name: Build Thicket and Upload to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build_and_upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install Python Build Tool
+        run: |
+          python3 -m pip install --upgrade build
+      - name: Build Thicket
+        run: |
+          python3 -m build -s -w
+      - name: Publish Thicket to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This PR adds a new GitHub Action that will publish a new Thicket release on PyPI whenever a new GitHub release is published.

For this Action to work, a PyPI API token will have to be added as a secret to this repo. This article explains the process of obtaining the API token and adding it to the repo: https://www.seanh.cc/2022/05/21/publishing-python-packages-from-github-actions/#create-a-pypi-api-token

The name of the token should be `PYPI_API_TOKEN`. If it's not, I'll have to change the last line of the `.yaml` file for the Action refer to the correct secret.

@slabasan, if we want to add this Action, it would probably be best if you added the secret.