### PR TITLE
Draft: Fill Performance DataFrame

### DIFF
--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -817,8 +817,6 @@ class Thicket(GraphFrame):
             new_df.set_index(index_names, inplace=True)
             # Sort the index
             new_df.sort_index(inplace=True)
-            # Since we are calling _insert_missing_rows on multiple thickets, this is meaningless.
-            new_df.drop(columns=["_missing_node"], inplace=True)
             return new_df
 
         # Create the unified graph


### PR DESCRIPTION
# Summary
Current behavior dictates that a profile won't show up in the PerfData if it does not exist for that node. This causes bugs when operating on profiles as the tree is always full whereas a slice of a profile may not be. This PR forces the PerfData to always have a full structure, inserting `NaN`s where applicable.