### PR TITLE
Refactor test_filter_stats to Support Columnar Join Testing

### DIFF
--- a/thicket/tests/test_columnar_join.py
+++ b/thicket/tests/test_columnar_join.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from test_filter import check_filter
+from test_filter import check_filter, check_filter_stats
 from thicket import Thicket
 
 
@@ -92,3 +92,22 @@ def test_filter_columnar_join(columnar_join_thicket):
     }
 
     check_filter(combined_th, columns_values)
+
+
+def test_filter_stats_columnar_join(columnar_join_thicket):
+    thicket_list, thicket_list_cp, combined_th = columnar_join_thicket
+    # columns and corresponding values to filter by
+    columns_values = {
+        ("test", "test_string_column"): ["less than 20"],
+        ("test", "test_numeric_column"): [4, 15],
+    }
+    # set string column values
+    less_than_20 = ["less than 20"] * 21
+    less_than_45 = ["less than 45"] * 25
+    less_than_178 = ["less than 178"] * 131
+    new_col = less_than_20 + less_than_45 + less_than_178
+    combined_th.statsframe.dataframe[("test", "test_string_column")] = new_col
+    # set numeric column values
+    combined_th.statsframe.dataframe[("test", "test_numeric_column")] = range(0, 177)
+
+    check_filter_stats(combined_th, columns_values)

--- a/thicket/tests/test_filter.py
+++ b/thicket/tests/test_filter.py
@@ -71,36 +71,7 @@ def check_filter(th, columns_values):
         th.filter_metadata(lambda x: x["cluster"] == "chekov")
 
 
-def test_filter(example_cali):
-    # example thicket
-    th = Thicket.from_caliperreader(example_cali)
-    # columns and corresponding values to filter by
-    columns_values = {"problem_size": ["30"], "cluster": ["quartz", "chekov"]}
-
-    check_filter(th, columns_values)
-
-
-def test_filter_stats(example_cali):
-    # example thicket
-    th = Thicket.from_caliperreader(example_cali)
-
-    # columns and corresponding values to filter by
-    columns_values = {
-        "test_string_column": ["less than 20"],
-        "test_numeric_column": [4, 15],
-    }
-
-    # set string column values
-    less_than_20 = ["less than 20"] * 21
-    less_than_45 = ["less than 45"] * 25
-    less_than_87 = ["less than 87"] * 40
-    new_col = less_than_20 + less_than_45 + less_than_87
-
-    th.statsframe.dataframe["test_string_column"] = new_col
-
-    # set numeric column values
-    th.statsframe.dataframe["test_numeric_column"] = range(0, 86)
-
+def check_filter_stats(th, columns_values):
     for column in columns_values:
         for value in columns_values[column]:
             # for type str column
@@ -129,7 +100,7 @@ def test_filter_stats(example_cali):
             # check if output is a thicket object
             assert isinstance(new_th, Thicket)
 
-            # fitlered statsframe nodes
+            # filtered statsframe nodes
             stats_nodes = sorted(
                 new_th.statsframe.dataframe.index.drop_duplicates().tolist()
             )
@@ -142,3 +113,32 @@ def test_filter_stats(example_cali):
             )
             # check filtered ensembleframe nodes match exp_nodes
             assert ensemble_nodes == exp_nodes
+
+
+def test_filter(example_cali):
+    # example thicket
+    th = Thicket.from_caliperreader(example_cali)
+    # columns and corresponding values to filter by
+    columns_values = {"problem_size": ["30"], "cluster": ["quartz", "chekov"]}
+
+    check_filter(th, columns_values)
+
+
+def test_filter_stats(example_cali):
+    # example thicket
+    th = Thicket.from_caliperreader(example_cali)
+    # columns and corresponding values to filter by
+    columns_values = {
+        "test_string_column": ["less than 20"],
+        "test_numeric_column": [4, 15],
+    }
+    # set string column values
+    less_than_20 = ["less than 20"] * 21
+    less_than_45 = ["less than 45"] * 25
+    less_than_87 = ["less than 87"] * 40
+    new_col = less_than_20 + less_than_45 + less_than_87
+    th.statsframe.dataframe["test_string_column"] = new_col
+    # set numeric column values
+    th.statsframe.dataframe["test_numeric_column"] = range(0, 86)
+
+    check_filter_stats(th, columns_values)


### PR DESCRIPTION
- Refactor `test_filter_stats` into `test_filter_stats` and `check_filter_stats` .
- Use `check_filter_stats` in new function `test_filter_stats_columnar_join`.