### PR TITLE
Removing .set_title() from initial sns.heatmap call in display_heatmap.py

### DIFF
--- a/thicket/stats/display_heatmap.py
+++ b/thicket/stats/display_heatmap.py
@@ -50,8 +50,8 @@ def display_heatmap(thicket, columns=None, **kwargs):
             else:
                 cols.append(columns[i][1])
 
-        ax = sns.heatmap(
-            thicket.statsframe.dataframe[initial_idx][cols], **kwargs
-        ).set_title(initial_idx)
+        ax = sns.heatmap(thicket.statsframe.dataframe[initial_idx][cols], **kwargs)
+
+        ax.set_title(initial_idx)
 
         return ax


### PR DESCRIPTION
Within the columnar index section of code, it was discussed previously to add a title automatically to the generated plot to distinguish what column index you were using to create the heatmap. 

The original implementation for this was: `sns.heatmap(thicket, columns, **kwargs).set_title('Title')`. However, the issue with this implementation is that instead of returning axes that a user could change, it would return text and would not allow a user any way to change the plot. 

The new implementation is the following: 
```
ax = sns.heatmap(thicket, columns, **kwargs)
ax.set_title('Title')
return ax
```

This will still allow the functionality of setting the title, but also allow a user to change x and y ticks/labels.