### PR TITLE
Improve NCU Reader

### DIFF
--- a/thicket/ncu.py
+++ b/thicket/ncu.py
@@ -33,7 +33,7 @@ class NCUReader:
                 predicate (function): predicate function
             """
             if is_regex:
-                return lambda row: row["name"].apply(lambda x: kernel in x).all()
+                return lambda row: row["name"].apply(lambda x: kernel in x if x is not None else False).all()
             else:
                 return lambda row: row["name"].apply(lambda x: x == kernel).all()
 

--- a/thicket/ncu.py
+++ b/thicket/ncu.py
@@ -110,7 +110,9 @@ class NCUReader:
                 }
 
                 # Query action in range
-                for action in tqdm(range):
+                pbar = tqdm(range)
+                for i, action in enumerate(pbar):
+                    pbar.set_description(f"Processing action {i}/{len(range)}")
                     # Name of kernel
                     kernel_name = action.name()
                     # Get NCU-side kernel trace

--- a/thicket/ncu.py
+++ b/thicket/ncu.py
@@ -98,6 +98,10 @@ class NCUReader:
                 )
             # Loop through ranges in report
             for range in report:
+                # Setup rollup dict. Same for all actions
+                first_action = range.action_by_idx(0)
+                rollup_dict = {first_action[name].name(): first_action[name].rollup_operation() for name in first_action.metric_names()}
+
                 # Query action in range
                 for action in tqdm(range):
                     # Name of kernel
@@ -140,7 +144,6 @@ class NCUReader:
                         metric_dict = {}
                         for metric in [action[name] for name in action.metric_names()]:
                             metric_dict[metric.name()] = metric.value()
-                            rollup_dict[metric.name()] = metric.rollup_operation()
                         data_dict[(matched_node, ncu_hash)].append(metric_dict)
 
         return data_dict, rollup_dict

--- a/thicket/ncu.py
+++ b/thicket/ncu.py
@@ -69,9 +69,7 @@ class NCUReader:
         # Loop through NCU files
         for ncu_report_file in ncu_report_mapping:
             # NCU hash
-            profile_mapping_flipped = {
-                v: k for k, v in thicket.profile_mapping.items()
-            }
+            profile_mapping_flipped = {v: k for k, v in thicket.profile_mapping.items()}
             ncu_hash = profile_mapping_flipped[ncu_report_mapping[ncu_report_file]]
 
             # Load file

--- a/thicket/ncu.py
+++ b/thicket/ncu.py
@@ -98,9 +98,12 @@ class NCUReader:
                 )
             # Loop through ranges in report
             for range in report:
-                # Setup rollup dict. Same for all actions
+                # Grab first action
                 first_action = range.action_by_idx(0)
-                rollup_dict = {first_action[name].name(): first_action[name].rollup_operation() for name in first_action.metric_names()}
+                # Metric names
+                metric_names = [first_action[name].name() for name in first_action.metric_names()]
+                # Setup rollup dict
+                rollup_dict = {name: first_action[name].rollup_operation() for name in metric_names}
 
                 # Query action in range
                 for action in tqdm(range):
@@ -140,10 +143,9 @@ class NCUReader:
                         # Set mapping
                         kernel_map[kernel_name] = matched_node
 
-                        # Add kernel metrics to data_dict
-                        metric_dict = {}
-                        for metric in [action[name] for name in action.metric_names()]:
-                            metric_dict[metric.name()] = metric.value()
-                        data_dict[(matched_node, ncu_hash)].append(metric_dict)
+
+                        metric_values = [action[name].value() for name in metric_names]
+                        assert len(metric_names) == len(metric_values)
+                        data_dict[(matched_node, ncu_hash)].append(dict(zip(metric_names, metric_values)))
 
         return data_dict, rollup_dict

--- a/thicket/ncu.py
+++ b/thicket/ncu.py
@@ -101,9 +101,13 @@ class NCUReader:
                 # Grab first action
                 first_action = range.action_by_idx(0)
                 # Metric names
-                metric_names = [first_action[name].name() for name in first_action.metric_names()]
+                metric_names = [
+                    first_action[name].name() for name in first_action.metric_names()
+                ]
                 # Setup rollup dict
-                rollup_dict = {name: first_action[name].rollup_operation() for name in metric_names}
+                rollup_dict = {
+                    name: first_action[name].rollup_operation() for name in metric_names
+                }
 
                 # Query action in range
                 for action in tqdm(range):
@@ -143,9 +147,10 @@ class NCUReader:
                         # Set mapping
                         kernel_map[kernel_name] = matched_node
 
-
                         metric_values = [action[name].value() for name in metric_names]
                         assert len(metric_names) == len(metric_values)
-                        data_dict[(matched_node, ncu_hash)].append(dict(zip(metric_names, metric_values)))
+                        data_dict[(matched_node, ncu_hash)].append(
+                            dict(zip(metric_names, metric_values))
+                        )
 
         return data_dict, rollup_dict

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -514,7 +514,9 @@ class Thicket(GraphFrame):
             agg_data["node"] = node_profile[0]
             agg_data["profile"] = node_profile[1]
             # Discard other rows (should be duplicates).
-            agg_data = agg_data.loc[0,]
+            agg_data = agg_data.loc[
+                0,
+            ]
             # Append to main df
             ncu_df = ncu_df.append(agg_data, ignore_index=True)
         ncu_df = ncu_df.set_index(["node", "profile"])

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -495,14 +495,10 @@ class Thicket(GraphFrame):
                 return col
 
         # Initialize reader
-        ncureader = NCUReader(
-            thicket=self,
-            ncu_report_mapping=ncu_report_mapping,
-            chosen_metrics=chosen_metrics,
-        )
+        ncureader = NCUReader()
 
         # Dictionary of NCU data
-        data_dict = ncureader._read_ncu()
+        data_dict = ncureader._read_ncu(self, ncu_report_mapping)
 
         # Create empty df
         ncu_df = pd.DataFrame()

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -489,8 +489,9 @@ class Thicket(GraphFrame):
             Arguments:
                 col (pd.Series): column of data
             """
