### PR TITLE
Fill Performance DataFrame

### DIFF
--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -824,6 +824,9 @@ class Thicket(GraphFrame):
                 unify_profile_mapping.update(th.profile_mapping)
             unify_df = pd.concat([th.dataframe, unify_df])
 
+        # Fill missing rows in dataframe with NaN's
+        unify_df = unify_df.reindex(pd.MultiIndex.from_product(unify_df.index.levels))
+
         # Operations specific to a superthicket
         if superthicket:
             unify_metadata.index.rename("thicket", inplace=True)

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -825,7 +825,14 @@ class Thicket(GraphFrame):
             unify_df = pd.concat([th.dataframe, unify_df])
 
         # Fill missing rows in dataframe with NaN's
-        unify_df = unify_df.reindex(pd.MultiIndex.from_product(unify_df.index.levels))
+        fill_value = np.nan
+        unify_df = unify_df.reindex(
+            pd.MultiIndex.from_product(unify_df.index.levels), fill_value=fill_value
+        )
+        # Replace NaN with None in string columns
+        for col in unify_df.columns:
+            if pd.api.types.is_string_dtype(unify_df[col].dtype):
+                unify_df[col].replace(fill_value, None, inplace=True)
 
         # Operations specific to a superthicket
         if superthicket:


### PR DESCRIPTION
# Summary
Current behavior dictates that a profile won't show up in the PerfData if it does not exist for that node. This causes bugs when operating on profiles as the tree is always full whereas a slice of a profile may not be. This PR forces the PerfData to always have a full structure, inserting `None` for string columns and `NaN`s elsewhere.