### PR TITLE
StatsFrame Name Bugfix Level

### DIFF
--- a/thicket/helpers.py
+++ b/thicket/helpers.py
@@ -86,7 +86,7 @@ def _new_statsframe_df(df, multiindex=False):
 
     # Create MultiIndex structure if necessary.
     if multiindex:
-        new_df.columns = pd.MultiIndex.from_tuples([("", "name")])
+        new_df.columns = pd.MultiIndex.from_tuples([("name", "")])
 
     return new_df
 

--- a/thicket/tests/test_thicket.py
+++ b/thicket/tests/test_thicket.py
@@ -71,7 +71,18 @@ def test_sync_nodes(example_cali):
     assert helpers._are_synced(th.graph, th.dataframe)
 
 
-def test_aggregated_statistics_table(example_cali):
+def test_statsframe(example_cali):
+
+    def _test_multiindex():
+        th1 = Thicket.from_caliperreader(example_cali[0])
+        th2 = Thicket.from_caliperreader(example_cali[1])
+        th_cj = Thicket.columnar_join([th1, th2])
+
+        # Check column format
+        assert ("name", "") in th_cj.statsframe.dataframe.columns
+
+    _test_multiindex()
+
     th = Thicket.from_caliperreader(example_cali[-1])
 
     # Arbitrary value insertion in aggregated statistics table.

--- a/thicket/tests/test_thicket.py
+++ b/thicket/tests/test_thicket.py
@@ -74,6 +74,7 @@ def test_sync_nodes(example_cali):
 def test_statsframe(example_cali):
 
     def _test_multiindex():
+        """Test statsframe when headers are multiindexed."""
         th1 = Thicket.from_caliperreader(example_cali[0])
         th2 = Thicket.from_caliperreader(example_cali[1])
         th_cj = Thicket.columnar_join([th1, th2])

--- a/thicket/tests/test_thicket.py
+++ b/thicket/tests/test_thicket.py
@@ -72,7 +72,6 @@ def test_sync_nodes(example_cali):
 
 
 def test_statsframe(example_cali):
-
     def _test_multiindex():
         """Test statsframe when headers are multiindexed."""
         th1 = Thicket.from_caliperreader(example_cali[0])


### PR DESCRIPTION
# Summary
When the statsframe columns are multiindex, the name column should reside at the same level as in the PerfData.