### PR TITLE
Use Deterministic Hash Algorithm

### DIFF
--- a/thicket/ncu.py
+++ b/thicket/ncu.py
@@ -24,17 +24,19 @@ def add_ncu_metrics(th, ncu_report_mapping, chosen_metrics=None):
 
     # Loop through dict
     for ncu_report_file in ncu_report_mapping:
-        # Find hash value that should exist in th
+        # Find hash value that should exist in thicket profile map
         ncu_hash = None
+        
         tprof = ncu_report_mapping[ncu_report_file]
         for k, v in th.profile_mapping.items():
             for prf in v:
                 if prf == tprof:
                     ncu_hash = k
                     break
+                    
         if ncu_hash is None:
             raise ValueError(
-                f"Could not find profile {tprof} in thicket profile mapping"
+                "Could not find profile " + str(tprof) + " in thicket profile mapping"
             )
 
         # Load kernels

--- a/thicket/ncu.py
+++ b/thicket/ncu.py
@@ -26,14 +26,14 @@ def add_ncu_metrics(th, ncu_report_mapping, chosen_metrics=None):
     for ncu_report_file in ncu_report_mapping:
         # Find hash value that should exist in thicket profile map
         ncu_hash = None
-        
+
         tprof = ncu_report_mapping[ncu_report_file]
         for k, v in th.profile_mapping.items():
             for prf in v:
                 if prf == tprof:
                     ncu_hash = k
                     break
-                    
+
         if ncu_hash is None:
             raise ValueError(
                 "Could not find profile " + str(tprof) + " in thicket profile mapping"

--- a/thicket/ncu.py
+++ b/thicket/ncu.py
@@ -24,8 +24,18 @@ def add_ncu_metrics(th, ncu_report_mapping, chosen_metrics=None):
 
     # Loop through dict
     for ncu_report_file in ncu_report_mapping:
-        # Hash value that should exist in th
-        ncu_hash = hash(ncu_report_mapping[ncu_report_file])
+        # Find hash value that should exist in th
+        ncu_hash = None
+        tprof = ncu_report_mapping[ncu_report_file]
+        for k, v in th.profile_mapping.items():
+            for prf in v:
+                if prf == tprof:
+                    ncu_hash = k
+                    break
+        if ncu_hash is None:
+            raise ValueError(
+                f"Could not find profile {tprof} in thicket profile mapping"
+            )
 
         # Load kernels
         report = ncu_report.load_report(ncu_report_file)

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -140,19 +140,19 @@ class Thicket(GraphFrame):
             inc_metrics=gf.inc_metrics,
             metadata=gf.metadata,
         )
-        
+
         if th.profile is None and isinstance(prf, str):
             # Store used profiles and profile mappings using a truncated md5 hash of their string.
             # Resulting int hash will be at least hex_length digits and theoretically up to
             # ceil(log_10(16^n - 1)) digits after conversion.
-            
+
             # length of the hex string before being converted to an integer.
-            hex_length = 8  
-            
+            hex_length = 8
+
             hash_arg = int(md5(prf.encode("utf-8")).hexdigest()[:hex_length], 16)
             th.profile = [hash_arg]
             th.profile_mapping = OrderedDict({hash_arg: [prf]})
-            
+
             # format metadata as a dict of dicts
             temp_meta = {}
             temp_meta[hash_arg] = th.metadata
@@ -165,7 +165,7 @@ class Thicket(GraphFrame):
             index_names.insert(1, "profile")
             th.dataframe.reset_index(inplace=True)
             th.dataframe.set_index(index_names, inplace=True)
-            
+
         return th
 
     @staticmethod

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -143,7 +143,7 @@ class Thicket(GraphFrame):
         if th.profile is None and isinstance(prf, str):
             # Store used profiles and profile mappings using a truncated md5 hash of their string.
             # Resulting int hash will be at least hex_length digits and theoretically up to
-            # hex_length + floor(log(hex_length)) digits after conversion.
+            # ceil(log_10(16^n - 1)) digits after conversion.
             hex_length = (
                 10  # length of the hex string before being converted to an integer.
             )

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -141,8 +141,13 @@ class Thicket(GraphFrame):
             metadata=gf.metadata,
         )
         if th.profile is None and isinstance(prf, str):
-            # Store used profiles and profile mappings using a truncated md5 hash of their string
-            hash_arg = int(md5(prf.encode("utf-8")).hexdigest()[:10], 16)
+            # Store used profiles and profile mappings using a truncated md5 hash of their string.
+            # Resulting int hash will be at least hex_length digits and theoretically up to
+            # hex_length + floor(log(hex_length)) digits after conversion.
+            hex_length = (
+                10  # length of the hex string before being converted to an integer.
+            )
+            hash_arg = int(md5(prf.encode("utf-8")).hexdigest()[:hex_length], 16)
             th.profile = [hash_arg]
             th.profile_mapping = OrderedDict({hash_arg: [prf]})
             # format metadata as a dict of dicts

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -140,16 +140,19 @@ class Thicket(GraphFrame):
             inc_metrics=gf.inc_metrics,
             metadata=gf.metadata,
         )
