### PR TITLE
Update to allow get_perf_columns to work with columnar joined thicket

### DIFF
--- a/thicket/helpers.py
+++ b/thicket/helpers.py
@@ -190,7 +190,12 @@ def _get_perf_columns(df):
 
     numeric_columns = df.select_dtypes(include=numeric_types).columns.tolist()
 
-    if "nid" in numeric_columns:
-        numeric_columns.remove("nid")
+    # thicket object without columnar index
+    if df.columns.nlevels == 1:
+        if "nid" in numeric_columns:
+            numeric_columns.remove("nid")
 
-    return numeric_columns
+        return numeric_columns
+    # columnar joined thicket object
+    else:
+        return [x for x in numeric_columns if "nid" not in x]

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -501,6 +501,7 @@ class Thicket(GraphFrame):
                 combined_th.dataframe, multiindex=True
             ),
         )
+        combined_th.performance_cols = helpers._get_perf_columns(combined_th.dataframe)
 
         return combined_th
 


### PR DESCRIPTION
This PR is for `get_perf_columns`. The PR updates  the functionality of `get_perf_columns ` to work with a columnar joined thicket. 