### PR TITLE
Thicket-specific tree renderer

### DIFF
--- a/thicket/external/console.py
+++ b/thicket/external/console.py
@@ -1,0 +1,233 @@
+import warnings
+
+import numpy as np
+import pandas as pd
+from hatchet.external.console import ConsoleRenderer
+from hatchet.util.colormaps import ColorMaps
+
+from ..version import __version__
+
+
+class ThicketRenderer(ConsoleRenderer):
+    # pylint: disable=W1401
+    def render_preamble(self):
+        lines = [
+            r"  _____ _     _      _        _   ",
+            r" |_   _| |__ (_) ___| | _____| |_ ",
+            r"   | | | '_ \| |/ __| |/ / _ \ __|",
+            r"   | | | | | | | (__|   <  __/ |_ ",
+            r"   |_| |_| |_|_|\___|_|\_\___|\__|  {:>2}".format("v" + __version__),
+            r"",
+            r"",
+        ]
+
+        return "\n".join(lines)
+
+    def render(self, roots, dataframe, **kwargs):
+        self.render_header = kwargs["render_header"]
+
+        if self.render_header:
+            result = self.render_preamble()
+        else:
+            result = ""
+
+        if roots is None:
+            result += "The graph is empty.\n\n"
+            return result
+
+        self.metric_columns = kwargs["metric_column"]
+        self.annotation_column = kwargs["annotation_column"]
+        self.precision = kwargs["precision"]
+        self.name = kwargs["name_column"]
+        self.expand = kwargs["expand_name"]
+        self.context = kwargs["context_column"]
+        self.rank = kwargs["rank"]
+        self.thread = kwargs["thread"]
+        self.depth = kwargs["depth"]
+        self.highlight = kwargs["highlight_name"]
+        self.colormap = kwargs["colormap"]
+        self.invert_colormap = kwargs["invert_colormap"]
+        self.colormap_annotations = kwargs["colormap_annotations"]
+        self.min_value = kwargs["min_value"]
+        self.max_value = kwargs["max_value"]
+
+        if self.color:
+            self.colors = self.colors_enabled
+            # set the colormap based on user input
+            self.colors.colormap = ColorMaps().get_colors(
+                self.colormap, self.invert_colormap
+            )
+
+            if self.annotation_column and self.colormap_annotations:
+                self.colors_annotations = self.colors_enabled()
+                if isinstance(self.colormap_annotations, (str, list)):
+                    if isinstance(self.colormap_annotations, str):
+                        self.colors_annotations.colormap = ColorMaps().get_colors(
+                            self.colormap_annotations, False
+                        )
+                    elif isinstance(self.colormap_annotations, list):
+                        self.colors_annotations.colormap = self.colormap_annotations
+                    self.colors_annotations_mapping = sorted(
+                        list(dataframe[self.annotation_column].apply(str).unique())
+                    )
+                elif isinstance(self.colormap_annotations, dict):
+                    self.colors_annotations_mapping = self.colormap_annotations
+        else:
+            self.colors = self.colors_disabled
+
+        if isinstance(self.metric_columns, (str, tuple)):
+            self.primary_metric = self.metric_columns
+            self.second_metric = None
+        elif isinstance(self.metric_columns, list):
+            if len(self.metric_columns) > 2:
+                warnings.warn(
+                    "More than 2 metrics specified in metric_column=. Tree() will only show 2 metrics at a time. The remaining metrics will not be shown.",
+                    SyntaxWarning,
+                )
+                self.primary_metric = self.metric_columns[0]
+                self.second_metric = self.metric_columns[1]
+            elif len(self.metric_columns) == 2:
+                self.primary_metric = self.metric_columns[0]
+                self.second_metric = self.metric_columns[1]
+            elif len(self.metric_columns) == 1:
+                self.primary_metric = self.metric_columns[0]
+                self.second_metric = None
+
+        if self.primary_metric not in dataframe.columns:
+            raise KeyError(
+                "metric_column={} does not exist in the dataframe, please select a valid column. See a list of the available metrics with GraphFrame.show_metric_columns().".format(
+                    self.primary_metric
+                )
+            )
+        if (
+            self.second_metric is not None
+            and self.second_metric not in dataframe.columns
+        ):
+            raise KeyError(
+                "metric_column={} does not exist in the dataframe, please select a valid column. See a list of the available metrics with GraphFrame.show_metric_columns().".format(
+                    self.second_metric
+                )
+            )
+
+        # grab the min and max value for the primary metric, ignoring inf and
+        # nan values
+
+        if "rank" in dataframe.index.names:
+            metric_series = (dataframe.xs(self.rank, level=1))[self.primary_metric]
+        else:
+            metric_series = dataframe[self.primary_metric]
+        isfinite_mask = np.isfinite(metric_series.values)
+        filtered_series = pd.Series(
+            metric_series.values[isfinite_mask], metric_series.index[isfinite_mask]
+        )
+
+        self.max_metric = self.max_value if self.max_value else filtered_series.max()
+        self.min_metric = self.min_value if self.min_value else filtered_series.min()
+
+        if self.unicode:
+            self.lr_arrows = {"◀": "◀ ", "▶": "▶ "}
+        else:
+            self.lr_arrows = {"◀": "< ", "▶": "> "}
+
+        for root in sorted(roots, key=lambda n: n.frame):
+            result += self.render_frame(root, dataframe)
+
+        if self.color is True:
+            result += self.render_legend()
+
+        if self.unicode:
+            return result
+        else:
+            return result.encode("utf-8")
+
+    def render_frame(self, node, dataframe, indent="", child_indent=""):
+        node_depth = node._depth
+        if node_depth < self.depth:
+            df_index = node
+            node_metric = dataframe.loc[df_index, self.primary_metric]
+
+            metric_precision = "{:." + str(self.precision) + "f}"
+            metric_str = (
+                self._ansi_color_for_metric(node_metric)
+                + metric_precision.format(node_metric)
+                + self.colors.end
+            )
+
+            if self.second_metric is not None:
+                metric_str += " {c.faint}{second_metric:.{precision}f}{c.end}".format(
+                    second_metric=dataframe.loc[df_index, self.second_metric],
+                    precision=self.precision,
+                    c=self.colors,
+                )
+
+            if self.annotation_column is not None:
+                annotation_content = str(
+                    dataframe.loc[df_index, self.annotation_column]
+                )
+                if self.colormap_annotations:
+                    if isinstance(self.colormap_annotations, dict):
+                        color_annotation = self.colors_annotations_mapping[
+                            annotation_content
+                        ]
+                    else:
+                        color_annotation = self.colors_annotations.colormap[
+                            self.colors_annotations_mapping.index(annotation_content)
+                            % len(self.colors_annotations.colormap)
+                        ]
+                    metric_str += " [{}".format(color_annotation)
+                    metric_str += "{}".format(annotation_content)
+                    metric_str += "{}]".format(self.colors_annotations.end)
+                else:
+                    metric_str += " [{}]".format(annotation_content)
+
+            if isinstance(dataframe.columns, pd.MultiIndex):
+                node_name = dataframe.loc[df_index, (self.name, "")]
+            else:
+                node_name = dataframe.loc[df_index, self.name]
+            if self.expand is False:
+                if len(node_name) > 39:
+                    node_name = (
+                        node_name[:18] + "..." + node_name[(len(node_name) - 18) :]
+                    )
+            name_str = (
+                self._ansi_color_for_name(node_name) + node_name + self.colors.end
+            )
+
+            result = "{indent}{metric_str} {name_str}".format(
+                indent=indent, metric_str=metric_str, name_str=name_str
+            )
+            if self.context in dataframe.columns:
+                result += " {c.faint}{context}{c.end}\n".format(
+                    context=dataframe.loc[df_index, self.context], c=self.colors
+                )
+            else:
+                result += "\n"
+
+            if self.unicode:
+                indents = {"├": "├─ ", "│": "│  ", "└": "└─ ", " ": "   "}
+            else:
+                indents = {"├": "|- ", "│": "|  ", "└": "`- ", " ": "   "}
+
+            # ensures that we never revisit nodes in the case of
+            # large complex graphs
+            if node not in self.visited:
+                self.visited.append(node)
+                sorted_children = sorted(node.children, key=lambda n: n.frame)
+                if sorted_children:
+                    last_child = sorted_children[-1]
+
+                for child in sorted_children:
+                    if child is not last_child:
+                        c_indent = child_indent + indents["├"]
+                        cc_indent = child_indent + indents["│"]
+                    else:
+                        c_indent = child_indent + indents["└"]
+                        cc_indent = child_indent + indents[" "]
+                    result += self.render_frame(
+                        child, dataframe, indent=c_indent, child_indent=cc_indent
+                    )
+        else:
+            result = ""
+            indents = {"├": "", "│": "", "└": "", " ": ""}
+
+        return result

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -689,7 +689,7 @@ class Thicket(GraphFrame):
         max_value=None,
     ):
         """Visualize the Thicket as a tree
-        
+
         Arguments:
             metric_column (str, tuple, list, optional): Columns to use the metrics from. Defaults to None.
             annotation_column (str, optional): Column to use as an annotation. Defaults to None.
@@ -707,7 +707,7 @@ class Thicket(GraphFrame):
             render_header (bool, optional): Shows the Preamble. Defaults to True.
             min_value (int, optional): Overwrites the min value for the coloring legend. Defaults to None.
             max_value (int, optional): Overwrites the max value for the coloring legend. Defaults to None.
-        
+
         Returns:
             str: String representation of the tree, ready to print
         """

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -689,6 +689,7 @@ class Thicket(GraphFrame):
         max_value=None,
     ):
         """Visualize the Thicket as a tree
+        
         Arguments:
             metric_column (str, tuple, list, optional): Columns to use the metrics from. Defaults to None.
             annotation_column (str, optional): Column to use as an annotation. Defaults to None.
@@ -706,6 +707,7 @@ class Thicket(GraphFrame):
             render_header (bool, optional): Shows the Preamble. Defaults to True.
             min_value (int, optional): Overwrites the min value for the coloring legend. Defaults to None.
             max_value (int, optional): Overwrites the max value for the coloring legend. Defaults to None.
+        
         Returns:
             str: String representation of the tree, ready to print
         """

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -5,6 +5,7 @@
 
 import copy
 import os
