### PR TITLE
bugfix: get unique metadata on non-list values

### DIFF
--- a/thicket/tests/test_thicket.py
+++ b/thicket/tests/test_thicket.py
@@ -158,4 +158,4 @@ def test_unique_metadata_base_cuda(rajaperf_basecuda_xl_cali):
     res = t_ens.get_unique_metadata()
     assert res["systype_build"] == ["blueos_3_ppc64le_ib_p9"]
     assert res["variant"] == ["Base_CUDA"]
-    assert res["gpu_targets_block_sizes"] == ["128"]
+    assert res["gpu_targets_block_sizes"] == [128]

--- a/thicket/tests/test_thicket.py
+++ b/thicket/tests/test_thicket.py
@@ -150,3 +150,12 @@ def test_unify_ensemble(mpi_scaling_cali):
     # Check specific values. Row order can vary so use "sum" to check
     node = th_listwise.dataframe.index.get_level_values("node")[8]
     assert sum(th_listwise.dataframe.loc[node, "Min time/rank"]) == 0.000453
+
+
+def test_unique_metadata_base_cuda(rajaperf_basecuda_xl_cali):
+    t_ens = Thicket.from_caliperreader(rajaperf_basecuda_xl_cali)
+
+    res = t_ens.get_unique_metadata()
+    assert res["systype_build"] == ["blueos_3_ppc64le_ib_p9"]
+    assert res["variant"] == ["Base_CUDA"]
+    assert res["gpu_targets_block_sizes"] == ["128"]

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1178,7 +1178,6 @@ class Thicket(GraphFrame):
             (dict): alphabetical ordered dictionary with key's being the column names
                       and the values being unique values for a column
         """
-
         unique_meta = {}
 
         for col in self.metadata.columns:

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1180,11 +1180,14 @@ class Thicket(GraphFrame):
         """
 
         unique_meta = {}
-        columns = self.metadata.columns
 
-        for col in columns:
-            unique_entries = self.metadata[col].unique().tolist()
-            unique_meta[col] = unique_entries
+        for col in self.metadata.columns:
+            # skip columns where the values are a list
+            if isinstance(self.metadata[col].iloc[0], list):
+                continue
+            else:
+                unique_entries = self.metadata[col].unique().tolist()
+                unique_meta[col] = unique_entries
 
         sorted_meta = dict(sorted(unique_meta.items(), key=lambda x: x[0].lower()))
 


### PR DESCRIPTION
get_unique_metadata will skip columns where the values are of a list

Fixes #12