### PR TITLE
Adds usability of show_metric_columns() to statistic functions

### DIFF
--- a/thicket/stats/calc_boxplot_statistics.py
+++ b/thicket/stats/calc_boxplot_statistics.py
@@ -83,6 +83,12 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
                 if not profile:
                     profile = []
                 boxplot_dict[col + "_outliers" + q_list].append(profile)
+            # check to see if exclusive metric
+            if col in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.extend(list(boxplot_dict.keys()))
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.extend(list(boxplot_dict.keys()))
 
             df_box = pd.DataFrame(boxplot_dict)
             df_box["node"] = thicket.statsframe.dataframe.index.tolist()
@@ -139,6 +145,14 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
                 for outerKey, innerDict in boxplot_dict.items()
                 for innerKey, values in innerDict.items()
             }
+
+            # check to see if exclusive metric
+            if (idx, col) in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.extend(list(create_multi_index.keys()))
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.extend(list(create_multi_index.keys()))
+
             df_box = pd.DataFrame(create_multi_index)
             df_box["node"] = thicket.statsframe.dataframe.reset_index()["node"].tolist()
             df_box = df_box.set_index("node")

--- a/thicket/stats/check_normality.py
+++ b/thicket/stats/check_normality.py
@@ -48,6 +48,12 @@ def check_normality(thicket, columns=None):
                     normality.append("True")
                 else:
                     normality.append(pd.NA)
+            # check to see if exclusive metric
+            if column in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.append(column + "_normality")
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.append(column + "_normality")
 
             thicket.statsframe.dataframe[column + "_normality"] = normality
     # columnar joined thicket object
@@ -63,6 +69,12 @@ def check_normality(thicket, columns=None):
                     normality.append("True")
                 else:
                     normality.append(pd.NA)
+            # check to see if exclusive metric
+            if (idx, column) in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.append((idx, column + "_normality"))
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.append((idx, column + "_normality"))
 
             thicket.statsframe.dataframe[(idx, column + "_normality")] = normality
 

--- a/thicket/stats/correlation_nodewise.py
+++ b/thicket/stats/correlation_nodewise.py
@@ -14,6 +14,10 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
     Designed to take in a thicket, and append one or more columns to the aggregated
     statistics table for the nodewise correlation calculation for each node.
 
+    Note: Resulting columns from correlation nodewise will currently not be appended
+        to exc_metrics or inc_metrics until creating new data structure to store
+        combined metrics (inclusive + exclusive).
+
     Arguments:
         thicket (thicket): Thicket object
         column1 (str): First comparison column. Note, if using a columnar joined thicket

--- a/thicket/stats/maximum.py
+++ b/thicket/stats/maximum.py
@@ -37,6 +37,13 @@ def maximum(thicket, columns=None):
             maximum = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 maximum.append(max(thicket.dataframe.loc[node][column]))
+            # check to see if exclusive metric
+            if column in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.append(column + "_max")
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.append(column + "_max")
+
             thicket.statsframe.dataframe[column + "_max"] = maximum
     # columnar joined thicket object
     else:
@@ -44,6 +51,13 @@ def maximum(thicket, columns=None):
             maximum = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 maximum.append(max(thicket.dataframe.loc[node][(idx, column)]))
+            # check to see if exclusive metric
+            if (idx, column) in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.append((idx, column + "_max"))
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.append((idx, column + "_max"))
+
             thicket.statsframe.dataframe[(idx, column + "_max")] = maximum
 
         # sort columns in index

--- a/thicket/stats/mean.py
+++ b/thicket/stats/mean.py
@@ -36,6 +36,13 @@ def mean(thicket, columns=None):
             mean = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 mean.append(np.mean(thicket.dataframe.loc[node][column]))
+            # check to see if exclusive metric
+            if column in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.append(column + "_mean")
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.append(column + "_mean")
+
             thicket.statsframe.dataframe[column + "_mean"] = mean
     # columnar joined thicket object
     else:
@@ -43,6 +50,13 @@ def mean(thicket, columns=None):
             mean = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 mean.append(np.mean(thicket.dataframe.loc[node][(idx, column)]))
+            # check to see if exclusive metric
+            if (idx, column) in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.append((idx, column + "_mean"))
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.append((idx, column + "_mean"))
+
             thicket.statsframe.dataframe[(idx, column + "_mean")] = mean
 
         # sort columns in index

--- a/thicket/stats/median.py
+++ b/thicket/stats/median.py
@@ -36,6 +36,13 @@ def median(thicket, columns=None):
             median = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 median.append(np.median(thicket.dataframe.loc[node][column]))
+            # check to see if exclusive metric
+            if column in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.append(column + "_median")
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.append(column + "_median")
+
             thicket.statsframe.dataframe[column + "_median"] = median
     # columnar joined thicket object
     else:
@@ -43,6 +50,13 @@ def median(thicket, columns=None):
             median = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 median.append(np.median(thicket.dataframe.loc[node][(idx, column)]))
+            # check to see if exclusive metric
+            if (idx, column) in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.append((idx, column + "_median"))
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.append((idx, column + "_median"))
+
             thicket.statsframe.dataframe[(idx, column + "_median")] = median
 
         # sort columns in index

--- a/thicket/stats/minimum.py
+++ b/thicket/stats/minimum.py
@@ -37,6 +37,13 @@ def minimum(thicket, columns=None):
             minimum = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 minimum.append(min(thicket.dataframe.loc[node][column]))
+            # check to see if exclusive metric
+            if column in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.append(column + "_min")
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.append(column + "_min")
+
             thicket.statsframe.dataframe[column + "_min"] = minimum
     # columnar joined thicket object
     else:
@@ -44,6 +51,13 @@ def minimum(thicket, columns=None):
             minimum = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 minimum.append(min(thicket.dataframe.loc[node][(idx, column)]))
+            # check to see if exclusive metric
+            if (idx, column) in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.append((idx, column + "_min"))
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.append((idx, column + "_min"))
+
             thicket.statsframe.dataframe[(idx, column + "_min")] = minimum
 
         # sort columns in index

--- a/thicket/stats/percentiles.py
+++ b/thicket/stats/percentiles.py
@@ -47,6 +47,13 @@ def percentiles(thicket, columns=None):
                 percentiles.append(
                     np.percentile(thicket.dataframe.loc[node][column], [25, 50, 75])
                 )
+            # check to see if exclusive metric
+            if column in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.append(column + "_percentiles")
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.append(column + "_percentiles")
+
             thicket.statsframe.dataframe[column + "_percentiles"] = percentiles
     # columnar joined thicket object
     else:
@@ -58,6 +65,13 @@ def percentiles(thicket, columns=None):
                         thicket.dataframe.loc[node][(idx, column)], [25, 50, 75]
                     )
                 )
+            # check to see if exclusive metric
+            if (idx, column) in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.append((idx, column + "_percentiles"))
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.append((idx, column + "_percentiles"))
+
             thicket.statsframe.dataframe[(idx, column + "_percentiles")] = percentiles
 
         # sort columns in index

--- a/thicket/stats/std.py
+++ b/thicket/stats/std.py
@@ -38,6 +38,13 @@ def std(thicket, columns=None):
             std = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 std.append(np.std(thicket.dataframe.loc[node][column]))
+            # check to see if exclusive metric
+            if column in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.append(column + "_std")
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.append(column + "_std")
+
             thicket.statsframe.dataframe[column + "_std"] = std
     # columnar joined thicket object
     else:
@@ -45,6 +52,13 @@ def std(thicket, columns=None):
             std = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 std.append(np.std(thicket.dataframe.loc[node][(idx, column)]))
+            # check to see if exclusive metric
+            if (idx, column) in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.append((idx, column + "_std"))
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.append((idx, column + "_std"))
+
             thicket.statsframe.dataframe[(idx, column + "_std")] = std
 
         # sort columns in index

--- a/thicket/stats/variance.py
+++ b/thicket/stats/variance.py
@@ -39,6 +39,13 @@ def variance(thicket, columns=None):
             var = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 var.append(np.var(thicket.dataframe.loc[node][column]))
+            # check to see if exclusive metric
+            if column in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.append(column + "_var")
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.append(column + "_var")
+
             thicket.statsframe.dataframe[column + "_var"] = var
     # columnar joined thicket object
     else:
@@ -46,6 +53,12 @@ def variance(thicket, columns=None):
             var = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 var.append(np.var(thicket.dataframe.loc[node][(idx, column)]))
+            # check to see if exclusive metric
+            if (idx, column) in thicket.exc_metrics:
+                thicket.statsframe.exc_metrics.append((idx, column + "_var"))
+            # check to see if inclusive metric
+            else:
+                thicket.statsframe.inc_metrics.append((idx, column + "_var"))
             thicket.statsframe.dataframe[(idx, column + "_var")] = var
 
         # sort columns in index


### PR DESCRIPTION
Originally when calling `.show_metric_columns()` on a thicket's aggregated statistic table, an empty list would output. This was due to no metrics being added properly to either `exc_metrics` or `inc_metrics` after calling an aggregated statistic function on a thicket. 

This code update addresses this issue. Where upon a user calling an aggregated statistic function on a thicket, resulting metrics will now be appended to either `exc_metrics` or `inc_metrics` accordingly. Therefore, calling `.show_metric_columns()` on a thicket's aggregated statistic table will now result with the following two behaviors:

- Empty list: If no metrics appear within the thicket's aggregated statistic table
- Filled in list: If metrics appear within the thicket's aggregated statistic table