+        
         if th.profile is None and isinstance(prf, str):
             # Store used profiles and profile mappings using a truncated md5 hash of their string.
             # Resulting int hash will be at least hex_length digits and theoretically up to
             # ceil(log_10(16^n - 1)) digits after conversion.
-            hex_length = (
-                8  # length of the hex string before being converted to an integer.
-            )
+            
+            # length of the hex string before being converted to an integer.
+            hex_length = 8  
+            
             hash_arg = int(md5(prf.encode("utf-8")).hexdigest()[:hex_length], 16)
             th.profile = [hash_arg]
             th.profile_mapping = OrderedDict({hash_arg: [prf]})
+            
             # format metadata as a dict of dicts
             temp_meta = {}
             temp_meta[hash_arg] = th.metadata
@@ -162,6 +165,7 @@ class Thicket(GraphFrame):
             index_names.insert(1, "profile")
             th.dataframe.reset_index(inplace=True)
             th.dataframe.set_index(index_names, inplace=True)
+            
         return th
 
     @staticmethod

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -145,7 +145,7 @@ class Thicket(GraphFrame):
             # Resulting int hash will be at least hex_length digits and theoretically up to
             # ceil(log_10(16^n - 1)) digits after conversion.
             hex_length = (
-                10  # length of the hex string before being converted to an integer.
+                8  # length of the hex string before being converted to an integer.
             )
             hash_arg = int(md5(prf.encode("utf-8")).hexdigest()[:hex_length], 16)
             th.profile = [hash_arg]

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -8,6 +8,7 @@ import os
 import json
 import warnings
 from collections import OrderedDict
+from hashlib import md5
 
 import pandas as pd
 import numpy as np
@@ -140,8 +141,8 @@ class Thicket(GraphFrame):
             metadata=gf.metadata,
         )
         if th.profile is None and isinstance(prf, str):
-            # Store used profiles and profile mappings using a hash of their string
-            hash_arg = hash(prf)
+            # Store used profiles and profile mappings using a truncated md5 hash of their string
+            hash_arg = int(md5(prf.encode("utf-8")).hexdigest()[:10], 16)
             th.profile = [hash_arg]
             th.profile_mapping = OrderedDict({hash_arg: [prf]})
             # format metadata as a dict of dicts


### PR DESCRIPTION
# Summary

We want deterministic profile id's in Thicket so user's analysis won't be limited due to avoiding directly referencing profile id's.

# Problem
Since Python3.3, the [`hash()`](https://docs.python.org/3/library/functions.html#hash) function is only [deterministic in the scope of a process](https://peps.python.org/pep-0456/). Between processes, hashing the same object will result in different hashes.

# Features considered:
1. Cryptographic vs. Non-cryptographic - cryptographic hashes are unnecessary in our case and only add extra time since they are designed for security purposes.
2. Standard library vs. Third party - We preferably don't want to add an extra dependency if we can avoid it.
3. Readability - Preferably we want the id's to be short (10 digits or less), and integers as compared to strings since integers work better with Pandas<2.0 (no Arrow data types).
4. Collision rate - We need negligible collision odds for up to `10^3` hashes, since that is roughly the scope of Thicket. Observations listed below are either from other sources or are from small, non-comprehensive testing.

# Algorithms considered:
1. `hashlib.md5` (Cryptographic, Std lib) - The shortest and simplest hashlib algorithm, md5 is an insecure cryptographic algorithm (which is irrelevant since we don't need security). Its full output of 128-bits has an extremely low collision-rate, but is too long to be readable in the thicket structure, so we must truncate the final result*.
   - `*`truncation greatly negatively impacts the collision rate, but since we are hashing so few strings, it's negligible in practice until generating large numbers of hashes. Also we can always increase the length in exchange for readability.
2. `xxHash.xxh32` (Non-cryptographic, Third party) - Being non-crypto and designed for this purpose, xxh32 is one of the best third-party algorithms and gets the result in the least-hacky way with it's `intdigest` function. However, it comes with all the concerns of a third party library.
3. `zlib.Adler32` (Non-cryptographic, Std lib) - Checksum function that is commonly mistaken as a [hashing algorithm](https://stackoverflow.com/a/13464812), which it isn't and therefore has a terrible collision rate.

# Decision
Between `md5` and `xxh32`, `xxh32` has a lower collision rate and is faster when `md5` is truncated to be the same resulting hash length. But both are negligible up to 10^5, and we can always truncate less of the `md5` to lower the hash-collision chance. The breaking difference is that `xxh32` depends on a third party library whereas `md5` is standard library.

## Ref
Short practical collision number comparison example when hashes are roughly forced to be around the length of 10.
```
files: 100
	orig: 0
	xxhash: 0
	md5: 0
	md5hex: 0
	adler32: 0
files: 1000
	orig: 0
	xxhash: 0
	md5: 0
	md5hex: 0
	adler32: 576
files: 10000
	orig: 0
	xxhash: 0
	md5: 0
	md5hex: 0
	adler32: 8784
files: 100000
	orig: 0
	xxhash: 0
	md5: 3
	md5hex: 1
	adler32: 97209
files: 1000000
	orig: 0
	xxhash: 13
	md5: 129
	md5hex: 110
	adler32: 994455
files: 10000000
	orig: 0
	xxhash: 2158
	md5: 13124
	md5hex: 11459
	adler32: 9990045
```
