### PR TITLE
Relax Verify Thicket Structure Check for Stats Functions

### DIFF
--- a/thicket/stats/calc_boxplot_statistics.py
+++ b/thicket/stats/calc_boxplot_statistics.py
@@ -9,7 +9,7 @@ import numpy as np
 from ..utils import verify_thicket_structures
 
 
-def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **kwargs):
+def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75]):
     """Calculate boxplots lowerfence, q1, q2, q3, iqr, upperfence, and outliers for each
     node in the performance data table.
 
@@ -54,7 +54,7 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 values = thicket.dataframe.loc[node][col].tolist()
 
-                q = np.quantile(values, quartiles, **kwargs)
+                q = np.quantile(values, quartiles)
                 q1 = q[0]
                 median = q[1]
                 q3 = q[2]
@@ -110,7 +110,7 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 values = thicket.dataframe.loc[node][(idx, col)].tolist()
 
-                q = np.quantile(values, quartiles, **kwargs)
+                q = np.quantile(values, quartiles)
                 q1 = q[0]
                 median = q[1]
                 q3 = q[2]

--- a/thicket/stats/calc_boxplot_statistics.py
+++ b/thicket/stats/calc_boxplot_statistics.py
@@ -34,9 +34,7 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
             "To see a list of valid columns, please run Thicket.get_perf_columns()."
         )
 
-    verify_thicket_structures(
-        thicket.dataframe, index=["node", "profile"], columns=columns
-    )
+    verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)
 
     q_list = str(tuple(quartiles))
 
@@ -56,7 +54,7 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 values = thicket.dataframe.loc[node][col].tolist()
 
-                q = np.quantile(values, quartiles)
+                q = np.quantile(values, quartiles, **kwargs)
                 q1 = q[0]
                 median = q[1]
                 q3 = q[2]
@@ -112,7 +110,7 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 values = thicket.dataframe.loc[node][(idx, col)].tolist()
 
-                q = np.quantile(values, quartiles)
+                q = np.quantile(values, quartiles, **kwargs)
                 q1 = q[0]
                 median = q[1]
                 q3 = q[2]

--- a/thicket/stats/calc_boxplot_statistics.py
+++ b/thicket/stats/calc_boxplot_statistics.py
@@ -9,7 +9,7 @@ import numpy as np
 from ..utils import verify_thicket_structures
 
 
-def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75]):
+def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **kwargs):
     """Calculate boxplots lowerfence, q1, q2, q3, iqr, upperfence, and outliers for each
     node in the performance data table.
 

--- a/thicket/stats/check_normality.py
+++ b/thicket/stats/check_normality.py
@@ -31,9 +31,7 @@ def check_normality(thicket, columns=None):
             "To see a list of valid columns, please run Thicket.get_perf_columns()."
         )
 
-    verify_thicket_structures(
-        thicket.dataframe, index=["node", "profile"], columns=columns
-    )
+    verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:

--- a/thicket/stats/correlation_nodewise.py
+++ b/thicket/stats/correlation_nodewise.py
@@ -8,9 +8,7 @@ from scipy import stats
 from ..utils import verify_thicket_structures
 
 