-            if col.dtype == np.dtype("float64") or col.dtype == np.dtype("int64"):
-                return col.mean()
+            agg_func = ncureader.rollup_operations[rollup_dict[col.name]]
+            if agg_func is not None and pd.api.types.is_numeric_dtype(col):
+                return agg_func(col)
             else:
                 return col
 
@@ -498,7 +499,7 @@ class Thicket(GraphFrame):
         ncureader = NCUReader()
 
         # Dictionary of NCU data
-        data_dict = ncureader._read_ncu(self, ncu_report_mapping)
+        data_dict, rollup_dict = ncureader._read_ncu(self, ncu_report_mapping)
 
         # Create empty df
         ncu_df = pd.DataFrame()
@@ -510,9 +511,7 @@ class Thicket(GraphFrame):
             agg_data["node"] = node_profile[0]
             agg_data["profile"] = node_profile[1]
             # Discard other rows (should be duplicates).
-            agg_data = agg_data.loc[
-                0,
-            ]
+            agg_data = agg_data.loc[0,]
             # Append to main df
             ncu_df = ncu_df.append(agg_data, ignore_index=True)
         ncu_df = ncu_df.set_index(["node", "profile"])

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -489,11 +489,12 @@ class Thicket(GraphFrame):
             Arguments:
                 col (pd.Series): column of data
             """
-            agg_func = ncureader.rollup_operations[rollup_dict[col.name]]
+            rollup_operation = rollup_dict[col.name]
+            agg_func = ncureader.rollup_operations[rollup_operation]
             if agg_func is not None and pd.api.types.is_numeric_dtype(col):
                 return agg_func(col)
             else:
-                return col
+                return col[0]
 
         # Initialize reader
         ncureader = NCUReader()
@@ -510,10 +511,6 @@ class Thicket(GraphFrame):
             # Add node and profile
             agg_data["node"] = node_profile[0]
             agg_data["profile"] = node_profile[1]
-            # Discard other rows (should be duplicates).
-            agg_data = agg_data.loc[
-                0,
-            ]
             # Append to main df
             ncu_df = ncu_df.append(agg_data, ignore_index=True)
         ncu_df = ncu_df.set_index(["node", "profile"])

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -512,7 +512,7 @@ class Thicket(GraphFrame):
             agg_data["node"] = node_profile[0]
             agg_data["profile"] = node_profile[1]
             # Append to main df
-            ncu_df = ncu_df.append(agg_data, ignore_index=True)
+            ncu_df = pd.concat([ncu_df, pd.DataFrame([agg_data])], ignore_index=True)
         ncu_df = ncu_df.set_index(["node", "profile"])
 
         # Apply chosen metrics

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -19,6 +19,11 @@ from hatchet.query import AbstractQuery, QueryMatcher
 import tqdm
 
 from thicket.ensemble import Ensemble
+
+try:
+    from .ncu import NCUReader
+except ModuleNotFoundError:
+    pass
 import thicket.helpers as helpers
 from .groupby import GroupBy
 from .utils import (
@@ -469,6 +474,63 @@ class Thicket(GraphFrame):
 
         # make and return thicket?
         return th
+
+    def add_ncu(self, ncu_report_mapping, chosen_metrics=None):
+        """Add NCU data into the PerformanceDataFrame
+
+        Arguments:
+            ncu_report_mapping (dict): mapping from NCU report file to profile
+            chosen_metrics (list): list of metrics to sub-select from NCU report
+        """
+
+        def _rep_agg_func(col):
+            """Aggregate function for repition data.
+
+            Arguments:
+                col (pd.Series): column of data
+            """
+            if col.dtype == np.dtype("float64") or col.dtype == np.dtype("int64"):
+                return col.mean()
+            else:
+                return col
+
+        # Initialize reader
+        ncureader = NCUReader(
+            thicket=self,
+            ncu_report_mapping=ncu_report_mapping,
+            chosen_metrics=chosen_metrics,
+        )
+
+        # Dictionary of NCU data
+        data_dict = ncureader._read_ncu()
+
+        # Create empty df
+        ncu_df = pd.DataFrame()
+        # Loop to aggregate data across reps
+        for node_profile, rep_data in data_dict.items():
+            # Aggregate data using _rep_agg_func
+            agg_data = pd.DataFrame.from_records(rep_data).agg(_rep_agg_func)
+            # Add node and profile
+            agg_data["node"] = node_profile[0]
+            agg_data["profile"] = node_profile[1]
+            # Discard other rows (should be duplicates).
+            agg_data = agg_data.loc[0,]
+            # Append to main df
+            ncu_df = ncu_df.append(agg_data, ignore_index=True)
+        ncu_df = ncu_df.set_index(["node", "profile"])
+
+        # Apply chosen metrics
+        if chosen_metrics:
+            ncu_df = ncu_df[chosen_metrics]
+
+        # Join NCU DataFrame into Thicket
+        self.dataframe = self.dataframe.join(
+            ncu_df,
+            how="outer",
+            sort=True,
+            lsuffix="_left",
+            rsuffix="_right",
+        )
 
     def metadata_column_to_perfdata(self, metadata_key, overwrite=False, drop=False):
         """Add a column from the metadata table to the performance data table.

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -511,7 +511,9 @@ class Thicket(GraphFrame):
             agg_data["node"] = node_profile[0]
             agg_data["profile"] = node_profile[1]
             # Discard other rows (should be duplicates).
-            agg_data = agg_data.loc[0,]
+            agg_data = agg_data.loc[
+                0,
+            ]
             # Append to main df
             ncu_df = ncu_df.append(agg_data, ignore_index=True)
         ncu_df = ncu_df.set_index(["node", "profile"])


### PR DESCRIPTION
# Summary
Improve the NCU Reader.
1. Leverage nvtx push_pop_ranges call trace and Hatchet Query Language to improve node-mapping logic accuracy.
2. Add aggregation of kernel reps instead of discarding duplicate kernel runs. 4 different aggregation options available, `mean, max, min, sum`,  programmatically determined from ncu's `rollup_operation` metric function.
3. Improve interface by making NCU a thicket class function.
4. Refactor NCU into a class object.
5. Add `tqdm` to main loop in reader to provide some clarity to the user.