### PR TITLE
One Profile per Hash

### DIFF
--- a/thicket/model_extrap.py
+++ b/thicket/model_extrap.py
@@ -125,7 +125,7 @@ class Modeling:
                     + len(self.tht.profile)
                 )
             profile_mapping_flipped = {
-                v[0]: k for k, v in self.tht.profile_mapping.items()
+                v: k for k, v in self.tht.profile_mapping.items()
             }
             for file_name, value in params.items():
                 self.tht.metadata.at[

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -151,7 +151,7 @@ class Thicket(GraphFrame):
 
             hash_arg = int(md5(prf.encode("utf-8")).hexdigest()[:hex_length], 16)
             th.profile = [hash_arg]
-            th.profile_mapping = OrderedDict({hash_arg: [prf]})
+            th.profile_mapping = OrderedDict({hash_arg: prf})
 
             # format metadata as a dict of dicts
             temp_meta = {}


### PR DESCRIPTION
# Summary
For the original version of columnar join, multiple profiles could be matched to the same hash. The new version of columnar join with tuple keys never requires this, and as a standard we should enforce that one profile maps to one hash, as it is less confusing.