-def correlation_nodewise(
-    thicket, column1=None, column2=None, correlation="pearson", **kwargs
-):
+def correlation_nodewise(thicket, column1=None, column2=None, correlation="pearson"):
     """Calculate the nodewise correlation for each node in the performance data table.
 
     Designed to take in a thicket, and append one or more columns to the aggregated
@@ -47,7 +45,6 @@ def correlation_nodewise(
                     stats.pearsonr(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
-                        **kwargs,
                     )[0]
                 )
             elif correlation == "spearman":
@@ -55,7 +52,6 @@ def correlation_nodewise(
                     stats.spearmanr(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
-                        **kwargs,
                     )[0]
                 )
             elif correlation == "kendall":
@@ -63,7 +59,6 @@ def correlation_nodewise(
                     stats.kendalltau(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
-                        **kwargs,
                     )[0]
                 )
             else:
@@ -82,7 +77,6 @@ def correlation_nodewise(
                     stats.pearsonr(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
-                        **kwargs,
                     )[0]
                 )
             elif correlation == "spearman":
@@ -90,7 +84,6 @@ def correlation_nodewise(
                     stats.spearmanr(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
-                        **kwargs,
                     )[0]
                 )
             elif correlation == "kendall":
@@ -98,7 +91,6 @@ def correlation_nodewise(
                     stats.kendalltau(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
-                        **kwargs,
                     )[0]
                 )
             else:

--- a/thicket/stats/correlation_nodewise.py
+++ b/thicket/stats/correlation_nodewise.py
@@ -8,7 +8,9 @@ from scipy import stats
 from ..utils import verify_thicket_structures
 
 
-def correlation_nodewise(thicket, column1=None, column2=None, correlation="pearson"):
+def correlation_nodewise(
+    thicket, column1=None, column2=None, correlation="pearson", **kwargs
+):
     """Calculate the nodewise correlation for each node in the performance data table.
 
     Designed to take in a thicket, and append one or more columns to the aggregated
@@ -33,19 +35,9 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
             "To see a list of valid columns, please run Thicket.get_perf_columns()."
         )
 
-    if "profile" in thicket.dataframe.index.names:
-        verify_thicket_structures(
-            thicket.dataframe,
-            index=["node", "profile"],
-            columns=[column1, column2],
-        )
-    else:
-        verify_thicket_structures(
-            thicket.dataframe,
-            index=["node", "thicket"],
-            columns=[column1, column2],
-        )
-
+    verify_thicket_structures(
+        thicket.dataframe, index=["node"], columns=[column1, column2]
+    )
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
         correlated = []
@@ -55,6 +47,7 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
                     stats.pearsonr(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
+                        **kwargs,
                     )[0]
                 )
             elif correlation == "spearman":
@@ -62,6 +55,7 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
                     stats.spearmanr(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
+                        **kwargs,
                     )[0]
                 )
             elif correlation == "kendall":
@@ -69,10 +63,13 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
                     stats.kendalltau(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
+                        **kwargs,
                     )[0]
                 )
             else:
-                raise ValueError("Invalid correlation")
+                raise ValueError(
+                    "Invalid correlation, options are pearson, spearman, and kendall."
+                )
         thicket.statsframe.dataframe[
             column1 + "_vs_" + column2 + " " + correlation
         ] = correlated
@@ -85,6 +82,7 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
                     stats.pearsonr(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
+                        **kwargs,
                     )[0]
                 )
             elif correlation == "spearman":
@@ -92,6 +90,7 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
                     stats.spearmanr(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
+                        **kwargs,
                     )[0]
                 )
             elif correlation == "kendall":
@@ -99,6 +98,7 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
                     stats.kendalltau(
                         thicket.dataframe.loc[node][column1],
                         thicket.dataframe.loc[node][column2],
+                        **kwargs,
                     )[0]
                 )
             else:

--- a/thicket/stats/display_boxplot.py
+++ b/thicket/stats/display_boxplot.py
@@ -33,9 +33,7 @@ def display_boxplot(thicket, nodes=[], columns=[], **kwargs):
                 "Value(s) passed to node argument must be of type hatchet.node.Node."
             )
 
-    verify_thicket_structures(
-        thicket.dataframe, index=["node", "profile"], columns=columns
-    )
+    verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:

--- a/thicket/stats/display_histogram.py
+++ b/thicket/stats/display_histogram.py
@@ -34,9 +34,7 @@ def display_histogram(thicket, node=None, column=None, **kwargs):
             "Value passed to node argument must be of type hatchet.node.Node."
         )
 
-    verify_thicket_structures(
-        thicket.dataframe, index=["node", "profile"], columns=[column]
-    )
+    verify_thicket_structures(thicket.dataframe, index=["node"], columns=[column])
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:

--- a/thicket/stats/maximum.py
+++ b/thicket/stats/maximum.py
@@ -27,9 +27,7 @@ def maximum(thicket, columns=None):
             "To see a list of valid columns, please run Thicket.get_perf_columns()."
         )
 
