### PR TITLE
Sort PerfData Index After columnar_join

### DIFF
--- a/thicket/tests/test_columnar_join.py
+++ b/thicket/tests/test_columnar_join.py
@@ -5,9 +5,9 @@
 
 import re
 
+import hatchet as ht
 import pandas as pd
 
-import hatchet as ht
 from test_filter_metadata import filter_one_column
 from test_filter_metadata import filter_multiple_and
 from test_filter_stats import check_filter_stats

--- a/thicket/tests/test_columnar_join.py
+++ b/thicket/tests/test_columnar_join.py
@@ -5,8 +5,9 @@
 
 import re
 
-import hatchet as ht
+import pandas as pd
 
+import hatchet as ht
 from test_filter_metadata import filter_one_column
 from test_filter_metadata import filter_multiple_and
 from test_filter_stats import check_filter_stats
@@ -46,6 +47,11 @@ def test_columnar_join(columnar_join_thicket):
     assert len(combined_th.profile_mapping) == sum(
         [len(th.profile_mapping) for th in thicket_list]
     )
+
+    # PerfData and StatsFrame nodes should be in the same order.
+    assert (pd.unique(combined_th.dataframe.reset_index()["node"].tolist()) == pd.unique(
+        combined_th.statsframe.dataframe.reset_index()["node"].tolist())
+    ).all()
 
 
 def test_filter_columnar_join(columnar_join_thicket):

--- a/thicket/tests/test_columnar_join.py
+++ b/thicket/tests/test_columnar_join.py
@@ -49,8 +49,9 @@ def test_columnar_join(columnar_join_thicket):
     )
 
     # PerfData and StatsFrame nodes should be in the same order.
-    assert (pd.unique(combined_th.dataframe.reset_index()["node"].tolist()) == pd.unique(
-        combined_th.statsframe.dataframe.reset_index()["node"].tolist())
+    assert (
+        pd.unique(combined_th.dataframe.reset_index()["node"].tolist())
+        == pd.unique(combined_th.statsframe.dataframe.reset_index()["node"].tolist())
     ).all()
 
 

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -469,6 +469,9 @@ class Thicket(GraphFrame):
             inplace=True,
         )
 
+        # Sort DataFrame
+        combined_th.dataframe.sort_index(inplace=True)
+
         ###
         # Step 3: Join "self" & "other" metadata table
         ###


### PR DESCRIPTION
# Summary
We expect the nodes in the PerfData and StatsFrame to be in the same order.