### PR TITLE
Adds GitHub Action to build and upload wheels and sdist

### DIFF
--- a/.github/workflows/build_and_upload_wheels.yaml
+++ b/.github/workflows/build_and_upload_wheels.yaml
@@ -1,0 +1,160 @@
+name: Build wheels
+
+on:
+  Uncomment for testing through a PR
+  pull_request:
+    branches: [develop, releases/**]
+  workflow_dispatch:
+  release:
+    types:
+      - published
+  push:
+    tags:
+      - 'v**'
+
+jobs:
+
+  build_wheels_linux_3:
+    name: Build wheels for Linux
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU to support non-x86 architectures
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
+      - uses: pypa/cibuildwheel@v2.12.1
+        env:
+          CIBW_SKIP: pp* *musllinux*
+          CIBW_ARCHS_LINUX: auto aarch64 ppc64le
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_wheels_linux_27:
+    name: Build wheels for Python 2.7 on Linux
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      # Neeed to use cibuildwheel 1 for Python 2.7
+      - uses: pypa/cibuildwheel@v1.12.0
+        env:
+          CIBW_SKIP: pp*
+          CIBW_ARCHS_LINUX: auto
+          CIBW_PROJECT_REQUIRES_PYTHON: "~=2.7"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  # TODO: uncomment if/when we decide to build wheels for macOS
+  # build_wheels_macos_36_37:
+  #   name: Build wheels for Python 3.6 and 3.7 on macOS
+  #   runs-on: macos-12
+  #   steps:
+  #     - uses: actions/checkout@v3
+
+  #     - uses: pypa/cibuildwheel@v2.12.1
+  #       env:
+  #         CIBW_SKIP: pp*
+  #         CIBW_ARCHS_MACOS: x86_64
+  #         CIBW_PROJECT_REQUIRES_PYTHON: ">=3.6,<3.8"
+
+  #     - uses: actions/upload-artifact@v3
+  #       with:
+  #         path: ./wheelhouse/*.whl
+
+  # build_wheels_macos_38_plus:
+  #   name: Build wheels for Python 3.8+ on macOS
+  #   runs-on: macos-12
+  #   steps:
+  #     - uses: actions/checkout@v3
+
+  #     - uses: pypa/cibuildwheel@v2.12.1
+  #       env:
+  #         CIBW_SKIP: pp*
+  #         CIBW_ARCHS_MACOS: x86_64 universal2 arm64
+  #         CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
+
+  #     - uses: actions/upload-artifact@v3
+  #       with:
+  #         path: ./wheelhouse/*.whl
+
+  # build_wheels_macos_27:
+  #   name: Build wheels for Python 2.7 on macOS
+  #   runs-on: macos-12
+  #   steps:
+  #     - uses: actions/checkout@v3
+
+  #     # Neeed to use cibuildwheel 1 for Python 2.7
+  #     - uses: pypa/cibuildwheel@v1.12.0
+  #       env:
+  #         CIBW_SKIP: pp*
+  #         CIBW_BUILD: cp27-macosx_x86_64
+
+  #     - uses: actions/upload-artifact@v3
+  #       with:
+  #         path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build sdist
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get PyPA build
+        run: python -m pip install build
+
+      - name: Build sdist
+        run: python -m build -s
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  test_upload_to_pypi:
+    needs:
+      - build_wheels_linux_3
+      - build_wheels_linux_27
+        # - build_wheels_macos_36_37
+        # - build_wheels_macos_38_plus
+        # - build_wheels_macos_27
+      - build_sdist
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.5.0
+        with:
+          user: __token__
+          password: ${{ secrets.THICKET_TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+  upload_to_pypi:
+    needs:
+      - build_wheels_linux_3
+      - build_wheels_linux_27
+        # - build_wheels_macos_36_37
+        # - build_wheels_macos_38_plus
+        # - build_wheels_macos_27
+      - build_sdist
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.5.0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build_and_upload_wheels.yaml
+++ b/.github/workflows/build_and_upload_wheels.yaml
@@ -14,42 +14,68 @@ on:
 
 jobs:
 
-  build_wheels_linux_3:
+  # TODO: if we ever add compiled code to Thicket (e.g., Cython modules),
+  #       remove the build_wheels job
+  build_wheels:
     name: Build wheels for Linux
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up QEMU to support non-x86 architectures
-        uses: docker/setup-qemu-action@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
         with:
-          platforms: all
+          python-version: ${{ matrix.python-version }}
 
-      - uses: pypa/cibuildwheel@v2.12.1
-        env:
-          CIBW_SKIP: pp* *musllinux*
-          CIBW_ARCHS_LINUX: auto aarch64 ppc64le
+      - name: Build wheel for Python ${{ matrix.python-version }}
+        run: pip wheel -w ./tmp_wheel_dir .
 
       - uses: actions/upload-artifact@v3
         with:
-          path: ./wheelhouse/*.whl
+          path: ./tmp_wheel_dir/*.whl
 
-  build_wheels_linux_27:
-    name: Build wheels for Python 2.7 on Linux
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
+  # TODO: if we ever add compiled code to Thicket (e.g., Cython modules),
+  #       uncomment these steps to build wheel files
+  #
+  # build_wheels_linux_3:
+  #   name: Build wheels for Linux
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@v3
 
-      # Neeed to use cibuildwheel 1 for Python 2.7
-      - uses: pypa/cibuildwheel@v1.12.0
-        env:
-          CIBW_SKIP: pp*
-          CIBW_ARCHS_LINUX: auto
-          CIBW_PROJECT_REQUIRES_PYTHON: "~=2.7"
+  #     - name: Set up QEMU to support non-x86 architectures
+  #       uses: docker/setup-qemu-action@v2
+  #       with:
+  #         platforms: all
 
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ./wheelhouse/*.whl
+  #     - uses: pypa/cibuildwheel@v2.12.1
+  #       env:
+  #         CIBW_SKIP: pp* *musllinux*
+  #         CIBW_ARCHS_LINUX: auto aarch64 ppc64le
+
+  #     - uses: actions/upload-artifact@v3
+  #       with:
+  #         path: ./wheelhouse/*.whl
+
+  # build_wheels_linux_27:
+  #   name: Build wheels for Python 2.7 on Linux
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@v3
+
+  #     # Neeed to use cibuildwheel 1 for Python 2.7
+  #     - uses: pypa/cibuildwheel@v1.12.0
+  #       env:
+  #         CIBW_SKIP: pp*
+  #         CIBW_ARCHS_LINUX: auto
+  #         CIBW_PROJECT_REQUIRES_PYTHON: "~=2.7"
+
+  #     - uses: actions/upload-artifact@v3
+  #       with:
+  #         path: ./wheelhouse/*.whl
 
   # TODO: uncomment if/when we decide to build wheels for macOS
   # build_wheels_macos_36_37:
@@ -118,11 +144,12 @@ jobs:
 
   test_upload_to_pypi:
     needs:
-      - build_wheels_linux_3
-      - build_wheels_linux_27
+        # - build_wheels_linux_3
+        # - build_wheels_linux_27
         # - build_wheels_macos_36_37
         # - build_wheels_macos_38_plus
         # - build_wheels_macos_27
+      - build_wheels
       - build_sdist
     runs-on: ubuntu-20.04
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
@@ -140,11 +167,12 @@ jobs:
 
   upload_to_pypi:
     needs:
-      - build_wheels_linux_3
-      - build_wheels_linux_27
+        # - build_wheels_linux_3
+        # - build_wheels_linux_27
         # - build_wheels_macos_36_37
         # - build_wheels_macos_38_plus
         # - build_wheels_macos_27
+      - build_wheels
       - build_sdist
     runs-on: ubuntu-20.04
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/build_and_upload_wheels.yaml
+++ b/.github/workflows/build_and_upload_wheels.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 3.11]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build_and_upload_wheels.yaml
+++ b/.github/workflows/build_and_upload_wheels.yaml
@@ -1,4 +1,4 @@
-name: Build wheels
+name: Build wheels for Thicket
 
 on:
   Uncomment for testing through a PR

--- a/.github/workflows/build_and_upload_wheels.yaml
+++ b/.github/workflows/build_and_upload_wheels.yaml
@@ -1,7 +1,7 @@
 name: Build wheels for Thicket
 
 on:
-  Uncomment for testing through a PR
+  # Uncomment for testing through a PR
   pull_request:
     branches: [develop, releases/**]
   workflow_dispatch:

--- a/.github/workflows/build_and_upload_wheels.yaml
+++ b/.github/workflows/build_and_upload_wheels.yaml
@@ -30,12 +30,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Build wheel for Python ${{ matrix.python-version }}
-        run: pip wheel -w ./tmp_wheel_dir .
+      - name: Get PyPA build
+        run: python -m pip install build
+
+      - name: Build wheel for Python ${{ matrix.python_version }}
+        run: python -m build -w
 
       - uses: actions/upload-artifact@v3
         with:
-          path: ./tmp_wheel_dir/*.whl
+          path: dist/*.whl
 
   # TODO: if we ever add compiled code to Thicket (e.g., Cython modules),
   #       uncomment these steps to build wheel files


### PR DESCRIPTION
This PR ports Hatchet's new GitHub build-and-upload Action to Thicket. When triggered, this Action will build a sdist and wheels for Thicket. If the trigger is a tag push, the Action will also upload the build artifacts to TestPyPI. On the other hand, if the trigger is a release publication, the Action will upload the artifacts to regular PyPI.