### PR TITLE
Update Filter to Support MultiIndex Columns

### DIFF
--- a/thicket/tests/test_columnar_join.py
+++ b/thicket/tests/test_columnar_join.py
@@ -5,6 +5,7 @@
 
 import pytest
 
+from test_filter import check_filter
 from thicket import Thicket
 
 
@@ -17,7 +18,7 @@ def columnar_join_thicket(mpi_scaling_cali, rajaperf_basecuda_xl_cali):
         rajaperf_basecuda_xl_cali (list): List of Caliper files for basecuda.
 
     Returns:
-        list: List of Thicket objects.
+        list: List of original thickets, list of deepcopies of original thickets, and columnar-joined thicket.
     """
     th_mpi_1 = Thicket.from_caliperreader(mpi_scaling_cali[0:2])
     th_mpi_2 = Thicket.from_caliperreader(mpi_scaling_cali[2:4])
@@ -80,3 +81,14 @@ def test_columnar_join(columnar_join_thicket):
     assert len(combined_th.profile_mapping) == sum(
         [len(th.profile_mapping) for th in thicket_list]
     )
+
+
+def test_filter_columnar_join(columnar_join_thicket):
+    thicket_list, thicket_list_cp, combined_th = columnar_join_thicket
+    # columns and corresponding values to filter by
+    columns_values = {
+        ("MPI1", "mpi.world.size"): [27],
+        ("Cuda128", "cali.caliper.version"): ["2.9.0-dev"],
+    }
+
+    check_filter(combined_th, columns_values)

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1002,8 +1002,17 @@ class Thicket(GraphFrame):
         """
         if callable(select_function):
             if not self.metadata.empty:
-                # check profile is an index level in metadata
-                verify_thicket_structures(self.metadata, index=["profile"])
+                # check only 1 index in metadata
+                assert self.metadata.index.nlevels == 1
+
+                # Add warning if filtering on MultiIndex columns
+                if isinstance(new_th.dataframe.columns, pd.MultiIndex):
+                    warnings.warn(
+                        "Filtering on MultiIndex columns will impact the entire row."
+                    )
+
+                # Get index name
+                index_name = self.metadata.index.name
 
                 # create a copy of the thicket object
                 new_thicket = self.copy()
@@ -1012,12 +1021,12 @@ class Thicket(GraphFrame):
                 filtered_rows = new_thicket.metadata.apply(select_function, axis=1)
                 new_thicket.metadata = new_thicket.metadata[filtered_rows]
 
-                # note profile keys to filter EnsembleFrame
-                profile_id = new_thicket.metadata.index.values.tolist()
+                # note index keys to filter EnsembleFrame
+                index_id = new_thicket.metadata.index.values.tolist()
                 # filter EnsembleFrame based on the MetadataFrame
                 new_thicket.dataframe = new_thicket.dataframe[
-                    new_thicket.dataframe.index.get_level_values("profile").isin(
-                        profile_id
+                    new_thicket.dataframe.index.get_level_values(index_name).isin(
+                        index_id
                     )
                 ]
 

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1006,9 +1006,9 @@ class Thicket(GraphFrame):
                 assert self.metadata.index.nlevels == 1
 
                 # Add warning if filtering on MultiIndex columns
-                if isinstance(new_th.dataframe.columns, pd.MultiIndex):
+                if isinstance(self.metadata.columns, pd.MultiIndex):
                     warnings.warn(
-                        "Filtering on MultiIndex columns will impact the entire row."
+                        "Filtering on MultiIndex columns will impact the entire row, not just the subsection of the provided MultiIndex."
                     )
 
                 # Get index name


### PR DESCRIPTION
- Small change to `filter_metadata` to include MultiIndex column support.
- Refactor `test_filter` unit test in order to add `test_filter_columnar_join` unit test.

These changes are apart of the effort to run our existing unit tests on the new MultiIndex structure created from running a columnar join.