-    verify_thicket_structures(
-        thicket.dataframe, index=["node", "profile"], columns=columns
-    )
+    verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:

--- a/thicket/stats/mean.py
+++ b/thicket/stats/mean.py
@@ -9,7 +9,7 @@ import pandas as pd
 from ..utils import verify_thicket_structures
 
 
-def mean(thicket, columns=None):
+def mean(thicket, columns=None, **kwargs):
     """Calculate the mean for each node in the performance data table.
 
     Designed to take in a thicket, and append one or more columns to the
@@ -26,16 +26,14 @@ def mean(thicket, columns=None):
             "To see a list of valid columns, please run Thicket.get_perf_columns()."
         )
 
-    verify_thicket_structures(
-        thicket.dataframe, index=["node", "profile"], columns=columns
-    )
+    verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             mean = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                mean.append(np.mean(thicket.dataframe.loc[node][column]))
+                mean.append(np.mean(thicket.dataframe.loc[node][column], **kwargs))
             # check to see if exclusive metric
             if column in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append(column + "_mean")
@@ -49,7 +47,9 @@ def mean(thicket, columns=None):
         for idx, column in columns:
             mean = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                mean.append(np.mean(thicket.dataframe.loc[node][(idx, column)]))
+                mean.append(
+                    np.mean(thicket.dataframe.loc[node][(idx, column)], **kwargs)
+                )
             # check to see if exclusive metric
             if (idx, column) in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append((idx, column + "_mean"))

--- a/thicket/stats/mean.py
+++ b/thicket/stats/mean.py
@@ -9,7 +9,7 @@ import pandas as pd
 from ..utils import verify_thicket_structures
 
 
-def mean(thicket, columns=None, **kwargs):
+def mean(thicket, columns=None):
     """Calculate the mean for each node in the performance data table.
 
     Designed to take in a thicket, and append one or more columns to the
@@ -33,7 +33,7 @@ def mean(thicket, columns=None, **kwargs):
         for column in columns:
             mean = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                mean.append(np.mean(thicket.dataframe.loc[node][column], **kwargs))
+                mean.append(np.mean(thicket.dataframe.loc[node][column]))
             # check to see if exclusive metric
             if column in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append(column + "_mean")
@@ -48,7 +48,7 @@ def mean(thicket, columns=None, **kwargs):
             mean = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 mean.append(
-                    np.mean(thicket.dataframe.loc[node][(idx, column)], **kwargs)
+                    np.mean(thicket.dataframe.loc[node][(idx, column)])
                 )
             # check to see if exclusive metric
             if (idx, column) in thicket.exc_metrics:

--- a/thicket/stats/mean.py
+++ b/thicket/stats/mean.py
@@ -47,9 +47,7 @@ def mean(thicket, columns=None):
         for idx, column in columns:
             mean = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                mean.append(
-                    np.mean(thicket.dataframe.loc[node][(idx, column)])
-                )
+                mean.append(np.mean(thicket.dataframe.loc[node][(idx, column)]))
             # check to see if exclusive metric
             if (idx, column) in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append((idx, column + "_mean"))

--- a/thicket/stats/median.py
+++ b/thicket/stats/median.py
@@ -26,9 +26,7 @@ def median(thicket, columns=None):
             "To see a list of valid columns, please run Thicket.get_perf_columns()."
         )
 
-    verify_thicket_structures(
-        thicket.dataframe, index=["node", "profile"], columns=columns
-    )
+    verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:

--- a/thicket/stats/minimum.py
+++ b/thicket/stats/minimum.py
@@ -27,9 +27,7 @@ def minimum(thicket, columns=None):
             "To see a list of valid columns, please run Thicket.get_perf_columns()."
         )
 
-    verify_thicket_structures(
-        thicket.dataframe, index=["node", "profile"], columns=columns
-    )
+    verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:

--- a/thicket/stats/percentiles.py
+++ b/thicket/stats/percentiles.py
@@ -60,7 +60,8 @@ def percentiles(thicket, columns=None):
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 percentiles.append(
                     np.percentile(
-                        thicket.dataframe.loc[node][(idx, column)],[25, 50, 75],
+                        thicket.dataframe.loc[node][(idx, column)],
+                        [25, 50, 75],
                     )
                 )
             # check to see if exclusive metric

