### PR TITLE
Update filter_metadata() test case for two columns

### DIFF
--- a/thicket/tests/test_columnar_join.py
+++ b/thicket/tests/test_columnar_join.py
@@ -8,7 +8,10 @@ import re
 import pytest
 import hatchet as ht
 
-from test_filter_metadata import check_filter_metadata
+from test_filter_metadata import (
+    filter_one_column,
+    filter_multiple_and,
+)
 from test_filter_stats import check_filter_stats
 from test_query import check_query
 from thicket import Thicket
@@ -96,7 +99,8 @@ def test_filter_columnar_join(columnar_join_thicket):
         ("Cuda128", "cali.caliper.version"): ["2.9.0-dev"],
     }
 
-    check_filter_metadata(combined_th, columns_values)
+    filter_one_column(combined_th, columns_values)
+    filter_multiple_and(combined_th, columns_values)
 
 
 def test_filter_stats_columnar_join(columnar_join_thicket):

--- a/thicket/tests/test_columnar_join.py
+++ b/thicket/tests/test_columnar_join.py
@@ -8,10 +8,8 @@ import re
 import pytest
 import hatchet as ht
 
-from test_filter_metadata import (
-    filter_one_column,
-    filter_multiple_and,
-)
+from test_filter_metadata import filter_one_column
+from test_filter_metadata import filter_multiple_and
 from test_filter_stats import check_filter_stats
 from test_query import check_query
 from thicket import Thicket
@@ -23,7 +21,7 @@ def columnar_join_thicket(mpi_scaling_cali, rajaperf_basecuda_xl_cali):
 
     Arguments:
         mpi_scaling_cali (list): List of Caliper files for MPI scaling study.
-        rajaperf_basecuda_xl_cali (list): List of Caliper files for basecuda.
+        rajaperf_basecuda_xl_cali (list): List of Caliper files for base cuda variant.
 
     Returns:
         list: List of original thickets, list of deepcopies of original thickets, and columnar-joined thicket.

--- a/thicket/tests/test_filter_metadata.py
+++ b/thicket/tests/test_filter_metadata.py
@@ -8,56 +8,114 @@ import pytest
 from thicket import Thicket, InvalidFilter, EmptyMetadataFrame
 
 
-def check_filter_metadata(th, columns_values):
+def check_filter_metadata(th, columns_values, total_col=1):
     """Check filter function for Thicket object.
 
     Arguments:
         th (Thicket): Thicket object to test.
         columns_values (dict): Dictionary of columns and corresponding values to filter by.
     """
+    if total_col == 1:
+        index_name = th.metadata.index.name
+        for column in columns_values:
+            for value in columns_values[column]:
+                # get expected profile hash and nodes after filtering
+                exp_index = sorted(
+                    th.metadata.index[th.metadata[column] == value].tolist()
+                )
+                exp_nodes = sorted(
+                    th.dataframe[
+                        th.dataframe.index.get_level_values(index_name).isin(exp_index)
+                    ]
+                    .index.get_level_values(0)
+                    .drop_duplicates()
+                    .tolist()
+                )
 
-    index_name = th.metadata.index.name
-    for column in columns_values:
-        for value in columns_values[column]:
-            # get expected profile hash and nodes after filtering
-            exp_index = sorted(th.metadata.index[th.metadata[column] == value].tolist())
-            exp_nodes = sorted(
-                th.dataframe[
-                    th.dataframe.index.get_level_values(index_name).isin(exp_index)
-                ]
-                .index.get_level_values(0)
-                .drop_duplicates()
-                .tolist()
-            )
+                # filter function
+                new_th = th.filter_metadata(lambda x: x[column] == value)
 
-            # filter function
-            new_th = th.filter_metadata(lambda x: x[column] == value)
+                # check if output is a thicket object
+                assert isinstance(new_th, Thicket)
 
-            # check if output is a thicket object
-            assert isinstance(new_th, Thicket)
+                # MetadataFrame: compare profile hash keys after filter to expected
+                metadata_profile = new_th.metadata.index.tolist()
+                assert metadata_profile == exp_index
 
