### PR TITLE
Hotfix: Fixes the triggers for the Build and Upload Wheels Action

### DIFF
--- a/.github/workflows/build_and_upload_wheels.yaml
+++ b/.github/workflows/build_and_upload_wheels.yaml
@@ -2,8 +2,8 @@ name: Build wheels for Thicket
 
 on:
   # Uncomment for testing through a PR
-  pull_request:
-    branches: [develop, releases/**]
+  # pull_request:
+  #   branches: [develop, releases/**]
   workflow_dispatch:
   release:
     types:


### PR DESCRIPTION
This is a small hotfix PR for the Build and Upload Wheels Action to prevent it from running on every commit to a PR.