--- a/thicket/stats/percentiles.py
+++ b/thicket/stats/percentiles.py
@@ -9,7 +9,7 @@ import pandas as pd
 from ..utils import verify_thicket_structures
 
 
-def percentiles(thicket, columns=None, **kwargs):
+def percentiles(thicket, columns=None):
     """Calculate the q-th percentile for each node in the performance data table.
 
     Designed to take in a thicket, and append one or more columns to the aggregated
@@ -43,9 +43,7 @@ def percentiles(thicket, columns=None, **kwargs):
             percentiles = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 percentiles.append(
-                    np.percentile(
-                        thicket.dataframe.loc[node][column], [25, 50, 75], **kwargs
-                    )
+                    np.percentile(thicket.dataframe.loc[node][column], [25, 50, 75])
                 )
             # check to see if exclusive metric
             if column in thicket.exc_metrics:
@@ -62,9 +60,7 @@ def percentiles(thicket, columns=None, **kwargs):
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 percentiles.append(
                     np.percentile(
-                        thicket.dataframe.loc[node][(idx, column)],
-                        [25, 50, 75],
-                        **kwargs,
+                        thicket.dataframe.loc[node][(idx, column)],[25, 50, 75],
                     )
                 )
             # check to see if exclusive metric

--- a/thicket/stats/percentiles.py
+++ b/thicket/stats/percentiles.py
@@ -9,7 +9,7 @@ import pandas as pd
 from ..utils import verify_thicket_structures
 
 
-def percentiles(thicket, columns=None):
+def percentiles(thicket, columns=None, **kwargs):
     """Calculate the q-th percentile for each node in the performance data table.
 
     Designed to take in a thicket, and append one or more columns to the aggregated
@@ -35,9 +35,7 @@ def percentiles(thicket, columns=None):
             "To see a list of valid columns, please run Thicket.get_perf_columns()."
         )
 
-    verify_thicket_structures(
-        thicket.dataframe, index=["node", "profile"], columns=columns
-    )
+    verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
@@ -45,7 +43,9 @@ def percentiles(thicket, columns=None):
             percentiles = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 percentiles.append(
-                    np.percentile(thicket.dataframe.loc[node][column], [25, 50, 75])
+                    np.percentile(
+                        thicket.dataframe.loc[node][column], [25, 50, 75], **kwargs
+                    )
                 )
             # check to see if exclusive metric
             if column in thicket.exc_metrics:
@@ -62,7 +62,9 @@ def percentiles(thicket, columns=None):
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
                 percentiles.append(
                     np.percentile(
-                        thicket.dataframe.loc[node][(idx, column)], [25, 50, 75]
+                        thicket.dataframe.loc[node][(idx, column)],
+                        [25, 50, 75],
+                        **kwargs,
                     )
                 )
             # check to see if exclusive metric

--- a/thicket/stats/std.py
+++ b/thicket/stats/std.py
@@ -9,7 +9,7 @@ import pandas as pd
 from ..utils import verify_thicket_structures
 
 
-def std(thicket, columns=None):
+def std(thicket, columns=None, **kwargs):
     """Calculate the standard deviation for each node in the performance data table.
 
     Designed to take in a thicket, and append one or more columns to the aggregated
@@ -28,16 +28,14 @@ def std(thicket, columns=None):
             "To see a list of valid columns, please run Thicket.get_perf_columns()."
         )
 
-    verify_thicket_structures(
-        thicket.dataframe, index=["node", "profile"], columns=columns
-    )
+    verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             std = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                std.append(np.std(thicket.dataframe.loc[node][column]))
+                std.append(np.std(thicket.dataframe.loc[node][column], **kwargs))
             # check to see if exclusive metric
             if column in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append(column + "_std")
@@ -51,7 +49,7 @@ def std(thicket, columns=None):
         for idx, column in columns:
             std = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                std.append(np.std(thicket.dataframe.loc[node][(idx, column)]))
+                std.append(np.std(thicket.dataframe.loc[node][(idx, column)], **kwargs))
             # check to see if exclusive metric
             if (idx, column) in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append((idx, column + "_std"))

--- a/thicket/stats/std.py
+++ b/thicket/stats/std.py
@@ -9,7 +9,7 @@ import pandas as pd
 from ..utils import verify_thicket_structures
 
 
-def std(thicket, columns=None, **kwargs):
+def std(thicket, columns=None):
     """Calculate the standard deviation for each node in the performance data table.
 
     Designed to take in a thicket, and append one or more columns to the aggregated
