### PR TITLE
Ability to pass **kwargs to correlation_nodewise.py

### DIFF
--- a/thicket/stats/correlation_nodewise.py
+++ b/thicket/stats/correlation_nodewise.py
@@ -8,7 +8,9 @@ from scipy import stats
 from ..utils import verify_thicket_structures
 
 
-def correlation_nodewise(thicket, column1=None, column2=None, correlation="pearson"):
+def correlation_nodewise(
+    thicket, column1=None, column2=None, correlation="pearson", **kwargs
+):
     """Calculate the nodewise correlation for each node in the performance data table.
 
     Designed to take in a thicket, and append one or more columns to the aggregated
@@ -55,6 +57,7 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
                     stats.pearsonr(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
+                        **kwargs,
                     )[0]
                 )
             elif correlation == "spearman":
@@ -62,6 +65,7 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
                     stats.spearmanr(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
+                        **kwargs,
                     )[0]
                 )
             elif correlation == "kendall":
@@ -69,6 +73,7 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
                     stats.kendalltau(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
+                        **kwargs,
                     )[0]
                 )
             else:
@@ -85,6 +90,7 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
                     stats.pearsonr(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
+                        **kwargs,
                     )[0]
                 )
             elif correlation == "spearman":
@@ -92,6 +98,7 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
                     stats.spearmanr(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
+                        **kwargs,
                     )[0]
                 )
             elif correlation == "kendall":
@@ -99,6 +106,7 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
                     stats.kendalltau(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
+                        **kwargs,
                     )[0]
                 )
             else:


### PR DESCRIPTION
This PR will add the ability for a user to pass in keyword arguments to the correlation_nodewise.py. Primarily this is being done such that a user could specify how they would like to handle NaN's. Scipy has an optional argument `nan_policy` which has three options:

- "propagate": returns nan
- "omit": performs the calculations ignoring nan values
- "raise": throws an error

Therefore a user could pass `nan_policy` as a keyword argument to `correlation_nodewise()` and specify how they would like to handle if NaN's are within their data with one of the three aforementioned options. 