-            # MetadataFrame: compare profile hash keys after filter to expected
-            metadata_profile = new_th.metadata.index.tolist()
-            assert metadata_profile == exp_index
+                # EnsembleFrame: compare profile hash keys and nodes after filter to expected
+                ensemble_profile = sorted(
+                    new_th.dataframe.index.get_level_values(1)
+                    .drop_duplicates()
+                    .tolist()
+                )
+                ensemble_nodes = sorted(
+                    new_th.dataframe.index.get_level_values(0)
+                    .drop_duplicates()
+                    .tolist()
+                )
+                assert ensemble_profile == exp_index
+                assert ensemble_nodes == exp_nodes
 
-            # EnsembleFrame: compare profile hash keys and nodes after filter to expected
-            ensemble_profile = sorted(
-                new_th.dataframe.index.get_level_values(1).drop_duplicates().tolist()
-            )
-            ensemble_nodes = sorted(
-                new_th.dataframe.index.get_level_values(0).drop_duplicates().tolist()
-            )
-            assert ensemble_profile == exp_index
-            assert ensemble_nodes == exp_nodes
+                # StatsFrame: compare nodes after filter to expected; check for empty dataframe
+                stats_nodes = sorted(
+                    new_th.statsframe.dataframe.index.get_level_values(0)
+                    .drop_duplicates()
+                    .tolist()
+                )
+                assert exp_nodes == stats_nodes
+                assert "name" in new_th.statsframe.dataframe.columns
+    # add when filter takes two columns
+    elif total_col == 2:
+        column1 = list(columns_values.keys())[0]
+        column2 = list(columns_values.keys())[1]
+        idx_col1 = th.metadata.index[
+            th.metadata[column1] == columns_values[column1][0]
+        ].tolist()
+        idx_col2 = th.metadata.index[
+            th.metadata[column2] == columns_values[column2][1]
+        ].tolist()
+        exp_index = sorted(list(set(idx_col1) & set(idx_col2)))
+        new_th = th.filter_metadata(
+            lambda x: x[column1] == columns_values[column1][0]
+            and x[column2] == columns_values[column2][1]
+        )
 
-            # StatsFrame: compare nodes after filter to expected; check for empty dataframe
-            stats_nodes = sorted(
-                new_th.statsframe.dataframe.index.get_level_values(0)
-                .drop_duplicates()
-                .tolist()
-            )
-            assert exp_nodes == stats_nodes
-            assert "name" in new_th.statsframe.dataframe.columns
+        # check if output is a thicket object
+        assert isinstance(new_th, Thicket)
+
+        # MetadataFrame: compare profile hash keys after filter to expected
+        metadata_profile = new_th.metadata.index.tolist()
+        assert metadata_profile == exp_index
+
+        # filter nodes and profiles
+        filter_profiles = sorted(
+            new_th.dataframe.index.get_level_values(1).drop_duplicates().tolist()
+        )
+        filter_nodes = sorted(
+            new_th.dataframe.index.get_level_values(0).drop_duplicates().tolist()
+        )
+
+        # compare profile hash keys and nodes after filter to expected
+        index_name = th.metadata.index.name
+        exp_nodes = sorted(
+            th.dataframe[
+                th.dataframe.index.get_level_values(index_name).isin(exp_index)
+            ]
+            .index.get_level_values(0)
+            .drop_duplicates()
+            .tolist()
+        )
+        assert exp_nodes == filter_nodes
+        assert exp_index == filter_profiles
+
+        # StatsFrame: compare nodes after filter to expected; check for empty dataframe
+        stats_nodes = sorted(
+            new_th.statsframe.dataframe.index.get_level_values(0)
+            .drop_duplicates()
+            .tolist()
+        )
+        assert exp_nodes == stats_nodes
+        assert "name" in new_th.statsframe.dataframe.columns
 
     # check for invalid filter exception
     with pytest.raises(InvalidFilter):