@@ -35,7 +35,7 @@ def std(thicket, columns=None, **kwargs):
         for column in columns:
             std = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                std.append(np.std(thicket.dataframe.loc[node][column], **kwargs))
+                std.append(np.std(thicket.dataframe.loc[node][column]))
             # check to see if exclusive metric
             if column in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append(column + "_std")
@@ -49,7 +49,7 @@ def std(thicket, columns=None, **kwargs):
         for idx, column in columns:
             std = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                std.append(np.std(thicket.dataframe.loc[node][(idx, column)], **kwargs))
+                std.append(np.std(thicket.dataframe.loc[node][(idx, column)]))
             # check to see if exclusive metric
             if (idx, column) in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append((idx, column + "_std"))

--- a/thicket/stats/variance.py
+++ b/thicket/stats/variance.py
@@ -9,7 +9,7 @@ import pandas as pd
 from ..utils import verify_thicket_structures
 
 
-def variance(thicket, columns=None, **kwargs):
+def variance(thicket, columns=None):
     """Calculate the variance for each node in the performance data table.
 
     Designed to take in a thicket, and append one or more columns to the aggregated
@@ -36,7 +36,7 @@ def variance(thicket, columns=None, **kwargs):
         for column in columns:
             var = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                var.append(np.var(thicket.dataframe.loc[node][column], **kwargs))
+                var.append(np.var(thicket.dataframe.loc[node][column]))
             # check to see if exclusive metric
             if column in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append(column + "_var")
@@ -50,7 +50,7 @@ def variance(thicket, columns=None, **kwargs):
         for idx, column in columns:
             var = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                var.append(np.var(thicket.dataframe.loc[node][(idx, column)], **kwargs))
+                var.append(np.var(thicket.dataframe.loc[node][(idx, column)]))
             # check to see if exclusive metric
             if (idx, column) in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append((idx, column + "_var"))

--- a/thicket/stats/variance.py
+++ b/thicket/stats/variance.py
@@ -9,7 +9,7 @@ import pandas as pd
 from ..utils import verify_thicket_structures
 
 
-def variance(thicket, columns=None):
+def variance(thicket, columns=None, **kwargs):
     """Calculate the variance for each node in the performance data table.
 
     Designed to take in a thicket, and append one or more columns to the aggregated
@@ -29,16 +29,14 @@ def variance(thicket, columns=None):
             "To see a list of valid columns, please run Thicket.get_perf_columns()."
         )
 
-    verify_thicket_structures(
-        thicket.dataframe, index=["node", "profile"], columns=columns
-    )
+    verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
         for column in columns:
             var = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                var.append(np.var(thicket.dataframe.loc[node][column]))
+                var.append(np.var(thicket.dataframe.loc[node][column], **kwargs))
             # check to see if exclusive metric
             if column in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append(column + "_var")
@@ -52,7 +50,7 @@ def variance(thicket, columns=None):
         for idx, column in columns:
             var = []
             for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                var.append(np.var(thicket.dataframe.loc[node][(idx, column)]))
+                var.append(np.var(thicket.dataframe.loc[node][(idx, column)], **kwargs))
             # check to see if exclusive metric
             if (idx, column) in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append((idx, column + "_var"))


### PR DESCRIPTION
This PR contains a single change which will be outlined below. 

1. Update to `verify_thicket_structure` check within stats functions
    - Removed `profile` from the list of indexes to check for, this allows users to join on any metadata column they would like now.