+import sys
 import json
 import warnings
 from collections import OrderedDict
@@ -18,6 +19,7 @@ from hatchet.query import AbstractQuery, QueryMatcher
 import thicket.helpers as helpers
 from .utils import verify_sorted_profile
 from .utils import verify_thicket_structures
+from .external.console import ThicketRenderer
 
 
 class Thicket(GraphFrame):
@@ -667,18 +669,86 @@ class Thicket(GraphFrame):
             statsframe=self.statsframe.deepcopy(),
         )
 
-    def tree(self):
-        """hatchet tree() function for a thicket"""
-        temp_df = self.statsframe.dataframe.copy()
-        # Adjustments specific for multi-index.
-        if isinstance(temp_df.columns, pd.MultiIndex):
-            temp_df.columns = temp_df.columns.to_flat_index()
-            temp_df.rename(columns={("name", ""): "name"}, inplace=True)
-        # Placeholder value. TODO: Enable selection from performance data table.
-        temp_df["thicket_tree"] = -1
-        return GraphFrame.tree(
-            self=Thicket(graph=self.graph, dataframe=temp_df),
-            metric_column="thicket_tree",
+    def tree(
+        self,
+        metric_column=None,
+        annotation_column=None,
+        precision=3,
+        name_column="name",
+        expand_name=False,
+        context_column="file",
+        rank=0,
+        thread=0,
+        depth=10000,
+        highlight_name=False,
+        colormap="RdYlGn",
+        invert_colormap=False,
+        colormap_annotations=None,
+        render_header=True,
+        min_value=None,
+        max_value=None,
+    ):
+        """Visualize the Thicket as a tree
+        Arguments:
+            metric_column (str, list, optional): Columns to use the metrics from. Defaults to None.
+            annotation_column (str, optional): Column to use to adding an annotation. Defaults to None.
+            precision (int, optional): Precision of shown numbers. Defaults to 3.
+            name_column (str, optional): Column of the node name. Defaults to "name".
+            expand_name (bool, optional): Limits the lenght of the node name. Defaults to False.
+            context_column (str, optional): Shows the file this function was called in (Available with HPCToolkit). Defaults to "file".
+            rank (int, optional): Specifies the rank to take the data from. Defaults to 0.
+            thread (int, optional): Specifies the thread to take the data from. Defaults to 0.
+            depth (int, optional): Sets the maximum depth of the tree. Defaults to 10000.
+            highlight_name (bool, optional): Highlights the names of the nodes. Defaults to False.
+            colormap (str, optional): Specifies a colormap to use. Defaults to "RdYlGn".
+            invert_colormap (bool, optional): Reverts the chosen colormap. Defaults to False.
+            colormap_annotations (str, list, dict, optional): Either provide the name of a colormap, a list of colors to use or a dictionary which maps the used annotations to a color. Defaults to None.
+            render_header (bool, optional): Shows the Preamble. Defaults to True.
+            min_value (int, optional): Overwrites the min value for the coloring legend. Defaults to None.
+            max_value (int, optional): Overwrites the max value for the coloring legend. Defaults to None.
+        Returns:
+            str: String representation of the tree, ready to print
+        """
+        color = sys.stdout.isatty()
+        shell = None
+        if metric_column is None:
+            metric_column = self.default_metric
+
+        if color is False:
+            try:
+                import IPython
+
+                shell = IPython.get_ipython().__class__.__name__
+            except ImportError:
+                pass
+            # Test if running in a Jupyter notebook or qtconsole
+            if shell == "ZMQInteractiveShell":
+                color = True
+
+        if sys.version_info.major == 2:
+            unicode = False
+        elif sys.version_info.major == 3:
+            unicode = True
+
+        return ThicketRenderer(unicode=unicode, color=color).render(
+            self.graph.roots,
+            self.statsframe.dataframe,
+            metric_column=metric_column,
+            annotation_column=annotation_column,
+            precision=precision,
+            name_column=name_column,
+            expand_name=expand_name,
+            context_column=context_column,
+            rank=rank,
+            thread=thread,
+            depth=depth,
+            highlight_name=highlight_name,
+            colormap=colormap,
+            invert_colormap=invert_colormap,
+            colormap_annotations=colormap_annotations,
+            render_header=render_header,
+            min_value=min_value,
+            max_value=max_value,
         )
 
     def unify_pair(self, other):

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -690,8 +690,8 @@ class Thicket(GraphFrame):
     ):
         """Visualize the Thicket as a tree
         Arguments:
-            metric_column (str, list, optional): Columns to use the metrics from. Defaults to None.
-            annotation_column (str, optional): Column to use to adding an annotation. Defaults to None.
+            metric_column (str, tuple, list, optional): Columns to use the metrics from. Defaults to None.
+            annotation_column (str, optional): Column to use as an annotation. Defaults to None.
             precision (int, optional): Precision of shown numbers. Defaults to 3.
             name_column (str, optional): Column of the node name. Defaults to "name".
             expand_name (bool, optional): Limits the lenght of the node name. Defaults to False.


### PR DESCRIPTION
Adds a new tree renderer that inherits its behavior from the Hatchet renderer. 
This variant is capable of being used with columnar-joined Thickets and can serve as a basis for unique Thicket-specific features in the future. 