### PR TITLE
Update to aggregated statistical functions

### DIFF
--- a/thicket/stats/calc_boxplot_statistics.py
+++ b/thicket/stats/calc_boxplot_statistics.py
@@ -16,16 +16,16 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
     Designed to take in a thicket, and append one or more columns to the aggregated
     statistics table for the boxplot five number summary calculations for each node.
 
-    The 5 number summary includes (1) minimum, (2) q1, (3) median, (4) q3,
-    and (5) maximum.
+    The 5 number summary includes (1) minimum, (2) q1, (3) median, (4) q3, and (5)
+    maximum.
 
     Arguments:
         thicket (thicket): Thicket object
-        columns (list): List of columns to perform boxplot five number summary on
-                        Note, if using a columnar_joined thicket a list of tuples
-                        must be passed in with the format: (column index, column name).
+        columns (list): List of columns to perform boxplot five number summary on. Note,
+            if using a columnar joined thicket a list of tuples must be passed in with
+            the format (column index, column name).
         quartiles (list): List containing three values between 0 and 1 to cut the
-                          distribution into equal probabilities.
+            distribution into equal probabilities.
     """
     if len(quartiles) != 3:
         raise ValueError(
@@ -42,7 +42,8 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
     )
 
     q_list = str(tuple(quartiles))
-    # Code parses performance data with no columnar index
+
+    # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for col in columns:
             boxplot_dict = {
@@ -90,7 +91,7 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
             df_box["node"] = thicket.statsframe.dataframe.index.tolist()
             df_box.set_index("node", inplace=True)
             thicket.statsframe.dataframe = thicket.statsframe.dataframe.join(df_box)
-    # Code parses columnar joined performance data
+    # columnar joined thicket object
     else:
         for idx, col in columns:
             boxplot_dict = {
@@ -145,4 +146,6 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
             df_box["node"] = thicket.statsframe.dataframe.reset_index()["node"].tolist()
             df_box = df_box.set_index("node")
             thicket.statsframe.dataframe = thicket.statsframe.dataframe.join(df_box)
+
+        # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/calc_boxplot_statistics.py
+++ b/thicket/stats/calc_boxplot_statistics.py
@@ -10,20 +10,22 @@ from ..utils import verify_thicket_structures
 
 
 def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **kwargs):
-    """Calculate boxplot five number summary for each node in the performance data table.
+    """Calculate boxplot five number summary for each node in the performance data
+    table.
 
-    Designed to take in a thicket, and append one or more columns to the aggregated statistics table for
-    the boxplot five number summary calculations for each node.
+    Designed to take in a thicket, and append one or more columns to the aggregated
+    statistics table for the boxplot five number summary calculations for each node.
 
-    The 5 number summary includes (1) minimum, (2) q1, (3) median, (4) q3, and (5) maximum.
+    The 5 number summary includes (1) minimum, (2) q1, (3) median, (4) q3,
+    and (5) maximum.
 
     Arguments:
         thicket (thicket): Thicket object
         columns (list): List of columns to perform boxplot five number summary on
-                        Note, if using a columnar_joined thicket a list of tuples must be
-                        passed in with the format:(column index, column name).
+                        Note, if using a columnar_joined thicket a list of tuples
+                        must be passed in with the format: (column index, column name).
         quartiles (list): List containing three values between 0 and 1 to cut the
-            distribution into equal probabilities.
+                          distribution into equal probabilities.
     """
     if len(quartiles) != 3:
         raise ValueError(
@@ -32,7 +34,7 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
 
     if len(columns) == 0:
         raise ValueError(
-            "To see a list of valid columns, run thicket.performance_cols."
+            "To see a list of valid columns, please run Thicket.get_perf_columns()."
         )
 
     verify_thicket_structures(
@@ -40,7 +42,7 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
     )
 
     q_list = str(tuple(quartiles))
-
+    # Code parses performance data with no columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for col in columns:
             boxplot_dict = {
@@ -88,7 +90,7 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
             df_box["node"] = thicket.statsframe.dataframe.index.tolist()
             df_box.set_index("node", inplace=True)
             thicket.statsframe.dataframe = thicket.statsframe.dataframe.join(df_box)
-
+    # Code parses columnar joined performance data
     else:
         for idx, col in columns:
             boxplot_dict = {

--- a/thicket/stats/calc_boxplot_statistics.py
+++ b/thicket/stats/calc_boxplot_statistics.py
@@ -30,55 +30,106 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
             "To see a list of valid columns, run thicket.performance_cols."
         )
 
-    verify_thicket_structures(
-        thicket.dataframe, index=["node", "profile"], columns=columns
-    )
+    #verify_thicket_structures(
+    #    thicket.dataframe, index=["node", "profile"], columns=columns
+    #)
 
     q_list = str(tuple(quartiles))
+    
+    if thicket.dataframe.columns.nlevels == 1:
+        for col in columns:
+            boxplot_dict = {
+                col + "_q1" + q_list: [],
+                col + "_q2" + q_list: [],
+                col + "_q3" + q_list: [],
+                col + "_iqr" + q_list: [],
+                col + "_lowerfence" + q_list: [],
+                col + "_upperfence" + q_list: [],
+                col + "_outliers" + q_list: [],
+            }
 
-    for col in columns:
-        boxplot_dict = {
-            col + "_q1" + q_list: [],
-            col + "_q2" + q_list: [],
-            col + "_q3" + q_list: [],
-            col + "_iqr" + q_list: [],
-            col + "_lowerfence" + q_list: [],
-            col + "_upperfence" + q_list: [],
-            col + "_outliers" + q_list: [],
-        }
+            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
+                values = thicket.dataframe.loc[node][col].tolist()
 
-        for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-            values = thicket.dataframe.loc[node][col].tolist()
+                q = np.quantile(values, quartiles)
+                q1 = q[0]
+                median = q[1]
+                q3 = q[2]
 
-            q = np.quantile(values, quartiles)
-            q1 = q[0]
-            median = q[1]
-            q3 = q[2]
+                iqr = q3 - q1
+                lower_fence = q1 - (1.5 * iqr)
+                upper_fence = q3 + (1.5 * iqr)
 
-            iqr = q3 - q1
-            lower_fence = q1 - (1.5 * iqr)
-            upper_fence = q3 + (1.5 * iqr)
+                boxplot_dict[col + "_q1" + q_list].append(q1)
+                boxplot_dict[col + "_q2" + q_list].append(median)
+                boxplot_dict[col + "_q3" + q_list].append(q3)
+                boxplot_dict[col + "_iqr" + q_list].append(iqr)
+                boxplot_dict[col + "_lowerfence" + q_list].append(lower_fence)
+                boxplot_dict[col + "_upperfence" + q_list].append(upper_fence)
 
-            boxplot_dict[col + "_q1" + q_list].append(q1)
-            boxplot_dict[col + "_q2" + q_list].append(median)
-            boxplot_dict[col + "_q3" + q_list].append(q3)
-            boxplot_dict[col + "_iqr" + q_list].append(iqr)
-            boxplot_dict[col + "_lowerfence" + q_list].append(lower_fence)
-            boxplot_dict[col + "_upperfence" + q_list].append(upper_fence)
-
-            profile = []
-            for i in range(0, len(values)):
-                if values[i] > upper_fence or values[i] < lower_fence:
-                    profile.append(
-                        thicket.dataframe.loc[node].reset_index()["profile"][i]
-                    )
-                else:
-                    continue
-            if not profile:
                 profile = []
-            boxplot_dict[col + "_outliers" + q_list].append(profile)
+                for i in range(0, len(values)):
+                    if values[i] > upper_fence or values[i] < lower_fence:
+                        profile.append(
+                            thicket.dataframe.loc[node].reset_index()["profile"][i]
+                        )
+                    else:
+                        continue
+                if not profile:
+                    profile = []
+                boxplot_dict[col + "_outliers" + q_list].append(profile)
 
-        df_box = pd.DataFrame(boxplot_dict)
-        df_box["node"] = thicket.statsframe.dataframe.index.tolist()
-        df_box.set_index("node", inplace=True)
-        thicket.statsframe.dataframe = thicket.statsframe.dataframe.join(df_box)
+            df_box = pd.DataFrame(boxplot_dict)
+            df_box["node"] = thicket.statsframe.dataframe.index.tolist()
+            df_box.set_index("node", inplace=True)
+            thicket.statsframe.dataframe = thicket.statsframe.dataframe.join(df_box)
+
+    else:
+        for idx, col in columns:
+            boxplot_dict = {
+                col + "_q1" + q_list: [],
+                col + "_q2" + q_list: [],
+                col + "_q3" + q_list: [],
+                col + "_iqr" + q_list: [],
+                col + "_lowerfence" + q_list: [],
+                col + "_upperfence" + q_list: [],
+                col + "_outliers" + q_list: [],
+            }
+
+            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
+                values = thicket.dataframe.loc[node][(idx,col)].tolist()
+
+                q = np.quantile(values, quartiles)
+                q1 = q[0]
+                median = q[1]
+                q3 = q[2]
+
+                iqr = q3 - q1
+                lower_fence = q1 - (1.5 * iqr)
+                upper_fence = q3 + (1.5 * iqr)
+
+                boxplot_dict[col + "_q1" + q_list].append(q1)
+                boxplot_dict[col + "_q2" + q_list].append(median)
+                boxplot_dict[col + "_q3" + q_list].append(q3)
+                boxplot_dict[col + "_iqr" + q_list].append(iqr)
+                boxplot_dict[col + "_lowerfence" + q_list].append(lower_fence)
+                boxplot_dict[col + "_upperfence" + q_list].append(upper_fence)
+
+                profile = []
+                for i in range(0, len(values)):
+                    if values[i] > upper_fence or values[i] < lower_fence:
+                        profile.append(
+                            thicket.dataframe.loc[node].reset_index()["profile"][i]
+                        )
+                    else:
+                        continue
+                if not profile:
+                    profile = []
+                boxplot_dict[col + "_outliers" + q_list].append(profile)
+            
+            
+            df_box = pd.DataFrame(boxplot_dict)
+            return df_box
+            #df_box["node"] = thicket.statsframe.dataframe.index.tolist()
+            #df_box.set_index("node", inplace=True)
+            #thicket.statsframe.dataframe = thicket.statsframe.dataframe.join(df_box)

--- a/thicket/stats/check_normality.py
+++ b/thicket/stats/check_normality.py
@@ -13,9 +13,9 @@ def check_normality(thicket, columns=None):
     """Determine if the data is normal or non-normal for each node in the performance
     data table.
 
-    Designed to take in a thicket, and append one or more columns to the
-    aggregated statistics table.A true boolean value will be appended if the data is
-    normal and a false boolean value will be appended if the data is non-normal.
+    Designed to take in a thicket, and append one or more columns to the aggregated
+    statistics table. A true boolean value will be appended if the data is normal and a
+    false boolean value will be appended if the data is non-normal.
 
     For this test, the more data the better. Preferably you would want to have 20 data
     points (20 files) in a dataset to have an accurate result.
@@ -23,8 +23,8 @@ def check_normality(thicket, columns=None):
     Arguments:
         thicket (thicket): Thicket object
         columns (list): List of hardware/timing metrics to perform normality test on.
-                        Note, if using a columnar_joined thicket a list of tuples must
-                        be passed in with the format: (column index, column name).
+            Note, if using a columnar joined thicket a list of tuples must be passed in
+            with the format (column index, column name).
     """
     if columns is None:
         raise ValueError(
@@ -34,7 +34,8 @@ def check_normality(thicket, columns=None):
     verify_thicket_structures(
         thicket.dataframe, index=["node", "profile"], columns=columns
     )
-    # Code parses performance data with no columnar index
+
+    # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             normality = []
@@ -49,7 +50,7 @@ def check_normality(thicket, columns=None):
                     normality.append(pd.NA)
 
             thicket.statsframe.dataframe[column + "_normality"] = normality
-    # Code parses columnar joined performance data
+    # columnar joined thicket object
     else:
         for idx, column in columns:
             normality = []
@@ -65,4 +66,5 @@ def check_normality(thicket, columns=None):
 
             thicket.statsframe.dataframe[(idx, column + "_normality")] = normality
 
+        # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/check_normality.py
+++ b/thicket/stats/check_normality.py
@@ -5,15 +5,17 @@
 
 import pandas as pd
 from scipy import stats
+
 from ..utils import verify_thicket_structures
 
 
 def check_normality(thicket, columns=None):
-    """Determine if the data is normal or non-normal for each node in the performance data table.
+    """Determine if the data is normal or non-normal for each node in the performance
+    data table.
 
-    Designed to take in a thicket, and append one or more columns to the aggregated statistics table.
-    A true boolean value will be appended if the data is normal and a false boolean value will be appended
-    if the data is non-normal.
+    Designed to take in a thicket, and append one or more columns to the
+    aggregated statistics table.A true boolean value will be appended if the data is
+    normal and a false boolean value will be appended if the data is non-normal.
 
     For this test, the more data the better. Preferably you would want to have 20 data
     points (20 files) in a dataset to have an accurate result.
@@ -21,16 +23,18 @@ def check_normality(thicket, columns=None):
     Arguments:
         thicket (thicket): Thicket object
         columns (list): List of hardware/timing metrics to perform normality test on.
-                        Note, if using a columnar_joined thicket a list of tuples must be
-                        passed in with the format:(column index,column name).
+                        Note, if using a columnar_joined thicket a list of tuples must
+                        be passed in with the format: (column index, column name).
     """
     if columns is None:
-        raise ValueError("To see a list of valid columns run get_perf_columns().")
+        raise ValueError(
+            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+        )
 
     verify_thicket_structures(
         thicket.dataframe, index=["node", "profile"], columns=columns
     )
-
+    # Code parses performance data with no columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             normality = []
@@ -45,7 +49,7 @@ def check_normality(thicket, columns=None):
                     normality.append(pd.NA)
 
             thicket.statsframe.dataframe[column + "_normality"] = normality
-
+    # Code parses columnar joined performance data
     else:
         for idx, column in columns:
             normality = []

--- a/thicket/stats/check_normality.py
+++ b/thicket/stats/check_normality.py
@@ -9,24 +9,20 @@ from ..utils import verify_thicket_structures
 
 
 def check_normality(thicket, columns=None):
-    """
-    Designed to take in a Thicket, and will append a column to the statsframe.
+    """Determine if the data is normal or non-normal for each node in the performance data table.
+
+    Designed to take in a thicket, and append one or more columns to the aggregated statistics table.
+    A true boolean value will be appended if the data is normal and a false boolean value will be appended
+    if the data is non-normal.
 
     For this test, the more data the better. Preferably you would want to have 20 data
     points (20 files) in a dataset to have an accurate result.
 
-    Arguments/Parameters
-    _ _ _ _ _ _ _ _ _ _ _
-
-    thicket : A thicket
-
-    columns : List of hardware/timing metrics to perform normality test on
-
-    Returns
-    _ _ _ _ _ _ _ _ _ _ _
-
-    statsframe: Returns statsframe with appended columns for normality check
-
+    Arguments:
+        thicket (thicket): Thicket object
+        columns (list): List of hardware/timing metrics to perform normality test on.
+                        Note, if using a columnar_joined thicket a list of tuples must be
+                        passed in with the format:(column index,column name).
     """
     if columns is None:
         raise ValueError("To see a list of valid columns run get_perf_columns().")
@@ -51,11 +47,11 @@ def check_normality(thicket, columns=None):
             thicket.statsframe.dataframe[column + "_normality"] = normality
 
     else:
-        for idx,column in columns:
+        for idx, column in columns:
             normality = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                pvalue = stats.shapiro(thicket.dataframe.loc[node][(idx,column)])[1]
-                
+                pvalue = stats.shapiro(thicket.dataframe.loc[node][(idx, column)])[1]
+
                 if pvalue < 0.05:
                     normality.append("False")
                 elif pvalue > 0.05:
@@ -63,6 +59,6 @@ def check_normality(thicket, columns=None):
                 else:
                     normality.append(pd.NA)
 
-            thicket.statsframe.dataframe[(idx,column + "_normality")] = normality
+            thicket.statsframe.dataframe[(idx, column + "_normality")] = normality
 
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/correlation_nodewise.py
+++ b/thicket/stats/correlation_nodewise.py
@@ -16,14 +16,13 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
 
     Arguments:
         thicket (thicket): Thicket object
-        column1 (str): First comparison column
-                       Note, if using a columnar_joined thicket a tuple must be
-                       passed in with the format:(column index,column name).
-        column2 (str): Second comparison column
-                       Note, if using a columnar_joined thicket a tuple must be
-                       passed in with the format: (column index, column name).
-        correlation (str): correlation test to perform -- pearson (default),
-            spearman, and kendall.
+        column1 (str): First comparison column. Note, if using a columnar joined thicket
+            a tuple must be passed in with the format (column index, column name).
+        column2 (str): Second comparison column. Note, if using a columnar joined
+            thicket a tuple must be passed in with the format
+            (column index, column name).
+        correlation (str): correlation test to perform -- pearson (default), spearman,
+            and kendall.
     """
     if column1 is None or column2 is None:
         raise ValueError(
@@ -42,7 +41,8 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
             index=["node", "thicket"],
             columns=[column1, column2],
         )
-    # Code parses performance data with no columnar index
+
+    # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
         correlated = []
         for node in thicket.statsframe.dataframe.index.tolist():
@@ -72,7 +72,7 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
         thicket.statsframe.dataframe[
             column1 + "_vs_" + column2 + " " + correlation
         ] = correlated
-    # Code parses columnar joined performance data
+    # columnar joined thicket object
     else:
         correlated = []
         for node in thicket.statsframe.dataframe.index.tolist():
@@ -114,4 +114,5 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
                 (column_idx, column1[1] + "_vs_" + column2[1] + " " + correlation)
             ] = correlated
 
+        # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/correlation_nodewise.py
+++ b/thicket/stats/correlation_nodewise.py
@@ -7,89 +7,106 @@ from scipy import stats
 from ..utils import verify_thicket_structures
 
 
-def correlation_nodewise(
-    thicket, base_column=None, correlate_columns=None, correlation="pearson"
-):
-    """Calculate the nodewise correlation on user-specified columns.
+def correlation_nodewise(thicket, column1=None, column2=None, correlation="pearson"):
+    """Calculate the nodewise correlation for each node in the performance data table.
 
-    Calculates the correlation nodewise for user passed in columns. This can
-    either be done for the EnsembleFrame or a super thicket.
+    Designed to take in a thicket, and append one or more columns to the aggregated statistics table for
+    the nodewise correlation calculation for each node.
 
     Arguments:
         thicket (thicket): Thicket object
-        base_column (str): base column that you want to compare
-        correlate_columns (list): list of columns to correlate to the passed in base column
+        column1 (str): First comparison column
+                       Note, if using a columnar_joined thicket a tuple must be
+                       passed in with the format:(column index,column name).
+        column2 (str): Second comparison column
+                       Note, if using a columnar_joined thicket a tuple must be
+                       passed in with the format:(column index,column name).
         correlation (str): correlation test to perform -- pearson (default),
-            spearman, and kendall
+            spearman, and kendall.
     """
-    if base_column is None or correlate_columns is None:
+    if column1 is None or column2 is None:
         raise ValueError("To see a list of valid columns run get_perf_columns().")
 
-    #if "profile" in thicket.dataframe.index.names:
-    #    verify_thicket_structures(
-    #        thicket.dataframe,
-    #        index=["node", "profile"],
-    #        columns=[base_column] + correlate_columns,
-    #    )
-    #else:
-    #    verify_thicket_structures(
-    #        thicket.dataframe,
-    #        index=["node", "thicket"],
-    #        columns=[base_column] + correlate_columns,
-    #    )
-    if thicket.dataframe.columns.nlevels == 1:
-        for col in correlate_columns:
-            correlated = []
-            for node in thicket.statsframe.dataframe.index.tolist():
-                if correlation == "pearson":
-                    correlated.append(stats.pearsonr(
-                        thicket.dataframe.loc[node][base_column], 
-                        thicket.dataframe.loc[node][col])[0]
-                    )
-                elif correlation == "spearman":
-                    correlated.append(stats.spearmanr(
-                        thicket.dataframe.loc[node][base_column], 
-                        thicket.dataframe.loc[node][col])[0]
-                    )
-                elif correlation == "kendall":
-                    correlated.append(stats.kendalltau(
-                        thicket.dataframe.loc[node][base_column], 
-                        thicket.dataframe.loc[node][col])[0]
-                    )
-                else:
-                    raise ValueError("Invalid correlation")
-            thicket.statsframe.dataframe[
-                base_column + "_vs_" + col + " " + correlation
-            ] = correlated
+    if "profile" in thicket.dataframe.index.names:
+        verify_thicket_structures(
+            thicket.dataframe,
+            index=["node", "profile"],
+            columns=[column1, column2],
+        )
     else:
-        idx_base,column_base = base_column
-        for idx_corr,column_corr in correlate_columns:
-            if idx_base != idx_corr:
-                raise ValueError("Column index must be the same between base_column and correlate_columns for combined thicket.")
-
-            correlated = []
-            for node in thicket.statsframe.dataframe.index.tolist():
-                if correlation == "pearson":
-                    correlated.append(stats.pearsonr(
-                        thicket.dataframe.loc[node][(idx_base,column_base)],
-                        thicket.dataframe.loc[node][(idx_corr,column_corr)])[0]
-                    )
-                elif correlation == "spearman":
-                    correlated.append(stats.spearmanr(
-                        thicket.dataframe.loc[node][(idx_base,column_base)],
-                        thicket.dataframe.loc[node][(idx_corr,column_corr)])[0]
-                    )
-                elif correlation == "kendall":
-                    correlated.append(stats.kendalltau(
-                        thicket.dataframe.loc[node][(idx_base,column_base)],
-                        thicket.dataframe.loc[node][(idx_corr,column_corr)])[0]
-                    )
-                else:
-                    raise ValueError("Invalid correlation, options are pearson, spearman, and kendall.")
-
+        verify_thicket_structures(
+            thicket.dataframe,
+            index=["node", "thicket"],
+            columns=[column1, column2],
+        )
+    if thicket.dataframe.columns.nlevels == 1:
+        correlated = []
+        for node in thicket.statsframe.dataframe.index.tolist():
+            if correlation == "pearson":
+                correlated.append(
+                    stats.pearsonr(
+                        thicket.dataframe.loc[node][column1],
+                        thicket.dataframe.loc[node][column2],
+                    )[0]
+                )
+            elif correlation == "spearman":
+                correlated.append(
+                    stats.spearmanr(
+                        thicket.dataframe.loc[node][column1],
+                        thicket.dataframe.loc[node][column2],
+                    )[0]
+                )
+            elif correlation == "kendall":
+                correlated.append(
+                    stats.kendalltau(
+                        thicket.dataframe.loc[node][column1],
+                        thicket.dataframe.loc[node][column2],
+                    )[0]
+                )
+            else:
+                raise ValueError("Invalid correlation")
+        thicket.statsframe.dataframe[
+            column1 + "_vs_" + column2 + " " + correlation
+        ] = correlated
+    else:
+        correlated = []
+        for node in thicket.statsframe.dataframe.index.tolist():
+            if correlation == "pearson":
+                correlated.append(
+                    stats.pearsonr(
+                        thicket.dataframe.loc[node][column1],
+                        thicket.dataframe.loc[node][column2],
+                    )[0]
+                )
+            elif correlation == "spearman":
+                correlated.append(
+                    stats.spearmanr(
+                        thicket.dataframe.loc[node][column1],
+                        thicket.dataframe.loc[node][column2],
+                    )[0]
+                )
+            elif correlation == "kendall":
+                correlated.append(
+                    stats.kendalltau(
+                        thicket.dataframe.loc[node][column1],
+                        thicket.dataframe.loc[node][column2],
+                    )[0]
+                )
+            else:
+                raise ValueError(
+                    "Invalid correlation, options are pearson, spearman, and kendall."
+                )
+        if column1[0] != column2[0]:
             thicket.statsframe.dataframe[
-                (idx_base,column_base + "_vs_" + column_corr + " " + correlation)
+                (
+                    "Union statistics",
+                    column1[1] + "_vs_" + column2[1] + " " + correlation,
+                )
+            ] = correlated
+        else:
+            column_idx = column1[0]
+            thicket.statsframe.dataframe[
+                (column_idx, column1[1] + "_vs_" + column2[1] + " " + correlation)
             ] = correlated
 
-     
-        thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)  
+        thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/correlation_nodewise.py
+++ b/thicket/stats/correlation_nodewise.py
@@ -1,0 +1,95 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Thicket Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+from scipy import stats
+from ..utils import verify_thicket_structures
+
+
+def correlation_nodewise(
+    thicket, base_column=None, correlate_columns=None, correlation="pearson"
+):
+    """Calculate the nodewise correlation on user-specified columns.
+
+    Calculates the correlation nodewise for user passed in columns. This can
+    either be done for the EnsembleFrame or a super thicket.
+
+    Arguments:
+        thicket (thicket): Thicket object
+        base_column (str): base column that you want to compare
+        correlate_columns (list): list of columns to correlate to the passed in base column
+        correlation (str): correlation test to perform -- pearson (default),
+            spearman, and kendall
+    """
+    if base_column is None or correlate_columns is None:
+        raise ValueError("To see a list of valid columns run get_perf_columns().")
+
+    #if "profile" in thicket.dataframe.index.names:
+    #    verify_thicket_structures(
+    #        thicket.dataframe,
+    #        index=["node", "profile"],
+    #        columns=[base_column] + correlate_columns,
+    #    )
+    #else:
+    #    verify_thicket_structures(
+    #        thicket.dataframe,
+    #        index=["node", "thicket"],
+    #        columns=[base_column] + correlate_columns,
+    #    )
+    if thicket.dataframe.columns.nlevels == 1:
+        for col in correlate_columns:
+            correlated = []
+            for node in thicket.statsframe.dataframe.index.tolist():
+                if correlation == "pearson":
+                    correlated.append(stats.pearsonr(
+                        thicket.dataframe.loc[node][base_column], 
+                        thicket.dataframe.loc[node][col])[0]
+                    )
+                elif correlation == "spearman":
+                    correlated.append(stats.spearmanr(
+                        thicket.dataframe.loc[node][base_column], 
+                        thicket.dataframe.loc[node][col])[0]
+                    )
+                elif correlation == "kendall":
+                    correlated.append(stats.kendalltau(
+                        thicket.dataframe.loc[node][base_column], 
+                        thicket.dataframe.loc[node][col])[0]
+                    )
+                else:
+                    raise ValueError("Invalid correlation")
+            thicket.statsframe.dataframe[
+                base_column + "_vs_" + col + " " + correlation
+            ] = correlated
+    else:
+        idx_base,column_base = base_column
+        for idx_corr,column_corr in correlate_columns:
+            if idx_base != idx_corr:
+                raise ValueError("Column index must be the same between base_column and correlate_columns for combined thicket.")
+
+            correlated = []
+            for node in thicket.statsframe.dataframe.index.tolist():
+                if correlation == "pearson":
+                    correlated.append(stats.pearsonr(
+                        thicket.dataframe.loc[node][(idx_base,column_base)],
+                        thicket.dataframe.loc[node][(idx_corr,column_corr)])[0]
+                    )
+                elif correlation == "spearman":
+                    correlated.append(stats.spearmanr(
+                        thicket.dataframe.loc[node][(idx_base,column_base)],
+                        thicket.dataframe.loc[node][(idx_corr,column_corr)])[0]
+                    )
+                elif correlation == "kendall":
+                    correlated.append(stats.kendalltau(
+                        thicket.dataframe.loc[node][(idx_base,column_base)],
+                        thicket.dataframe.loc[node][(idx_corr,column_corr)])[0]
+                    )
+                else:
+                    raise ValueError("Invalid correlation, options are pearson, spearman, and kendall.")
+
+            thicket.statsframe.dataframe[
+                (idx_base,column_base + "_vs_" + column_corr + " " + correlation)
+            ] = correlated
+
+     
+        thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)  

--- a/thicket/stats/correlation_nodewise.py
+++ b/thicket/stats/correlation_nodewise.py
@@ -4,14 +4,15 @@
 # SPDX-License-Identifier: MIT
 
 from scipy import stats
+
 from ..utils import verify_thicket_structures
 
 
 def correlation_nodewise(thicket, column1=None, column2=None, correlation="pearson"):
     """Calculate the nodewise correlation for each node in the performance data table.
 
-    Designed to take in a thicket, and append one or more columns to the aggregated statistics table for
-    the nodewise correlation calculation for each node.
+    Designed to take in a thicket, and append one or more columns to the aggregated
+    statistics table for the nodewise correlation calculation for each node.
 
     Arguments:
         thicket (thicket): Thicket object
@@ -20,12 +21,14 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
                        passed in with the format:(column index,column name).
         column2 (str): Second comparison column
                        Note, if using a columnar_joined thicket a tuple must be
-                       passed in with the format:(column index,column name).
+                       passed in with the format: (column index, column name).
         correlation (str): correlation test to perform -- pearson (default),
             spearman, and kendall.
     """
     if column1 is None or column2 is None:
-        raise ValueError("To see a list of valid columns run get_perf_columns().")
+        raise ValueError(
+            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+        )
 
     if "profile" in thicket.dataframe.index.names:
         verify_thicket_structures(
@@ -39,6 +42,7 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
             index=["node", "thicket"],
             columns=[column1, column2],
         )
+    # Code parses performance data with no columnar index
     if thicket.dataframe.columns.nlevels == 1:
         correlated = []
         for node in thicket.statsframe.dataframe.index.tolist():
@@ -68,6 +72,7 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
         thicket.statsframe.dataframe[
             column1 + "_vs_" + column2 + " " + correlation
         ] = correlated
+    # Code parses columnar joined performance data
     else:
         correlated = []
         for node in thicket.statsframe.dataframe.index.tolist():

--- a/thicket/stats/maximum.py
+++ b/thicket/stats/maximum.py
@@ -8,23 +8,25 @@ from ..utils import verify_thicket_structures
 
 
 def maximum(thicket, columns=None):
-    """Calculate the maximum value per node.
+    """Determine the maximum for each node in the performance data table.
 
-    Designed to take in a single indexed or a columnar join thicket, and will append a column to the statsframe
-    for the maximum value for all profiles per node.
+    Designed to take in a thicket, and append one or more columns to the aggregated statistics table for
+    the maximum value for each node.
 
-    The maxiumum is the highest observation in the dataset.
+    The maximum is the highest observation for a node and its associated profiles.
 
     Arguments:
         thicket (thicket): Thicket object
-        columns (list): list of hardware/timing metrics to perform extremnum calculations on
+        columns (list): List of hardware/timing metrics to determine maximum value for.
+                        Note, if using a columnar_joined thicket a list of tuples must be
+                        passed in with the format:(column index,column name).
     """
     if columns is None:
         raise ValueError("To see a list of valid columns run get_perf_columns().")
 
-    #verify_thicket_structures(
-    #    thicket.dataframe, index=["node", "profile"], columns=columns
-    #)
+    verify_thicket_structures(
+        thicket.dataframe, index=["node", "profile"], columns=columns
+    )
 
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
@@ -33,10 +35,10 @@ def maximum(thicket, columns=None):
                 maximum.append(max(thicket.dataframe.loc[node][column]))
             thicket.statsframe.dataframe[column + "_max"] = maximum
     else:
-        for idx,column in columns:
+        for idx, column in columns:
             maximum = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                maximum.append(max(thicket.dataframe.loc[node][(idx,column)]))
-            thicket.statsframe.dataframe[(idx,column + "_max")] = maximum
+                maximum.append(max(thicket.dataframe.loc[node][(idx, column)]))
+            thicket.statsframe.dataframe[(idx, column + "_max")] = maximum
 
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/maximum.py
+++ b/thicket/stats/maximum.py
@@ -19,8 +19,8 @@ def maximum(thicket, columns=None):
     Arguments:
         thicket (thicket): Thicket object
         columns (list): List of hardware/timing metrics to determine maximum value for.
-                        Note, if using a columnar_joined thicket a list of tuples must
-                        be passed in with the format: (column index, column name).
+            Note, if using a columnar joined thicket a list of tuples must be passed in
+            with the format (column index, column name).
     """
     if columns is None:
         raise ValueError(
@@ -30,14 +30,15 @@ def maximum(thicket, columns=None):
     verify_thicket_structures(
         thicket.dataframe, index=["node", "profile"], columns=columns
     )
-    # Code parses performance data with no columnar index
+
+    # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             maximum = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 maximum.append(max(thicket.dataframe.loc[node][column]))
             thicket.statsframe.dataframe[column + "_max"] = maximum
-    # Code parses columnar joined performance data
+    # columnar joined thicket object
     else:
         for idx, column in columns:
             maximum = []
@@ -45,4 +46,5 @@ def maximum(thicket, columns=None):
                 maximum.append(max(thicket.dataframe.loc[node][(idx, column)]))
             thicket.statsframe.dataframe[(idx, column + "_max")] = maximum
 
+        # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/maximum.py
+++ b/thicket/stats/maximum.py
@@ -1,0 +1,42 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Thicket Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import pandas as pd
+from ..utils import verify_thicket_structures
+
+
+def maximum(thicket, columns=None):
+    """Calculate the maximum value per node.
+
+    Designed to take in a single indexed or a columnar join thicket, and will append a column to the statsframe
+    for the maximum value for all profiles per node.
+
+    The maxiumum is the highest observation in the dataset.
+
+    Arguments:
+        thicket (thicket): Thicket object
+        columns (list): list of hardware/timing metrics to perform extremnum calculations on
+    """
+    if columns is None:
+        raise ValueError("To see a list of valid columns run get_perf_columns().")
+
+    #verify_thicket_structures(
+    #    thicket.dataframe, index=["node", "profile"], columns=columns
+    #)
+
+    if thicket.dataframe.columns.nlevels == 1:
+        for column in columns:
+            maximum = []
+            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
+                maximum.append(max(thicket.dataframe.loc[node][column]))
+            thicket.statsframe.dataframe[column + "_max"] = maximum
+    else:
+        for idx,column in columns:
+            maximum = []
+            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
+                maximum.append(max(thicket.dataframe.loc[node][(idx,column)]))
+            thicket.statsframe.dataframe[(idx,column + "_max")] = maximum
+
+        thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/maximum.py
+++ b/thicket/stats/maximum.py
@@ -4,36 +4,40 @@
 # SPDX-License-Identifier: MIT
 
 import pandas as pd
+
 from ..utils import verify_thicket_structures
 
 
 def maximum(thicket, columns=None):
     """Determine the maximum for each node in the performance data table.
 
-    Designed to take in a thicket, and append one or more columns to the aggregated statistics table for
-    the maximum value for each node.
+    Designed to take in a thicket, and append one or more columns to the aggregated
+    statistics table for the maximum value for each node.
 
     The maximum is the highest observation for a node and its associated profiles.
 
     Arguments:
         thicket (thicket): Thicket object
         columns (list): List of hardware/timing metrics to determine maximum value for.
-                        Note, if using a columnar_joined thicket a list of tuples must be
-                        passed in with the format:(column index,column name).
+                        Note, if using a columnar_joined thicket a list of tuples must
+                        be passed in with the format: (column index, column name).
     """
     if columns is None:
-        raise ValueError("To see a list of valid columns run get_perf_columns().")
+        raise ValueError(
+            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+        )
 
     verify_thicket_structures(
         thicket.dataframe, index=["node", "profile"], columns=columns
     )
-
+    # Code parses performance data with no columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             maximum = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 maximum.append(max(thicket.dataframe.loc[node][column]))
             thicket.statsframe.dataframe[column + "_max"] = maximum
+    # Code parses columnar joined performance data
     else:
         for idx, column in columns:
             maximum = []

--- a/thicket/stats/mean.py
+++ b/thicket/stats/mean.py
@@ -9,21 +9,23 @@ from ..utils import verify_thicket_structures
 
 
 def mean(thicket, columns=None):
-    """Calculate median and mean per node.
+    """Calculate the mean for each node in the performance data table.
 
-    Designed to take in a Thicket, and will append a column to the statsframe for
-    the median and mean calculations per node.
+    Designed to take in a thicket, and append one or more columns to the aggregated statistics table for
+    the mean calculation for each node.
 
     Arguments:
         thicket (thicket): Thicket object
-        columns (list): list of hardware/timing metrics to perform average calculations on
+        columns (list): List of hardware/timing metrics to perform mean calculation on.
+                        Note, if using a columnar_joined thicket a list of tuples must be
+                        passed in with the format:(column index,column name).
     """
     if columns is None:
         raise ValueError("To see a list of valid columns run get_perf_columns().")
 
-    #verify_thicket_structures(
-    #    thicket.dataframe, index=["node", "profile"], columns=columns
-    #)
+    verify_thicket_structures(
+        thicket.dataframe, index=["node", "profile"], columns=columns
+    )
 
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
@@ -33,10 +35,10 @@ def mean(thicket, columns=None):
             thicket.statsframe.dataframe[column + "_mean"] = mean
 
     else:
-        for idx,column in columns:
+        for idx, column in columns:
             mean = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                mean.append(np.mean(thicket.dataframe.loc[node][(idx,column)]))
-            thicket.statsframe.dataframe[(idx,column + "_mean")] = mean
+                mean.append(np.mean(thicket.dataframe.loc[node][(idx, column)]))
+            thicket.statsframe.dataframe[(idx, column + "_mean")] = mean
 
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/mean.py
+++ b/thicket/stats/mean.py
@@ -12,14 +12,14 @@ from ..utils import verify_thicket_structures
 def mean(thicket, columns=None):
     """Calculate the mean for each node in the performance data table.
 
-    Designed to take in a thicket, and append one or more columns to the aggregated
-    statistics table for the mean calculation for each node.
+    Designed to take in a thicket, and append one or more columns to the
+    aggregated statistics table for the mean calculation for each node.
 
     Arguments:
         thicket (thicket): Thicket object
         columns (list): List of hardware/timing metrics to perform mean calculation on.
-                        Note, if using a columnar_joined thicket a list of tuples must
-                        be passed in with the format: (column index, column name).
+            Note, if using a columnar joined thicket a list of tuples must be passed in
+            with the format (column index, column name).
     """
     if columns is None:
         raise ValueError(
@@ -29,14 +29,15 @@ def mean(thicket, columns=None):
     verify_thicket_structures(
         thicket.dataframe, index=["node", "profile"], columns=columns
     )
-    # Code parses performance data with no columnar index
+
+    # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             mean = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 mean.append(np.mean(thicket.dataframe.loc[node][column]))
             thicket.statsframe.dataframe[column + "_mean"] = mean
-    # Code parses columnar joined performance data
+    # columnar joined thicket object
     else:
         for idx, column in columns:
             mean = []
@@ -44,4 +45,5 @@ def mean(thicket, columns=None):
                 mean.append(np.mean(thicket.dataframe.loc[node][(idx, column)]))
             thicket.statsframe.dataframe[(idx, column + "_mean")] = mean
 
+        # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/mean.py
+++ b/thicket/stats/mean.py
@@ -1,0 +1,42 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Thicket Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import numpy as np
+import pandas as pd
+from ..utils import verify_thicket_structures
+
+
+def mean(thicket, columns=None):
+    """Calculate median and mean per node.
+
+    Designed to take in a Thicket, and will append a column to the statsframe for
+    the median and mean calculations per node.
+
+    Arguments:
+        thicket (thicket): Thicket object
+        columns (list): list of hardware/timing metrics to perform average calculations on
+    """
+    if columns is None:
+        raise ValueError("To see a list of valid columns run get_perf_columns().")
+
+    #verify_thicket_structures(
+    #    thicket.dataframe, index=["node", "profile"], columns=columns
+    #)
+
+    if thicket.dataframe.columns.nlevels == 1:
+        for column in columns:
+            mean = []
+            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
+                mean.append(np.mean(thicket.dataframe.loc[node][column]))
+            thicket.statsframe.dataframe[column + "_mean"] = mean
+
+    else:
+        for idx,column in columns:
+            mean = []
+            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
+                mean.append(np.mean(thicket.dataframe.loc[node][(idx,column)]))
+            thicket.statsframe.dataframe[(idx,column + "_mean")] = mean
+
+        thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/mean.py
+++ b/thicket/stats/mean.py
@@ -5,35 +5,38 @@
 
 import numpy as np
 import pandas as pd
+
 from ..utils import verify_thicket_structures
 
 
 def mean(thicket, columns=None):
     """Calculate the mean for each node in the performance data table.
 
-    Designed to take in a thicket, and append one or more columns to the aggregated statistics table for
-    the mean calculation for each node.
+    Designed to take in a thicket, and append one or more columns to the aggregated
+    statistics table for the mean calculation for each node.
 
     Arguments:
         thicket (thicket): Thicket object
         columns (list): List of hardware/timing metrics to perform mean calculation on.
-                        Note, if using a columnar_joined thicket a list of tuples must be
-                        passed in with the format:(column index,column name).
+                        Note, if using a columnar_joined thicket a list of tuples must
+                        be passed in with the format: (column index, column name).
     """
     if columns is None:
-        raise ValueError("To see a list of valid columns run get_perf_columns().")
+        raise ValueError(
+            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+        )
 
     verify_thicket_structures(
         thicket.dataframe, index=["node", "profile"], columns=columns
     )
-
+    # Code parses performance data with no columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             mean = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 mean.append(np.mean(thicket.dataframe.loc[node][column]))
             thicket.statsframe.dataframe[column + "_mean"] = mean
-
+    # Code parses columnar joined performance data
     else:
         for idx, column in columns:
             mean = []

--- a/thicket/stats/median.py
+++ b/thicket/stats/median.py
@@ -5,35 +5,39 @@
 
 import numpy as np
 import pandas as pd
+
 from ..utils import verify_thicket_structures
 
 
 def median(thicket, columns=None):
     """Calculate the median for each node in the performance data table.
 
-    Designed to take in a thicket, and append one or more columns to the aggregated statistics table for
-    the median calculation for each node.
+    Designed to take in a thicket, and append one or more columns to the aggregated
+    statistics table for the median calculation for each node.
 
     Arguments:
         thicket (thicket): Thicket object
-        columns (list): List of hardware/timing metrics to perform median calculation on.
-                        Note, if using a columnar_joined thicket a list of tuples must be
-                        passed in with the format:(column index,column name).
+        columns (list): List of hardware/timing metrics to perform median calculation
+                        on.
+                        Note, if using a columnar_joined thicket a list of tuples must
+                        be passed in with the format: (column index, column name).
     """
     if columns is None:
-        raise ValueError("To see a list of valid columns run get_perf_columns().")
+        raise ValueError(
+            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+        )
 
     verify_thicket_structures(
         thicket.dataframe, index=["node", "profile"], columns=columns
     )
-
+    # Code parses performance data with no columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             median = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 median.append(np.median(thicket.dataframe.loc[node][column]))
             thicket.statsframe.dataframe[column + "_median"] = median
-
+    # Code parses columnar joined performance data
     else:
         for idx, column in columns:
             median = []

--- a/thicket/stats/median.py
+++ b/thicket/stats/median.py
@@ -9,21 +9,23 @@ from ..utils import verify_thicket_structures
 
 
 def median(thicket, columns=None):
-    """Calculate median and mean per node.
+    """Calculate the median for each node in the performance data table.
 
-    Designed to take in a Thicket, and will append a column to the statsframe for
-    the median and mean calculations per node.
+    Designed to take in a thicket, and append one or more columns to the aggregated statistics table for
+    the median calculation for each node.
 
     Arguments:
         thicket (thicket): Thicket object
-        columns (list): list of hardware/timing metrics to perform average calculations on
+        columns (list): List of hardware/timing metrics to perform median calculation on.
+                        Note, if using a columnar_joined thicket a list of tuples must be
+                        passed in with the format:(column index,column name).
     """
     if columns is None:
         raise ValueError("To see a list of valid columns run get_perf_columns().")
 
-    #verify_thicket_structures(
-    #    thicket.dataframe, index=["node", "profile"], columns=columns
-    #)
+    verify_thicket_structures(
+        thicket.dataframe, index=["node", "profile"], columns=columns
+    )
 
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
@@ -33,10 +35,10 @@ def median(thicket, columns=None):
             thicket.statsframe.dataframe[column + "_median"] = median
 
     else:
-        for idx,column in columns:
+        for idx, column in columns:
             median = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                median.append(np.median(thicket.dataframe.loc[node][(idx,column)]))
-            thicket.statsframe.dataframe[(idx,column + "_median")] = median
+                median.append(np.median(thicket.dataframe.loc[node][(idx, column)]))
+            thicket.statsframe.dataframe[(idx, column + "_median")] = median
 
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/median.py
+++ b/thicket/stats/median.py
@@ -1,0 +1,42 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Thicket Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import numpy as np
+import pandas as pd
+from ..utils import verify_thicket_structures
+
+
+def median(thicket, columns=None):
+    """Calculate median and mean per node.
+
+    Designed to take in a Thicket, and will append a column to the statsframe for
+    the median and mean calculations per node.
+
+    Arguments:
+        thicket (thicket): Thicket object
+        columns (list): list of hardware/timing metrics to perform average calculations on
+    """
+    if columns is None:
+        raise ValueError("To see a list of valid columns run get_perf_columns().")
+
+    #verify_thicket_structures(
+    #    thicket.dataframe, index=["node", "profile"], columns=columns
+    #)
+
+    if thicket.dataframe.columns.nlevels == 1:
+        for column in columns:
+            median = []
+            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
+                median.append(np.median(thicket.dataframe.loc[node][column]))
+            thicket.statsframe.dataframe[column + "_median"] = median
+
+    else:
+        for idx,column in columns:
+            median = []
+            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
+                median.append(np.median(thicket.dataframe.loc[node][(idx,column)]))
+            thicket.statsframe.dataframe[(idx,column + "_median")] = median
+
+        thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/median.py
+++ b/thicket/stats/median.py
@@ -12,15 +12,14 @@ from ..utils import verify_thicket_structures
 def median(thicket, columns=None):
     """Calculate the median for each node in the performance data table.
 
-    Designed to take in a thicket, and append one or more columns to the aggregated
-    statistics table for the median calculation for each node.
+    Designed to take in a thicket, and append one or more columns to the
+    aggregated statistics table for the median calculation for each node.
 
     Arguments:
         thicket (thicket): Thicket object
         columns (list): List of hardware/timing metrics to perform median calculation
-                        on.
-                        Note, if using a columnar_joined thicket a list of tuples must
-                        be passed in with the format: (column index, column name).
+            on. Note, if using a columnar joined thicket a list of tuples must be passed
+            in with the format (column index, column name).
     """
     if columns is None:
         raise ValueError(
@@ -30,14 +29,15 @@ def median(thicket, columns=None):
     verify_thicket_structures(
         thicket.dataframe, index=["node", "profile"], columns=columns
     )
-    # Code parses performance data with no columnar index
+
+    # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             median = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 median.append(np.median(thicket.dataframe.loc[node][column]))
             thicket.statsframe.dataframe[column + "_median"] = median
-    # Code parses columnar joined performance data
+    # columnar joined thicket object
     else:
         for idx, column in columns:
             median = []
@@ -45,4 +45,5 @@ def median(thicket, columns=None):
                 median.append(np.median(thicket.dataframe.loc[node][(idx, column)]))
             thicket.statsframe.dataframe[(idx, column + "_median")] = median
 
+        # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/minimum.py
+++ b/thicket/stats/minimum.py
@@ -19,8 +19,8 @@ def minimum(thicket, columns=None):
     Arguments:
         thicket (thicket): Thicket object
         columns (list): List of hardware/timing metrics to determine minimum value for.
-                        Note, if using a columnar_joined thicket a list of tuples must
-                        be passed in with the format: (column index, column name).
+            Note, if using a columnar joined thicket a list of tuples must be passed in
+            with the format (column index, column name).
     """
     if columns is None:
         raise ValueError(
@@ -30,14 +30,15 @@ def minimum(thicket, columns=None):
     verify_thicket_structures(
         thicket.dataframe, index=["node", "profile"], columns=columns
     )
-    # Code parses performance data with no columnar index
+
+    # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             minimum = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 minimum.append(min(thicket.dataframe.loc[node][column]))
             thicket.statsframe.dataframe[column + "_min"] = minimum
-    # Code parses columnar joined performance data
+    # columnar joined thicket object
     else:
         for idx, column in columns:
             minimum = []
@@ -45,4 +46,5 @@ def minimum(thicket, columns=None):
                 minimum.append(min(thicket.dataframe.loc[node][(idx, column)]))
             thicket.statsframe.dataframe[(idx, column + "_min")] = minimum
 
+        # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/minimum.py
+++ b/thicket/stats/minimum.py
@@ -8,24 +8,25 @@ from ..utils import verify_thicket_structures
 
 
 def minimum(thicket, columns=None):
-    """Calculate min and max per node.
+    """Determine the minimum for each node in the performance data table.
 
-    Designed to take in a Thicket, and will append a column to the statsframe
-    for the min and max calculations per node.
+    Designed to take in a thicket, and append one or more columns to the aggregated statistics table for
+    the minimum value for each node.
 
-    The minimum is the lowest observation and the maxiumum is the highest
-    observation in the dataset.
+    The minimum is the lowest observation for a node and its associated profiles.
 
     Arguments:
         thicket (thicket): Thicket object
-        columns (list): list of hardware/timing metrics to perform extremnum calculations on
+        columns (list): List of hardware/timing metrics to determine minimum value for.
+                        Note, if using a columnar_joined thicket a list of tuples must be
+                        passed in with the format:(column index,column name).
     """
     if columns is None:
         raise ValueError("To see a list of valid columns run get_perf_columns().")
 
-    #verify_thicket_structures(
-    #    thicket.dataframe, index=["node", "profile"], columns=columns
-    #)
+    verify_thicket_structures(
+        thicket.dataframe, index=["node", "profile"], columns=columns
+    )
 
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
@@ -34,10 +35,10 @@ def minimum(thicket, columns=None):
                 minimum.append(min(thicket.dataframe.loc[node][column]))
             thicket.statsframe.dataframe[column + "_min"] = minimum
     else:
-        for idx,column in columns:
+        for idx, column in columns:
             minimum = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                minimum.append(min(thicket.dataframe.loc[node][(idx,column)]))
-            thicket.statsframe.dataframe[(idx,column + "_min")] = minimum
+                minimum.append(min(thicket.dataframe.loc[node][(idx, column)]))
+            thicket.statsframe.dataframe[(idx, column + "_min")] = minimum
 
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/minimum.py
+++ b/thicket/stats/minimum.py
@@ -1,0 +1,43 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Thicket Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import pandas as pd
+from ..utils import verify_thicket_structures
+
+
+def minimum(thicket, columns=None):
+    """Calculate min and max per node.
+
+    Designed to take in a Thicket, and will append a column to the statsframe
+    for the min and max calculations per node.
+
+    The minimum is the lowest observation and the maxiumum is the highest
+    observation in the dataset.
+
+    Arguments:
+        thicket (thicket): Thicket object
+        columns (list): list of hardware/timing metrics to perform extremnum calculations on
+    """
+    if columns is None:
+        raise ValueError("To see a list of valid columns run get_perf_columns().")
+
+    #verify_thicket_structures(
+    #    thicket.dataframe, index=["node", "profile"], columns=columns
+    #)
+
+    if thicket.dataframe.columns.nlevels == 1:
+        for column in columns:
+            minimum = []
+            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
+                minimum.append(min(thicket.dataframe.loc[node][column]))
+            thicket.statsframe.dataframe[column + "_min"] = minimum
+    else:
+        for idx,column in columns:
+            minimum = []
+            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
+                minimum.append(min(thicket.dataframe.loc[node][(idx,column)]))
+            thicket.statsframe.dataframe[(idx,column + "_min")] = minimum
+
+        thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/minimum.py
+++ b/thicket/stats/minimum.py
@@ -4,36 +4,40 @@
 # SPDX-License-Identifier: MIT
 
 import pandas as pd
+
 from ..utils import verify_thicket_structures
 
 
 def minimum(thicket, columns=None):
     """Determine the minimum for each node in the performance data table.
 
-    Designed to take in a thicket, and append one or more columns to the aggregated statistics table for
-    the minimum value for each node.
+    Designed to take in a thicket, and append one or more columns to the aggregated
+    statistics table for the minimum value for each node.
 
     The minimum is the lowest observation for a node and its associated profiles.
 
     Arguments:
         thicket (thicket): Thicket object
         columns (list): List of hardware/timing metrics to determine minimum value for.
-                        Note, if using a columnar_joined thicket a list of tuples must be
-                        passed in with the format:(column index,column name).
+                        Note, if using a columnar_joined thicket a list of tuples must
+                        be passed in with the format: (column index, column name).
     """
     if columns is None:
-        raise ValueError("To see a list of valid columns run get_perf_columns().")
+        raise ValueError(
+            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+        )
 
     verify_thicket_structures(
         thicket.dataframe, index=["node", "profile"], columns=columns
     )
-
+    # Code parses performance data with no columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             minimum = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 minimum.append(min(thicket.dataframe.loc[node][column]))
             thicket.statsframe.dataframe[column + "_min"] = minimum
+    # Code parses columnar joined performance data
     else:
         for idx, column in columns:
             minimum = []

--- a/thicket/stats/percentiles.py
+++ b/thicket/stats/percentiles.py
@@ -1,0 +1,64 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Thicket Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import pandas as pd
+import numpy as np
+
+from ..utils import verify_thicket_structures
+
+
+def percentiles(thicket, columns=None):
+    """Calculate the q-th percentile for each node in the performance data table.
+
+    Designed to take in a thicket, and append one or more columns to the aggregated
+    statistics table for the q-th percentile calculation for each node.
+
+    The 25th percentile is the lower quartile, and is the value at which 25% of
+    the answers lie below that value.
+
+    The 50th percentile, is the median and half of the values lie below the
+    median and half lie above the median.
+
+    The 75th percentile is the upper quartile, and is the value at which 25% of
+    the answers lie above that value and 75% of the answers lie below that
+    value.
+
+    Arguments:
+        thicket (thicket): Thicket object
+        columns (list): List of hardware/timing metrics to perform percentile
+                        calculation on.
+                        Note if using a columnar_joined thicket a list of tuples must
+                        be passed in with the format: (column index, column name).
+    """
+    if columns is None:
+        raise ValueError(
+            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+        )
+
+    verify_thicket_structures(
+        thicket.dataframe, index=["node", "profile"], columns=columns
+    )
+    # Code parses performance data with no columnar index
+    if thicket.dataframe.columns.nlevels == 1:
+        for column in columns:
+            percentiles = []
+            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
+                percentiles.append(
+                    np.percentile(thicket.dataframe.loc[node][column], [25, 50, 75])
+                )
+            thicket.statsframe.dataframe[column + "_percentiles"] = percentiles
+    # Code parses columnar joined performance data
+    else:
+        for idx, column in columns:
+            percentiles = []
+            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
+                percentiles.append(
+                    np.percentile(
+                        thicket.dataframe.loc[node][(idx, column)], [25, 50, 75]
+                    )
+                )
+            thicket.statsframe.dataframe[(idx, column + "_percentiles")] = percentiles
+
+        thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/percentiles.py
+++ b/thicket/stats/percentiles.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: MIT
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 from ..utils import verify_thicket_structures
 
@@ -15,22 +15,20 @@ def percentiles(thicket, columns=None):
     Designed to take in a thicket, and append one or more columns to the aggregated
     statistics table for the q-th percentile calculation for each node.
 
-    The 25th percentile is the lower quartile, and is the value at which 25% of
-    the answers lie below that value.
+    The 25th percentile is the lower quartile, and is the value at which 25% of the
+    answers lie below that value.
 
-    The 50th percentile, is the median and half of the values lie below the
-    median and half lie above the median.
+    The 50th percentile, is the median and half of the values lie below the median and
+    half lie above the median.
 
-    The 75th percentile is the upper quartile, and is the value at which 25% of
-    the answers lie above that value and 75% of the answers lie below that
-    value.
+    The 75th percentile is the upper quartile, and is the value at which 25% of the
+    answers lie above that value and 75% of the answers lie below that value.
 
     Arguments:
         thicket (thicket): Thicket object
         columns (list): List of hardware/timing metrics to perform percentile
-                        calculation on.
-                        Note if using a columnar_joined thicket a list of tuples must
-                        be passed in with the format: (column index, column name).
+            calculation on. Note if using a columnar joined thicket a list of tuples
+            must be passed in with the format (column index, column name).
     """
     if columns is None:
         raise ValueError(
@@ -40,7 +38,8 @@ def percentiles(thicket, columns=None):
     verify_thicket_structures(
         thicket.dataframe, index=["node", "profile"], columns=columns
     )
-    # Code parses performance data with no columnar index
+
+    # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             percentiles = []
@@ -49,7 +48,7 @@ def percentiles(thicket, columns=None):
                     np.percentile(thicket.dataframe.loc[node][column], [25, 50, 75])
                 )
             thicket.statsframe.dataframe[column + "_percentiles"] = percentiles
-    # Code parses columnar joined performance data
+    # columnar joined thicket object
     else:
         for idx, column in columns:
             percentiles = []
@@ -61,4 +60,5 @@ def percentiles(thicket, columns=None):
                 )
             thicket.statsframe.dataframe[(idx, column + "_percentiles")] = percentiles
 
+        # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/std.py
+++ b/thicket/stats/std.py
@@ -5,37 +5,41 @@
 
 import numpy as np
 import pandas as pd
+
 from ..utils import verify_thicket_structures
 
 
 def std(thicket, columns=None):
     """Calculate the standard deviation for each node in the performance data table.
 
-    Designed to take in a thicket, and append one or more columns to the aggregated statistics table for
-    the standard deviation calculation for each node.
+    Designed to take in a thicket, and append one or more columns to the aggregated
+    statistics table for the standard deviation calculation for each node.
 
     Standard deviation describes how dispersed the data is in relation to the mean.
 
     Arguments:
         thicket (thicket): Thicket object
-        columns (list): List of hardware/timing metrics to perform standard deviation calculation on.
-                        Note, if using a columnar_joined thicket a list of tuples must be
-                        passed in with the format:(column index,column name).
+        columns (list): List of hardware/timing metrics to perform standard deviation
+                        calculation on.
+                        Note, if using a columnar_joined thicket a list of tuples must
+                        be passed in with the format: (column index, column name).
     """
     if columns is None:
-        raise ValueError("To see a list of valid columns run get_perf_columns().")
+        raise ValueError(
+            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+        )
 
     verify_thicket_structures(
         thicket.dataframe, index=["node", "profile"], columns=columns
     )
-
+    # Code parses performance data with no columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             std = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 std.append(np.std(thicket.dataframe.loc[node][column]))
             thicket.statsframe.dataframe[column + "_std"] = std
-
+    # Code parses columnar joined performance data
     else:
         for idx, column in columns:
             std = []

--- a/thicket/stats/std.py
+++ b/thicket/stats/std.py
@@ -20,9 +20,8 @@ def std(thicket, columns=None):
     Arguments:
         thicket (thicket): Thicket object
         columns (list): List of hardware/timing metrics to perform standard deviation
-                        calculation on.
-                        Note, if using a columnar_joined thicket a list of tuples must
-                        be passed in with the format: (column index, column name).
+            calculation on. Note, if using a columnar_joined thicket a list of tuples
+            must be passed in with the format (column index, column name).
     """
     if columns is None:
         raise ValueError(
@@ -32,14 +31,15 @@ def std(thicket, columns=None):
     verify_thicket_structures(
         thicket.dataframe, index=["node", "profile"], columns=columns
     )
-    # Code parses performance data with no columnar index
+
+    # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             std = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 std.append(np.std(thicket.dataframe.loc[node][column]))
             thicket.statsframe.dataframe[column + "_std"] = std
-    # Code parses columnar joined performance data
+    # columnar joined thicket object
     else:
         for idx, column in columns:
             std = []
@@ -47,4 +47,5 @@ def std(thicket, columns=None):
                 std.append(np.std(thicket.dataframe.loc[node][(idx, column)]))
             thicket.statsframe.dataframe[(idx, column + "_std")] = std
 
+        # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/std.py
+++ b/thicket/stats/std.py
@@ -1,0 +1,45 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Thicket Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import numpy as np
+import pandas as pd
+from ..utils import verify_thicket_structures
+
+
+def std(thicket, columns=None):
+    """Calculate standard deviation and variance per node.
+
+    Designed to take in a Thicket, and will append a column to the statsframe
+    for the standard deviation and variance calculations per node.
+
+    Variance will allow you to see the spread within a dataset and standard
+    deviation will tell you how dispersed the data is in relation to the mean.
+
+    Arguments:
+        thicket (thicket): Thicket object
+        columns (list): list of hardware/timing metrics to perform deviation calculations on
+    """
+    if columns is None:
+        raise ValueError("To see a list of valid columns run get_perf_columns().")
+
+    #verify_thicket_structures(
+    #    thicket.dataframe, index=["node", "profile"], columns=columns
+    #)
+
+    if thicket.dataframe.columns.nlevels == 1:
+        for column in columns:
+            std = []
+            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
+                std.append(np.std(thicket.dataframe.loc[node][column]))
+            thicket.statsframe.dataframe[column + "_std"] = std
+
+    else:
+        for idx,column in columns:
+            std = []
+            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
+                std.append(np.std(thicket.dataframe.loc[node][(idx,column)]))
+            thicket.statsframe.dataframe[(idx,column + "_std")] = std
+
+        thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/std.py
+++ b/thicket/stats/std.py
@@ -9,24 +9,25 @@ from ..utils import verify_thicket_structures
 
 
 def std(thicket, columns=None):
-    """Calculate standard deviation and variance per node.
+    """Calculate the standard deviation for each node in the performance data table.
 
-    Designed to take in a Thicket, and will append a column to the statsframe
-    for the standard deviation and variance calculations per node.
+    Designed to take in a thicket, and append one or more columns to the aggregated statistics table for
+    the standard deviation calculation for each node.
 
-    Variance will allow you to see the spread within a dataset and standard
-    deviation will tell you how dispersed the data is in relation to the mean.
+    Standard deviation describes how dispersed the data is in relation to the mean.
 
     Arguments:
         thicket (thicket): Thicket object
-        columns (list): list of hardware/timing metrics to perform deviation calculations on
+        columns (list): List of hardware/timing metrics to perform standard deviation calculation on.
+                        Note, if using a columnar_joined thicket a list of tuples must be
+                        passed in with the format:(column index,column name).
     """
     if columns is None:
         raise ValueError("To see a list of valid columns run get_perf_columns().")
 
-    #verify_thicket_structures(
-    #    thicket.dataframe, index=["node", "profile"], columns=columns
-    #)
+    verify_thicket_structures(
+        thicket.dataframe, index=["node", "profile"], columns=columns
+    )
 
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
@@ -36,10 +37,10 @@ def std(thicket, columns=None):
             thicket.statsframe.dataframe[column + "_std"] = std
 
     else:
-        for idx,column in columns:
+        for idx, column in columns:
             std = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                std.append(np.std(thicket.dataframe.loc[node][(idx,column)]))
-            thicket.statsframe.dataframe[(idx,column + "_std")] = std
+                std.append(np.std(thicket.dataframe.loc[node][(idx, column)]))
+            thicket.statsframe.dataframe[(idx, column + "_std")] = std
 
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/variance.py
+++ b/thicket/stats/variance.py
@@ -5,37 +5,42 @@
 
 import numpy as np
 import pandas as pd
+
 from ..utils import verify_thicket_structures
 
 
 def variance(thicket, columns=None):
     """Calculate the variance for each node in the performance data table.
 
-    Designed to take in a thicket, and append one or more columns to the aggregated statistics table for
-    the variance calculation for each node.
+    Designed to take in a thicket, and append one or more columns to the aggregated
+    statistics table for the variance calculation for each node.
 
-    Variance will allow you to see the spread of data within a node and that nodes profiles.
+    Variance will allow you to see the spread of data within a node and that nodes
+    profiles.
 
     Arguments:
         thicket (thicket): Thicket object
-        columns (list): List of hardware/timing metrics to perform variance calculation on.
-                        Note, if using a columnar_joined thicket a list of tuples must be
-                        passed in with the format:(column index,column name).
+        columns (list): List of hardware/timing metrics to perform variance
+                        calculation on.
+                        Note, if using a columnar_joined thicket a list of tuples must
+                        be passed in with the format: (column index, column name).
     """
     if columns is None:
-        raise ValueError("To see a list of valid columns run get_perf_columns().")
+        raise ValueError(
+            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+        )
 
     verify_thicket_structures(
         thicket.dataframe, index=["node", "profile"], columns=columns
     )
-
+    # Code parses performance data with no columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             var = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 var.append(np.var(thicket.dataframe.loc[node][column]))
             thicket.statsframe.dataframe[column + "_var"] = var
-
+    # Code parses columnar joined performance data
     else:
         for idx, column in columns:
             var = []

--- a/thicket/stats/variance.py
+++ b/thicket/stats/variance.py
@@ -9,24 +9,25 @@ from ..utils import verify_thicket_structures
 
 
 def variance(thicket, columns=None):
-    """Calculate standard deviation and variance per node.
+    """Calculate the variance for each node in the performance data table.
 
-    Designed to take in a Thicket, and will append a column to the statsframe
-    for the standard deviation and variance calculations per node.
+    Designed to take in a thicket, and append one or more columns to the aggregated statistics table for
+    the variance calculation for each node.
 
-    Variance will allow you to see the spread within a dataset and standard
-    deviation will tell you how dispersed the data is in relation to the mean.
+    Variance will allow you to see the spread of data within a node and that nodes profiles.
 
     Arguments:
         thicket (thicket): Thicket object
-        columns (list): list of hardware/timing metrics to perform deviation calculations on
+        columns (list): List of hardware/timing metrics to perform variance calculation on.
+                        Note, if using a columnar_joined thicket a list of tuples must be
+                        passed in with the format:(column index,column name).
     """
     if columns is None:
         raise ValueError("To see a list of valid columns run get_perf_columns().")
 
-    #verify_thicket_structures(
-    #    thicket.dataframe, index=["node", "profile"], columns=columns
-    #)
+    verify_thicket_structures(
+        thicket.dataframe, index=["node", "profile"], columns=columns
+    )
 
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
@@ -36,10 +37,10 @@ def variance(thicket, columns=None):
             thicket.statsframe.dataframe[column + "_var"] = var
 
     else:
-        for idx,column in columns:
+        for idx, column in columns:
             var = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                var.append(np.var(thicket.dataframe.loc[node][(idx,column)]))
-            thicket.statsframe.dataframe[(idx,column + "_var")] = var
+                var.append(np.var(thicket.dataframe.loc[node][(idx, column)]))
+            thicket.statsframe.dataframe[(idx, column + "_var")] = var
 
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/variance.py
+++ b/thicket/stats/variance.py
@@ -20,10 +20,9 @@ def variance(thicket, columns=None):
 
     Arguments:
         thicket (thicket): Thicket object
-        columns (list): List of hardware/timing metrics to perform variance
-                        calculation on.
-                        Note, if using a columnar_joined thicket a list of tuples must
-                        be passed in with the format: (column index, column name).
+        columns (list): List of hardware/timing metrics to perform variance calculation
+            on. Note, if using a columnar_joined thicket a list of tuples must be passed
+            in with the format (column index, column name).
     """
     if columns is None:
         raise ValueError(
@@ -33,14 +32,15 @@ def variance(thicket, columns=None):
     verify_thicket_structures(
         thicket.dataframe, index=["node", "profile"], columns=columns
     )
-    # Code parses performance data with no columnar index
+
+    # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             var = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 var.append(np.var(thicket.dataframe.loc[node][column]))
             thicket.statsframe.dataframe[column + "_var"] = var
-    # Code parses columnar joined performance data
+    # columnar joined thicket object
     else:
         for idx, column in columns:
             var = []
@@ -48,4 +48,5 @@ def variance(thicket, columns=None):
                 var.append(np.var(thicket.dataframe.loc[node][(idx, column)]))
             thicket.statsframe.dataframe[(idx, column + "_var")] = var
 
+        # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/variance.py
+++ b/thicket/stats/variance.py
@@ -1,0 +1,45 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Thicket Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import numpy as np
+import pandas as pd
+from ..utils import verify_thicket_structures
+
+
+def variance(thicket, columns=None):
+    """Calculate standard deviation and variance per node.
+
+    Designed to take in a Thicket, and will append a column to the statsframe
+    for the standard deviation and variance calculations per node.
+
+    Variance will allow you to see the spread within a dataset and standard
+    deviation will tell you how dispersed the data is in relation to the mean.
+
+    Arguments:
+        thicket (thicket): Thicket object
+        columns (list): list of hardware/timing metrics to perform deviation calculations on
+    """
+    if columns is None:
+        raise ValueError("To see a list of valid columns run get_perf_columns().")
+
+    #verify_thicket_structures(
+    #    thicket.dataframe, index=["node", "profile"], columns=columns
+    #)
+
+    if thicket.dataframe.columns.nlevels == 1:
+        for column in columns:
+            var = []
+            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
+                var.append(np.var(thicket.dataframe.loc[node][column]))
+            thicket.statsframe.dataframe[column + "_var"] = var
+
+    else:
+        for idx,column in columns:
+            var = []
+            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
+                var.append(np.var(thicket.dataframe.loc[node][(idx,column)]))
+            thicket.statsframe.dataframe[(idx,column + "_var")] = var
+
+        thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)


### PR DESCRIPTION
This PR has two primary goals, one to split previous aggregated statistical functions which had two statistical operations into individual functions with a single statistical operation, and the second is to add the functionality to work with multi-indexed thickets (columnar-join). Below will be a list of previous functions that contained two statistical operations and that are now split into individual functions: 

- `calc_extremum.py`
    - Split into: `minimum.py` and `maximum.py`
- `calc_deviation.py`
    - Split into: `std.py` and `variance.py`
- `calc_average.py`
    - Split into: `mean.py` and `median.py`