@@ -76,5 +134,6 @@ def test_filter_metadata(example_cali):
     th = Thicket.from_caliperreader(example_cali)
     # columns and corresponding values to filter by
     columns_values = {"problem_size": ["30"], "cluster": ["quartz", "chekov"]}
-
-    check_filter_metadata(th, columns_values)
+    th1 = th.copy()
+    check_filter_metadata(th, columns_values, 1)
+    check_filter_metadata(th1, columns_values, 2)

--- a/thicket/tests/test_filter_metadata.py
+++ b/thicket/tests/test_filter_metadata.py
@@ -74,6 +74,7 @@ def check_filter_metadata(th, columns_values, total_col=1):
         idx_col2 = th.metadata.index[
             th.metadata[column2] == columns_values[column2][1]
         ].tolist()
+        # expected profiles for this filter case
         exp_index = sorted(list(set(idx_col1) & set(idx_col2)))
         new_th = th.filter_metadata(
             lambda x: x[column1] == columns_values[column1][0]
@@ -134,6 +135,7 @@ def test_filter_metadata(example_cali):
     th = Thicket.from_caliperreader(example_cali)
     # columns and corresponding values to filter by
     columns_values = {"problem_size": ["30"], "cluster": ["quartz", "chekov"]}
+    # thicket for second scenario
     th1 = th.copy()
     check_filter_metadata(th, columns_values, 1)
     check_filter_metadata(th1, columns_values, 2)

--- a/thicket/tests/test_filter_metadata.py
+++ b/thicket/tests/test_filter_metadata.py
@@ -8,115 +8,149 @@ import pytest
 from thicket import Thicket, InvalidFilter, EmptyMetadataFrame
 
 
-def check_filter_metadata(th, columns_values, total_col=1):
-    """Check filter function for Thicket object.
+def filter_one_column(th, columns_values):
+    index_name = th.metadata.index.name
+    for column in columns_values:
+        for value in columns_values[column]:
+            # get expected profile hash and nodes after filtering
+            exp_index = sorted(th.metadata.index[th.metadata[column] == value].tolist())
+            exp_nodes = sorted(
+                th.dataframe[
+                    th.dataframe.index.get_level_values(index_name).isin(exp_index)
+                ]
+                .index.get_level_values(0)
+                .drop_duplicates()
+                .tolist()
+            )
 
-    Arguments:
-        th (Thicket): Thicket object to test.
-        columns_values (dict): Dictionary of columns and corresponding values to filter by.
-    """
-    if total_col == 1:
-        index_name = th.metadata.index.name
-        for column in columns_values:
-            for value in columns_values[column]:
-                # get expected profile hash and nodes after filtering
-                exp_index = sorted(
-                    th.metadata.index[th.metadata[column] == value].tolist()
-                )
-                exp_nodes = sorted(
-                    th.dataframe[
-                        th.dataframe.index.get_level_values(index_name).isin(exp_index)
-                    ]
-                    .index.get_level_values(0)
-                    .drop_duplicates()
-                    .tolist()
-                )
+            # filter function
+            new_th = th.filter_metadata(lambda x: x[column] == value)
 
-                # filter function
-                new_th = th.filter_metadata(lambda x: x[column] == value)
+            # check if output is a thicket object
+            assert isinstance(new_th, Thicket)
 
-                # check if output is a thicket object
-                assert isinstance(new_th, Thicket)
+            # MetadataFrame: compare profile hash keys after filter to expected
+            metadata_profile = new_th.metadata.index.tolist()
+            assert metadata_profile == exp_index
 
-                # MetadataFrame: compare profile hash keys after filter to expected
-                metadata_profile = new_th.metadata.index.tolist()
-                assert metadata_profile == exp_index
+            # EnsembleFrame: compare profile hash keys and nodes after filter to expected
+            ensemble_profile = sorted(
+                new_th.dataframe.index.get_level_values(1).drop_duplicates().tolist()
+            )
+            ensemble_nodes = sorted(
+                new_th.dataframe.index.get_level_values(0).drop_duplicates().tolist()
+            )
+            assert ensemble_profile == exp_index
+            assert ensemble_nodes == exp_nodes
 
-                # EnsembleFrame: compare profile hash keys and nodes after filter to expected
-                ensemble_profile = sorted(
-                    new_th.dataframe.index.get_level_values(1)
-                    .drop_duplicates()
-                    .tolist()
-                )
-                ensemble_nodes = sorted(
-                    new_th.dataframe.index.get_level_values(0)
-                    .drop_duplicates()
-                    .tolist()
-                )
-                assert ensemble_profile == exp_index
-                assert ensemble_nodes == exp_nodes
+            # StatsFrame: compare nodes after filter to expected; check for empty dataframe
+            stats_nodes = sorted(
+                new_th.statsframe.dataframe.index.get_level_values(0)
+                .drop_duplicates()
+                .tolist()
+            )
+            assert exp_nodes == stats_nodes
+            assert "name" in new_th.statsframe.dataframe.columns
 
-                # StatsFrame: compare nodes after filter to expected; check for empty dataframe
-                stats_nodes = sorted(
-                    new_th.statsframe.dataframe.index.get_level_values(0)
-                    .drop_duplicates()
-                    .tolist()
-                )
-                assert exp_nodes == stats_nodes
-                assert "name" in new_th.statsframe.dataframe.columns
-    # add when filter takes two columns
-    elif total_col == 2:
-        column1 = list(columns_values.keys())[0]
-        column2 = list(columns_values.keys())[1]
-        idx_col1 = th.metadata.index[
-            th.metadata[column1] == columns_values[column1][0]
-        ].tolist()
-        idx_col2 = th.metadata.index[
-            th.metadata[column2] == columns_values[column2][1]
-        ].tolist()
-        # expected profiles for this filter case
-        exp_index = sorted(list(set(idx_col1) & set(idx_col2)))
-        new_th = th.filter_metadata(
-            lambda x: x[column1] == columns_values[column1][0]
-            and x[column2] == columns_values[column2][1]
-        )
 
-        # check if output is a thicket object
-        assert isinstance(new_th, Thicket)
+def filter_multiple_and(th, columns_values):
+    column1 = list(columns_values.keys())[0]
+    column2 = list(columns_values.keys())[1]
+    idx_col1 = th.metadata.index[
+        th.metadata[column1] == columns_values[column1][0]
+    ].tolist()
+    idx_col2 = th.metadata.index[
+        th.metadata[column2] == columns_values[column2][0]
+    ].tolist()
+    # expected profiles for this filter case
+    exp_index = sorted(list(set(idx_col1) & set(idx_col2)))
+    new_th = th.filter_metadata(
+        lambda x: x[column1] == columns_values[column1][0]
+        and x[column2] == columns_values[column2][0]
+    )
 
-        # MetadataFrame: compare profile hash keys after filter to expected
-        metadata_profile = new_th.metadata.index.tolist()
-        assert metadata_profile == exp_index
+    # check if output is a thicket object
+    assert isinstance(new_th, Thicket)
 
-        # filter nodes and profiles
-        filter_profiles = sorted(
-            new_th.dataframe.index.get_level_values(1).drop_duplicates().tolist()
-        )
-        filter_nodes = sorted(
-            new_th.dataframe.index.get_level_values(0).drop_duplicates().tolist()
-        )
+    # MetadataFrame: compare profile hash keys after filter to expected
+    metadata_profile = new_th.metadata.index.tolist()
+    assert metadata_profile == exp_index
 
-        # compare profile hash keys and nodes after filter to expected
-        index_name = th.metadata.index.name
-        exp_nodes = sorted(
-            th.dataframe[
-                th.dataframe.index.get_level_values(index_name).isin(exp_index)
-            ]
-            .index.get_level_values(0)
-            .drop_duplicates()
-            .tolist()
-        )
-        assert exp_nodes == filter_nodes
-        assert exp_index == filter_profiles
+    # filter nodes and profiles
+    filter_profiles = sorted(
+        new_th.dataframe.index.get_level_values(1).drop_duplicates().tolist()
+    )
+    filter_nodes = sorted(
+        new_th.dataframe.index.get_level_values(0).drop_duplicates().tolist()
+    )
 
-        # StatsFrame: compare nodes after filter to expected; check for empty dataframe
-        stats_nodes = sorted(
-            new_th.statsframe.dataframe.index.get_level_values(0)
-            .drop_duplicates()
-            .tolist()
-        )
-        assert exp_nodes == stats_nodes
-        assert "name" in new_th.statsframe.dataframe.columns
+    # compare profile hash keys and nodes after filter to expected
+    index_name = th.metadata.index.name
+    exp_nodes = sorted(
+        th.dataframe[th.dataframe.index.get_level_values(index_name).isin(exp_index)]
+        .index.get_level_values(0)
+        .drop_duplicates()
+        .tolist()
+    )
+    assert exp_nodes == filter_nodes
+    assert exp_index == filter_profiles
+
+    # StatsFrame: compare nodes after filter to expected; check for empty dataframe
+    stats_nodes = sorted(
+        new_th.statsframe.dataframe.index.get_level_values(0).drop_duplicates().tolist()
+    )
+    assert exp_nodes == stats_nodes
+    assert "name" in new_th.statsframe.dataframe.columns
+
+
+def filter_multiple_or(th, columns_values):
+    column1 = list(columns_values.keys())[0]
+    column2 = list(columns_values.keys())[1]
+    idx_col1 = th.metadata.index[
+        th.metadata[column1] == columns_values[column1][0]
+    ].tolist()
+    idx_col2 = th.metadata.index[
+        th.metadata[column2] == columns_values[column2][0]
+    ].tolist()
+    # expected profiles for this filter case
+    exp_index = sorted(list(set(idx_col1) or set(idx_col2)))
+    new_th = th.filter_metadata(
+        lambda x: x[column1] == columns_values[column1][0]
+        or x[column2] == columns_values[column2][0]
+    )
+
+    # check if output is a thicket object
+    assert isinstance(new_th, Thicket)
+
+    # MetadataFrame: compare profile hash keys after filter to expected
+    metadata_profile = new_th.metadata.index.tolist()
+    assert metadata_profile == exp_index
+
+    # filter nodes and profiles
+    filter_profiles = sorted(
+        new_th.dataframe.index.get_level_values(1).drop_duplicates().tolist()
+    )
+    filter_nodes = sorted(
+        new_th.dataframe.index.get_level_values(0).drop_duplicates().tolist()
+    )
+
+    # compare profile hash keys and nodes after filter to expected
+    index_name = th.metadata.index.name
+    exp_nodes = sorted(
+        th.dataframe[th.dataframe.index.get_level_values(index_name).isin(exp_index)]
+        .index.get_level_values(0)
+        .drop_duplicates()
+        .tolist()
+    )
+    assert exp_nodes == filter_nodes
+    assert exp_index == filter_profiles
+
+    # StatsFrame: compare nodes after filter to expected; check for empty dataframe
+    stats_nodes = sorted(
+        new_th.statsframe.dataframe.index.get_level_values(0).drop_duplicates().tolist()
+    )
+    assert exp_nodes == stats_nodes
+    assert "name" in new_th.statsframe.dataframe.columns
 
     # check for invalid filter exception
     with pytest.raises(InvalidFilter):
@@ -134,8 +168,7 @@ def test_filter_metadata(example_cali):
     # example thicket
     th = Thicket.from_caliperreader(example_cali)
     # columns and corresponding values to filter by
-    columns_values = {"problem_size": ["30"], "cluster": ["quartz", "chekov"]}
-    # thicket for second scenario
-    th1 = th.copy()
-    check_filter_metadata(th, columns_values, 1)
-    check_filter_metadata(th1, columns_values, 2)
+    columns_values = {"problem_size": ["30"], "cluster": ["chekov", "quartz"]}
+    filter_one_column(th, columns_values)
+    filter_multiple_and(th, columns_values)
+    filter_multiple_or(th, columns_values)


### PR DESCRIPTION
The goal of this PR is to add to the filter unit test for cases where user inputs two columns and conditions for filtering the metadata. 