### PR TITLE
Fix unify_ensemble Bug

### DIFF
--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -832,7 +832,7 @@ class Thicket(GraphFrame):
         # Replace NaN with None in string columns
         for col in unify_df.columns:
             if pd.api.types.is_string_dtype(unify_df[col].dtype):
-                unify_df[col].replace(fill_value, None, inplace=True)
+                unify_df[col].replace({fill_value: None}, inplace=True)
 
         # Operations specific to a superthicket
         if superthicket:


### PR DESCRIPTION
# Summary
The change added in #57 introduces weird behavior in `python3.7` & `pandas1.3.5`. This is due to passing `None` as the literal argument desired in the replace function, but that is also the default argument. Changing this to a mapping fixes the issue.