### PR TITLE
Update to get_unique_metadata for columnar join

### DIFF
--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1215,21 +1215,37 @@ class Thicket(GraphFrame):
 
         Returns:
             (dict): alphabetical ordered dictionary with key's being the column names
-                      and the values being unique values for a column
+                    and the values being unique values for a metadata column.
         """
         unique_meta = {}
+        # thicket object without columnar index
+        if self.dataframe.columns.nlevels == 1:
+            for col in self.metadata.columns:
+                # skip columns where the values are a list
+                if isinstance(self.metadata[col].iloc[0], list):
+                    continue
+                else:
+                    unique_entries = self.metadata[col].unique().tolist()
+                    unique_meta[col] = unique_entries
 
-        for col in self.metadata.columns:
-            # skip columns where the values are a list
-            if isinstance(self.metadata[col].iloc[0], list):
-                continue
-            else:
-                unique_entries = self.metadata[col].unique().tolist()
-                unique_meta[col] = unique_entries
+            sorted_meta = dict(sorted(unique_meta.items(), key=lambda x: x[0].lower()))
 
-        sorted_meta = dict(sorted(unique_meta.items(), key=lambda x: x[0].lower()))
+            return sorted_meta
+        # columnar joined thicket object
+        else:
+            sorted_meta = []
+            for idx in list(self.metadata.columns.levels[0]):
+                for col in self.metadata[idx].columns:
+                    if isinstance(self.metadata[idx][col].iloc[0], list):
+                        continue
+                    else:
+                        unique_entries = self.metadata[idx][col].unique().tolist()
+                        unique_meta[col] = unique_entries
 
-        return sorted_meta
+                sorted_meta.append(
+                    (idx, dict(sorted(unique_meta.items(), key=lambda x: x[0].lower())))
+                )
+            return sorted_meta
 
 
 class InvalidFilter(Exception):

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1215,9 +1215,10 @@ class Thicket(GraphFrame):
 
         Returns:
             (dict): alphabetical ordered dictionary with key's being the column names
-                    and the values being unique values for a metadata column.
+                and the values being unique values for a metadata column.
         """
         unique_meta = {}
+
         # thicket object without columnar index
         if self.dataframe.columns.nlevels == 1:
             for col in self.metadata.columns:
@@ -1229,8 +1230,6 @@ class Thicket(GraphFrame):
                     unique_meta[col] = unique_entries
 
             sorted_meta = dict(sorted(unique_meta.items(), key=lambda x: x[0].lower()))
-
-            return sorted_meta
         # columnar joined thicket object
         else:
             sorted_meta = []
@@ -1245,7 +1244,8 @@ class Thicket(GraphFrame):
                 sorted_meta.append(
                     (idx, dict(sorted(unique_meta.items(), key=lambda x: x[0].lower())))
                 )
-            return sorted_meta
+
+        return sorted_meta
 
 
 class InvalidFilter(Exception):


### PR DESCRIPTION
This PR is for `get_unique_metadata`. The PR addresses the functionality of `get_unique_metadata` such that it will be able to work properly with a columnar joined thicket. 

When passing in a columnar joined thicket, a list will be returned with the following format:

- [(column index, dictionary of unique metadata)]