### PR TITLE
Correct old references that don't match to current

### DIFF
--- a/thicket/__init__.py
+++ b/thicket/__init__.py
@@ -6,7 +6,9 @@
 # make flake8 unused names in this file.
 # flake8: noqa: F401
 
-from .thicket import Thicket, InvalidFilter, EmptyMetadataFrame
+from .thicket import Thicket
+from .thicket import InvalidFilter
+from .thicket import EmptyMetadataTable
 from .stats.maximum import maximum
 from .stats.mean import mean
 from .stats.median import median

--- a/thicket/helpers.py
+++ b/thicket/helpers.py
@@ -61,14 +61,16 @@ def _missing_nodes_to_list(a_df, b_df):
 
 
 def _new_statsframe_df(df, multiindex=False):
-    """Generate new StatsFrame DataFrame from a DataFrame. This is most commonly needed when changes are made to the PerfData's index.
+    """Generate new aggregated statistics table from a DataFrame. This is most commonly
+    needed when changes are made to the PerfData's index.
 
     Arguments:
-        df (DataFrame): Input DataFrame to generate the StatsFrame DataFrame from
-        multiindex (Bool, optional): Option to setup MultiIndex column structure. This is standard to do if PerfData is MultiIndex.
+        df (DataFrame): Input DataFrame to generate the aggregated statistics table from
+        multiindex (Bool, optional): Option to setup MultiIndex column structure. This
+            is standard to do if PerfData is MultiIndex.
 
     Returns:
-        (DataFrame): new StatsFrame DataFrame
+        (DataFrame): new aggregated statistics table
     """
     nodes = list(set(df.reset_index()["node"]))  # List of nodes
     names = [node.frame["name"] for node in nodes]  # List of names

--- a/thicket/model_extrap.py
+++ b/thicket/model_extrap.py
@@ -149,13 +149,14 @@ class Modeling:
 
         frm_dict = {met + MODEL_TAG: model_to_img_html for met in self.chosen_metrics}
 
-        # Subset of the statsframes with only the Extra-P columns selected
+        # Subset of the aggregated statistics table with only the Extra-P columns selected
         return self.tht.statsframe.dataframe[
             [met + MODEL_TAG for met in self.chosen_metrics]
         ].to_html(escape=False, formatters=frm_dict)
 
     def _add_extrap_statistics(self, node, metric):
-        """Insert the Extra-P hypothesis function statistics into the statsframe. Has to be called after "produce_models".
+        """Insert the Extra-P hypothesis function statistics into the aggregated
+        statistics table. Has to be called after "produce_models".
 
         Arguments:
             node (hatchet.Node): The node for which statistics should be calculated
@@ -188,10 +189,11 @@ class Modeling:
             agg_func (function): aggregation function to apply to
                 multi-dimensional measurement values. Extra-P v4.0.4 applies
                 mean by default so that is set here for clarity.
-            add_stats (bool): Option to add hypothesis function statistics to the statsframe
+            add_stats (bool): Option to add hypothesis function statistics to the
+                aggregated statistics table
         """
         # Setup domain values one time. Have to match ordering with range
-        # values (i.e. ensembleframe profile ordering)
+        # values (i.e. performance data table profile ordering)
         param_coords = []  # default coordinates for all profiles
 
         # Mapping from metadata profiles to the parameter
@@ -202,7 +204,7 @@ class Modeling:
             [(value, key) for key, value in meta_param_mapping.items()]
         )
 
-        # Ordering of profiles in the ensembleframe
+        # Ordering of profiles in the performance data table
         ensemble_profile_ordering = list(self.tht.dataframe.index.unique(level=1))
 
         # Append coordinates in order
@@ -274,7 +276,7 @@ class Modeling:
                 self.tht.statsframe.dataframe.at[node, met + MODEL_TAG] = ModelWrapper(
                     model_gen.models[mkey], self.param_name
                 )
-                # Add statistics to statsframe
+                # Add statistics to aggregated statistics table
                 if add_stats:
                     self._add_extrap_statistics(node, met)
 
@@ -304,11 +306,12 @@ class Modeling:
         return term_dict
 
     def componentize_statsframe(self, columns=None):
-        """Componentize multiple Extra-P modeling objects in the statsframe
+        """Componentize multiple Extra-P modeling objects in the aggregated statistics
+        table
 
         Arguments:
-            column (list): list of column names in the statsframe to componentize.
-                Values must be of type 'thicket.model_extrap.ModelWrapper'.
+            column (list): list of column names in the aggregated statistics table to
+                componentize. Values must be of type 'thicket.model_extrap.ModelWrapper'.
         """
         # Use all Extra-P columns
         if columns is None:
@@ -321,7 +324,9 @@ class Modeling:
         # Error checking
         for c in columns:
             if c not in self.tht.statsframe.dataframe.columns:
-                raise ValueError("column " + c + " is not in the statsframe.")
+                raise ValueError(
+                    "column " + c + " is not in the aggregated statistics table."
+                )
             elif not isinstance(self.tht.statsframe.dataframe[c][0], ModelWrapper):
                 raise TypeError(
                     "column "

--- a/thicket/tests/test_filter_metadata.py
+++ b/thicket/tests/test_filter_metadata.py
@@ -5,7 +5,9 @@
 
 import pytest
 
-from thicket import Thicket, InvalidFilter, EmptyMetadataFrame
+from thicket import Thicket
+from thicket import InvalidFilter
+from thicket import EmptyMetadataTable
 
 
 def filter_one_column(th, columns_values):
@@ -29,11 +31,12 @@ def filter_one_column(th, columns_values):
             # check if output is a thicket object
             assert isinstance(new_th, Thicket)
 
-            # MetadataFrame: compare profile hash keys after filter to expected
+            # metadata table: compare profile hash keys after filter to expected
             metadata_profile = new_th.metadata.index.tolist()
             assert metadata_profile == exp_index
 
-            # EnsembleFrame: compare profile hash keys and nodes after filter to expected
+            # performance data table: compare profile hash keys and nodes after filter
+            # to expected
             ensemble_profile = sorted(
                 new_th.dataframe.index.get_level_values(1).drop_duplicates().tolist()
             )
@@ -43,7 +46,8 @@ def filter_one_column(th, columns_values):
             assert ensemble_profile == exp_index
             assert ensemble_nodes == exp_nodes
 
-            # StatsFrame: compare nodes after filter to expected; check for empty dataframe
+            # aggregated statistics table: compare nodes after filter to expected; check
+            # for empty dataframe
             stats_nodes = sorted(
                 new_th.statsframe.dataframe.index.get_level_values(0)
                 .drop_duplicates()
@@ -72,7 +76,7 @@ def filter_multiple_and(th, columns_values):
     # check if output is a thicket object
     assert isinstance(new_th, Thicket)
 
-    # MetadataFrame: compare profile hash keys after filter to expected
+    # metadata table: compare profile hash keys after filter to expected
     metadata_profile = new_th.metadata.index.tolist()
     assert metadata_profile == exp_index
 
@@ -95,7 +99,8 @@ def filter_multiple_and(th, columns_values):
     assert exp_nodes == filter_nodes
     assert exp_index == filter_profiles
 
-    # StatsFrame: compare nodes after filter to expected; check for empty dataframe
+    # aggregated statistics table: compare nodes after filter to expected; check for
+    # empty dataframe
     stats_nodes = sorted(
         new_th.statsframe.dataframe.index.get_level_values(0).drop_duplicates().tolist()
     )
@@ -122,7 +127,7 @@ def filter_multiple_or(th, columns_values):
     # check if output is a thicket object
     assert isinstance(new_th, Thicket)
 
-    # MetadataFrame: compare profile hash keys after filter to expected
+    # metadata table: compare profile hash keys after filter to expected
     metadata_profile = new_th.metadata.index.tolist()
     assert metadata_profile == exp_index
 
@@ -145,7 +150,8 @@ def filter_multiple_or(th, columns_values):
     assert exp_nodes == filter_nodes
     assert exp_index == filter_profiles
 
-    # StatsFrame: compare nodes after filter to expected; check for empty dataframe
+    # aggregated statistics table: compare nodes after filter to expected; check for
+    # empty dataframe
     stats_nodes = sorted(
         new_th.statsframe.dataframe.index.get_level_values(0).drop_duplicates().tolist()
     )
@@ -156,11 +162,11 @@ def filter_multiple_or(th, columns_values):
     with pytest.raises(InvalidFilter):
         th.filter_metadata(123)
 
-    # drop all rows of the metadataframe
+    # drop all rows of the metadata table
     th.metadata = th.metadata.iloc[0:0]
 
-    # check for empty metadataframe exception
-    with pytest.raises(EmptyMetadataFrame):
+    # check for empty metadata table exception
+    with pytest.raises(EmptyMetadataTable):
         th.filter_metadata(lambda x: x["cluster"] == "chekov")
 
 

--- a/thicket/tests/test_filter_stats.py
+++ b/thicket/tests/test_filter_stats.py
@@ -35,18 +35,18 @@ def check_filter_stats(th, columns_values):
             # check if output is a thicket object
             assert isinstance(new_th, Thicket)
 
-            # filtered statsframe nodes
+            # filtered nodes in aggregated statistics table
             stats_nodes = sorted(
                 new_th.statsframe.dataframe.index.drop_duplicates().tolist()
             )
-            # check filtered statsframe nodes match exp_nodes
+            # check filtered nodes in aggregated statistics table match exp_nodes
             assert stats_nodes == exp_nodes
 
-            # filtered ensemble nodes
+            # filtered nodes in performance data table
             ensemble_nodes = sorted(
                 new_th.dataframe.index.get_level_values(0).drop_duplicates().tolist()
             )
-            # check filtered ensembleframe nodes match exp_nodes
+            # check filtered nodes in performance data table match exp_nodes
             assert ensemble_nodes == exp_nodes
 
 

--- a/thicket/tests/test_groupby.py
+++ b/thicket/tests/test_groupby.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from thicket import Thicket, EmptyMetadataFrame
+from thicket import Thicket, EmptyMetadataTable
 from test_columnar_join import test_columnar_join
 
 
@@ -37,7 +37,7 @@ def check_groupby(th, columns_values):
             metadata_profiles = sorted(th_list[itr].metadata.index.tolist())
             assert metadata_profiles == exp_profiles
 
-            # ensemble profile hash for unique value sub-thicket
+            #  performance data table profile hash for unique value sub-thicket
             ensemble_profiles = sorted(
                 th_list[itr]
                 .dataframe.index.get_level_values(1)
@@ -46,7 +46,7 @@ def check_groupby(th, columns_values):
             )
             assert ensemble_profiles == exp_profiles
 
-            # ensemble nodes for unique value sub-thicket
+            # performance data table nodes for unique value sub-thicket
             ensemble_nodes = sorted(
                 th_list[itr]
                 .dataframe.index.get_level_values(0)
@@ -55,7 +55,7 @@ def check_groupby(th, columns_values):
             )
             assert ensemble_nodes == exp_nodes
 
-            # stats nodes for unique value sub-thicket
+            # aggregated statistics nodes for unique value sub-thicket
             stats_nodes = sorted(
                 th_list[itr]
                 .statsframe.dataframe.index.get_level_values(0)
@@ -64,14 +64,14 @@ def check_groupby(th, columns_values):
             )
             assert stats_nodes == exp_nodes
 
-            # check for name column statsframe dataframe
+            # check for name column in aggregated statistics table
             assert "name" in th_list[itr].statsframe.dataframe.columns
 
-    # drop all rows of the metadataframe
+    # drop all rows of the metadata table
     th.metadata = th.metadata.iloc[0:0]
 
-    # check for empty metadataframe exception
-    with pytest.raises(EmptyMetadataFrame):
+    # check for empty metadata table exception
+    with pytest.raises(EmptyMetadataTable):
         th.groupby(["user"])
 
 

--- a/thicket/tests/test_make_superthicket.py
+++ b/thicket/tests/test_make_superthicket.py
@@ -11,7 +11,7 @@ def test_make_superthicket(mpi_scaling_cali):
     for file in mpi_scaling_cali:
         th_list.append(th.from_caliperreader(file))
 
-    # Add arbitrary value to statsframe
+    # Add arbitrary value to aggregated statistics table
     t_val = 0
     for t in th_list:
         t.statsframe.dataframe["test"] = t_val

--- a/thicket/tests/test_thicket.py
+++ b/thicket/tests/test_thicket.py
@@ -71,13 +71,13 @@ def test_sync_nodes(example_cali):
     assert helpers._are_synced(th.graph, th.dataframe)
 
 
-def test_statsframe(example_cali):
+def test_aggregated_statistics_table(example_cali):
     th = Thicket.from_caliperreader(example_cali[-1])
 
-    # Arbitrary value insertion in StatsFrame.
+    # Arbitrary value insertion in aggregated statistics table.
     th.statsframe.dataframe["test"] = 1
 
-    # Check that the statsframe is a Hatchet GraphFrame.
+    # Check that the aggregated statistics table is a Hatchet GraphFrame.
     assert isinstance(th.statsframe, ht.GraphFrame)
     # Check that 'name' column is in dataframe. If not, tree() will not work.
     assert "name" in th.statsframe.dataframe
@@ -86,8 +86,8 @@ def test_statsframe(example_cali):
 
     # Expected tree output
     tree_output = th.statsframe.tree(metric_column="test")
-    # Check if tree output is correct.
 
+    # Check if tree output is correct.
     assert bool(re.search("1.000.*MPI_Comm_dup", tree_output))
     assert bool(re.search("1.000.*MPI_Initialized", tree_output))
     assert bool(re.search("1.000.*CalcFBHourglassForceForElems", tree_output))
@@ -99,19 +99,19 @@ def test_add_column_from_metadata(mpi_scaling_cali):
     example_column = "jobsize"
     example_column_metrics = [27, 64, 125, 216, 343]
 
-    # Column should be in MetadataFrame
+    # Column should be in metadata table
     assert example_column in t_ens.metadata
-    # Column should not be in EnsembleFrame
+    # Column should not be in performance data table
     assert example_column not in t_ens.dataframe
     # Assume second level index is profile
     assert t_ens.dataframe.index.names[1] == "profile"
 
     t_ens.add_column_from_metadata_to_ensemble(example_column)
 
-    # Column should be in EnsembleFrame
+    # Column should be in performance data table
     assert example_column in t_ens.dataframe
 
-    # Check that the metrics exist in the EnsembleFrame
+    # Check that the metrics exist in the performance data table
     values = t_ens.dataframe[example_column].values.astype("int")
     for metric in example_column_metrics:
         assert metric in values


### PR DESCRIPTION
The goal of this PR to remove old verbiage such as EnsembleFrame, StatsFrame, and MetadataFrame and match them to how these components are currently referenced.