### PR TITLE
Adds support for Hatchet's "new-style" queries to Thicket

### DIFF
--- a/thicket/query.py
+++ b/thicket/query.py
@@ -1,0 +1,60 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Thicket Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+from hatchet.query import (
+    Query,
+    ObjectQuery,
+    StringQuery,
+    parse_string_dialect,
+    CompoundQuery,
+    ConjunctionQuery,
+    DisjunctionQuery,
+    ExclusiveDisjunctionQuery,
+    NegationQuery,
+    QueryEngine,
+    InvalidQueryPath,
+    InvalidQueryFilter,
+    RedundantQueryFilterWarning,
+    BadNumberNaryQueryArgs,
+)
+
+from hatchet.query.compat import (
+    AbstractQuery,
+    NaryQuery,
+    AndQuery,
+    IntersectionQuery,
+    OrQuery,
+    UnionQuery,
+    XorQuery,
+    SymDifferenceQuery,
+    NotQuery,
+    QueryMatcher,
+    CypherQuery,
+    parse_cypher_query,
+)
+
+import hatchet.query.is_hatchet_query
+
+def is_thicket_query(query_obj):
+    return hatchet.query.is_hatchet_query(query_obj)
+
+
+__all__ = [
+    "Query",
+    "ObjectQuery",
+    "StringQuery",
+    "parse_string_dialect",
+    "CompoundQuery",
+    "ConjunctionQuery",
+    "DisjunctionQuery",
+    "ExclusiveDisjunctionQuery",
+    "NegationQuery",
+    "QueryEngine",
+    "InvalidQueryPath",
+    "InvalidQueryFilter",
+    "RedundantQueryFilterWarning",
+    "BadNumberNaryQueryArgs",
+    "is_thicket_query",
+]

--- a/thicket/query.py
+++ b/thicket/query.py
@@ -37,6 +37,7 @@ from hatchet.query.compat import (
 
 import hatchet.query.is_hatchet_query
 
+
 def is_thicket_query(query_obj):
     return hatchet.query.is_hatchet_query(query_obj)
 

--- a/thicket/query.py
+++ b/thicket/query.py
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: MIT
 
+# Make flake8 ignore unused names in this file
+# flake8: noqa: F401
+
 from hatchet.query import (
     Query,
     ObjectQuery,
@@ -35,11 +38,11 @@ from hatchet.query.compat import (
     parse_cypher_query,
 )
 
-import hatchet.query.is_hatchet_query
+from hatchet.query import is_hatchet_query
 
 
 def is_thicket_query(query_obj):
-    return hatchet.query.is_hatchet_query(query_obj)
+    return is_hatchet_query(query_obj)
 
 
 __all__ = [

--- a/thicket/tests/test_query.py
+++ b/thicket/tests/test_query.py
@@ -5,8 +5,6 @@
 
 import re
 
-import hatchet as ht
-
 from thicket import Thicket
 from thicket.query import Query, QueryMatcher
 
@@ -60,7 +58,7 @@ def test_new_style_query_base(rajaperf_basecuda_xl_cali):
         )
     )
 
-    check_query(th, hnids, query)
+    check_query(th, hnids, query, multi_index_mode="off")
 
 
 def test_new_style_query_object(rajaperf_basecuda_xl_cali):
@@ -102,4 +100,4 @@ def test_old_style_query(rajaperf_basecuda_xl_cali):
         )
     )
 
-    check_query(th, hnids, query)
+    check_query(th, hnids, query, multi_index_mode="off")

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1094,7 +1094,9 @@ class Thicket(GraphFrame):
             "Invalid function: thicket.filter(), please use thicket.filter_metadata() or thicket.filter_stats()"
         )
 
-    def query(self, query_obj, squash=True, update_inc_cols=True, multi_index_mode="all"):
+    def query(
+        self, query_obj, squash=True, update_inc_cols=True, multi_index_mode="all"
+    ):
         """Apply a Hatchet query to the Thicket object.
 
         Arguments:
@@ -1116,7 +1118,9 @@ class Thicket(GraphFrame):
             raise TypeError(
                 "Input to 'query' must be a Hatchet query (i.e., list, str, or new- or old-style query object)"
             )
-        if multi_index_mode == "off" and (isinstance(query_obj, list) or isinstance(query_obj, str)):
+        if multi_index_mode == "off" and (
+            isinstance(query_obj, list) or isinstance(query_obj, str)
+        ):
             raise UnsupportedQuery(
                 "'Raw' object- and string-based dialect queries cannot be used when 'multi_index_mode' is set to 'off'"
             )

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1114,7 +1114,7 @@ class Thicket(GraphFrame):
         Returns:
             (Thicket): a new Thicket object containing the data that matches the query
         """
-        if not is_thicket_query(query_obj):
+        if not is_thicket_query(query_obj) or not isinstance(query_obj, (list, str)):
             raise TypeError(
                 "Input to 'query' must be a Hatchet query (i.e., list, str, or new- or old-style query object)"
             )


### PR DESCRIPTION
This PR adds support for Hatchet's new-style queries to Thicket. More specifically, this PR adds the following:
* A new `thicket.query` module that re-exports the Query Language classes and functions
* **Support for the object- and string-based dialects of the Query Language**

The dialect support is enabled through the new `multi_index_mode` parameter. This parameter is currently being documented in LLNL/hatchet#90.