### PR TITLE
fix pytest errors

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -45,6 +45,7 @@ jobs:
 
     - name: Pin pandas version
       if: ${{ matrix.python-version == 3.7 }}
+      run: |
         pip install pandas==1.2.5
         python -m pip list | grep pandas
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -43,6 +43,11 @@ jobs:
         python setup.py build_ext --inplace
         python -m pip list
 
+    - name: Pin pandas version
+      if: ${{ matrix.python-version == 3.7 }}
+        pip install pandas==1.2.5
+        python -m pip list | grep pandas
+
     - name: Update Black
       if: ${{ matrix.python-version == 3.7 }}
       run: |

--- a/thicket/tests/test_copy.py
+++ b/thicket/tests/test_copy.py
@@ -54,8 +54,10 @@ def test_copy(example_cali):
     assert self.graph.roots[0] is other.graph.roots[0]
 
     # Shallow copy of data
-    other.dataframe.iloc[0, 0] = 0
-    assert other.dataframe.iloc[0, 0] == self.dataframe.iloc[0, 0]
+    node = other.dataframe.index.get_level_values("node")[0]
+    profile = other.dataframe.index.get_level_values("profile")[0]
+    other.dataframe.loc[(node, profile), "nid"] = -1
+    assert other.dataframe.loc[(node, profile), "nid"] == self.dataframe.loc[(node, profile), "nid"]
     # Deep copy of structure
     assert len(self.dataframe.columns) + len(self.dataframe.index[0]) == len(
         other.dataframe.reset_index().columns

--- a/thicket/tests/test_copy.py
+++ b/thicket/tests/test_copy.py
@@ -57,7 +57,10 @@ def test_copy(example_cali):
     node = other.dataframe.index.get_level_values("node")[0]
     profile = other.dataframe.index.get_level_values("profile")[0]
     other.dataframe.loc[(node, profile), "nid"] = -1
-    assert other.dataframe.loc[(node, profile), "nid"] == self.dataframe.loc[(node, profile), "nid"]
+    assert (
+        other.dataframe.loc[(node, profile), "nid"]
+        == self.dataframe.loc[(node, profile), "nid"]
+    )
     # Deep copy of structure
     assert len(self.dataframe.columns) + len(self.dataframe.index[0]) == len(
         other.dataframe.reset_index().columns

--- a/thicket/tests/test_thicket.py
+++ b/thicket/tests/test_thicket.py
@@ -257,7 +257,7 @@ def test_filter_stats(example_cali_multiprofile):
     # set string column values
     less_than_20 = ["less than 20"] * 21
     less_than_45 = ["less than 45"] * 25
-    less_than_87 = ["less than 87"] * 41
+    less_than_87 = ["less than 87"] * 40
     new_col = less_than_20 + less_than_45 + less_than_87
 
     th.statsframe.dataframe["test_string_column"] = new_col

--- a/thicket/tests/test_thicket.py
+++ b/thicket/tests/test_thicket.py
@@ -259,7 +259,7 @@ def test_filter_stats(example_cali_multiprofile):
     # set string column values
     less_than_20 = ["less than 20"] * 21
     less_than_45 = ["less than 45"] * 26
-    less_than_87 = ["less than 87"] * (nrows-45+1)
+    less_than_87 = ["less than 87"] * (nrows - 45 + 1)
     new_col = less_than_20 + less_than_45 + less_than_87
 
     th.statsframe.dataframe["test_string_column"] = new_col

--- a/thicket/tests/test_thicket.py
+++ b/thicket/tests/test_thicket.py
@@ -255,7 +255,7 @@ def test_filter_stats(example_cali_multiprofile):
     }
 
     # set string column values
-    th.statsframe.dataframe.loc[0:20, "test_string_column"] = "less than 20"
+    th.statsframe.dataframe["test_string_column"] = "less than 20"
     th.statsframe.dataframe.loc[20:45, "test_string_column"] = "less than 45"
     th.statsframe.dataframe.loc[45:, "test_string_column"] = "less that 87"
 

--- a/thicket/tests/test_thicket.py
+++ b/thicket/tests/test_thicket.py
@@ -254,12 +254,10 @@ def test_filter_stats(example_cali_multiprofile):
         "test_numeric_column": [4, 15],
     }
 
-    nrows = th.statsframe.dataframe.shape[0]
-
     # set string column values
     less_than_20 = ["less than 20"] * 21
-    less_than_45 = ["less than 45"] * 26
-    less_than_87 = ["less than 87"] * (nrows - 45 + 1)
+    less_than_45 = ["less than 45"] * 25
+    less_than_87 = ["less than 87"] * 41
     new_col = less_than_20 + less_than_45 + less_than_87
 
     th.statsframe.dataframe["test_string_column"] = new_col

--- a/thicket/tests/test_thicket.py
+++ b/thicket/tests/test_thicket.py
@@ -254,10 +254,15 @@ def test_filter_stats(example_cali_multiprofile):
         "test_numeric_column": [4, 15],
     }
 
+    nrows = th.statsframe.dataframe.shape[0]
+
     # set string column values
-    th.statsframe.dataframe["test_string_column"] = "less than 20"
-    th.statsframe.dataframe.loc[20:45, "test_string_column"] = "less than 45"
-    th.statsframe.dataframe.loc[45:, "test_string_column"] = "less that 87"
+    less_than_20 = ["less than 20"] * 21
+    less_than_45 = ["less than 45"] * 26
+    less_than_87 = ["less than 87"] * (nrows-45+1)
+    new_col = less_than_20 + less_than_45 + less_than_87
+
+    th.statsframe.dataframe["test_string_column"] = new_col
 
     # set numeric column values
     th.statsframe.dataframe["test_numeric_column"] = range(0, 86)


### PR DESCRIPTION
Fixing two errors with pandas 2.0 and pandas 1.3.5. First, is a TypeError for positional slicing. Second, we address an error with shallow dataframe copies. We bump to pandas 1.2.5 to address the issue, and still investigating the error in pandas 1.3.5.
 
add new dataframe column of initial values, then change certain rows to a different value

Pandas 1.3.5 shows a futurewarning:
```
FutureWarning: Slicing a positional slice with .loc is not supported, and will raise TypeError in a future version.  Use .loc with labels or .iloc with positions instead.
```

Pandas 2.0 results in a typeerror.
```
>       th.statsframe.dataframe.loc[0:20, "test_string_column"] = "less than 20"

E               TypeError: Slicing a positional slice with .loc is not allowed, Use .loc with labels or .iloc with positions instead.
```