### PR TITLE
Add Pandas Groupby Functionality to Stats Functions

### DIFF
--- a/thicket/stats/calc_boxplot_statistics.py
+++ b/thicket/stats/calc_boxplot_statistics.py
@@ -53,8 +53,9 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
                 col + "_outliers" + q_list: [],
             }
 
-            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                values = thicket.dataframe.loc[node][col].tolist()
+            df = thicket.dataframe.reset_index().groupby("node")
+            for node, item in df:
+                values = df.get_group(node)[col].tolist()
 
                 q = np.quantile(values, quartiles)
                 q1 = q[0]
@@ -109,8 +110,9 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
                 }
             }
 
-            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                values = thicket.dataframe.loc[node][(idx, col)].tolist()
+            df = thicket.dataframe.reset_index().groupby("node")
+            for node, item in df:
+                values = df.get_group(node)[(idx, col)].tolist()
 
                 q = np.quantile(values, quartiles)
                 q1 = q[0]

--- a/thicket/stats/check_normality.py
+++ b/thicket/stats/check_normality.py
@@ -35,9 +35,14 @@ def check_normality(thicket, columns=None):
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
-        df = thicket.dataframe.reset_index().groupby("node").agg(stats.shapiro)
+        df = (
+            thicket.dataframe.drop(columns="name")
+            .reset_index()
+            .groupby("node")
+            .agg(stats.shapiro)
+        )
         for column in columns:
-            for i in len(df[column]):
+            for i in range(0, len(df[column])):
                 pvalue = df[column][i].pvalue
 
                 if pvalue < 0.05:
@@ -60,10 +65,15 @@ def check_normality(thicket, columns=None):
                     thicket.statsframe.inc_metrics.append(column + "_normality")
     # columnar joined thicket object
     else:
-        df = thicket.dataframe.reset_index(level=1).groupby("node").agg(stats.shapiro)
+        df = (
+            thicket.dataframe.drop(columns=("name", ""))
+            .reset_index(level=1)
+            .groupby("node")
+            .agg(stats.shapiro)
+        )
         for idx, column in columns:
-            for i in len(df[(idx, column)]):
-                pvalue = df[column][i].pvalue
+            for i in range(0, len(df[(idx, column)])):
+                pvalue = df[(idx, column)][i].pvalue
 
                 if pvalue < 0.05:
                     thicket.statsframe.dataframe.loc[

--- a/thicket/stats/check_normality.py
+++ b/thicket/stats/check_normality.py
@@ -43,11 +43,17 @@ def check_normality(thicket, columns=None):
                 pvalue = df[column][i].pvalue
 
                 if pvalue < 0.05:
-                    thicket.statsframe.dataframe.loc[df.index[i], column + "_normality"] = "False"
+                    thicket.statsframe.dataframe.loc[
+                        df.index[i], column + "_normality"
+                    ] = "False"
                 elif pvalue > 0.05:
-                    thicket.statsframe.dataframe.loc[df.index[i], column + "_normality"] = "True"
+                    thicket.statsframe.dataframe.loc[
+                        df.index[i], column + "_normality"
+                    ] = "True"
                 else:
-                    thicket.stataframe.dataframe.loc[df.index[i], column + "_normality"] = pd.NA
+                    thicket.stataframe.dataframe.loc[
+                        df.index[i], column + "_normality"
+                    ] = pd.NA
                 # check to see if exclusive metric
                 if column in thicket.exc_metrics:
                     thicket.statsframe.exc_metrics.append(column + "_normality")
@@ -62,11 +68,17 @@ def check_normality(thicket, columns=None):
                 pvalue = df[column][i].pvalue
 
                 if pvalue < 0.05:
-                    thicket.statsframe.dataframe.loc[df.index[i], (idx, column + "_normality")] = "False"
+                    thicket.statsframe.dataframe.loc[
+                        df.index[i], (idx, column + "_normality")
+                    ] = "False"
                 elif pvalue > 0.05:
-                    thicket.statsframe.dataframe.loc[df.index[i], (idx, column + "_normality")] = "True"
+                    thicket.statsframe.dataframe.loc[
+                        df.index[i], (idx, column + "_normality")
+                    ] = "True"
                 else:
-                    thicket.statsframe.dataframe.loc[df.index[i], (idx, column + "_normality")] = pd.NA
+                    thicket.statsframe.dataframe.loc[
+                        df.index[i], (idx, column + "_normality")
+                    ] = pd.NA
             # check to see if exclusive metric
             if (idx, column) in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append((idx, column + "_normality"))

--- a/thicket/stats/correlation_nodewise.py
+++ b/thicket/stats/correlation_nodewise.py
@@ -48,27 +48,28 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
+        df = thicket.dataframe.reset_index().groupby("node")
         correlated = []
-        for node in thicket.statsframe.dataframe.index.tolist():
+        for node, item in df:
             if correlation == "pearson":
                 correlated.append(
                     stats.pearsonr(
-                        thicket.dataframe.loc[node][column1],
-                        thicket.dataframe.loc[node][column2],
+                        df.get_group(node)[column1],
+                        df.get_group(node)[column2],
                     )[0]
                 )
             elif correlation == "spearman":
                 correlated.append(
                     stats.spearmanr(
-                        thicket.dataframe.loc[node][column1],
-                        thicket.dataframe.loc[node][column2],
+                        df.get_group(node)[column1],
+                        df.get_group(node)[column2],
                     )[0]
                 )
             elif correlation == "kendall":
                 correlated.append(
                     stats.kendalltau(
-                        thicket.dataframe.loc[node][column1],
-                        thicket.dataframe.loc[node][column2],
+                        df.get_group(node)[column1],
+                        df.get_group(node)[column2],
                     )[0]
                 )
             else:
@@ -78,27 +79,28 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
         ] = correlated
     # columnar joined thicket object
     else:
+        df = thicket.dataframe.reset_index().groupby("node")
         correlated = []
-        for node in thicket.statsframe.dataframe.index.tolist():
+        for node, item in df:
             if correlation == "pearson":
                 correlated.append(
                     stats.pearsonr(
-                        thicket.dataframe.loc[node][column1],
-                        thicket.dataframe.loc[node][column2],
+                        df.get_group(node)[column1],
+                        df.get_group(node)[column2],
                     )[0]
                 )
             elif correlation == "spearman":
                 correlated.append(
                     stats.spearmanr(
-                        thicket.dataframe.loc[node][column1],
-                        thicket.dataframe.loc[node][column2],
+                        df.get_group(node)[column1],
+                        df.get_group(node)[column2],
                     )[0]
                 )
             elif correlation == "kendall":
                 correlated.append(
                     stats.kendalltau(
-                        thicket.dataframe.loc[node][column1],
-                        thicket.dataframe.loc[node][column2],
+                        df.get_group(node)[column1],
+                        df.get_group(node)[column2],
                     )[0]
                 )
             else:

--- a/thicket/stats/maximum.py
+++ b/thicket/stats/maximum.py
@@ -33,10 +33,9 @@ def maximum(thicket, columns=None):
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
+        df = thicket.dataframe.reset_index().groupby("node").agg(max)
         for column in columns:
-            maximum = []
-            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                maximum.append(max(thicket.dataframe.loc[node][column]))
+            thicket.statsframe.dataframe[column + "_max"] = df[column]
             # check to see if exclusive metric
             if column in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append(column + "_max")
@@ -44,13 +43,11 @@ def maximum(thicket, columns=None):
             else:
                 thicket.statsframe.inc_metrics.append(column + "_max")
 
-            thicket.statsframe.dataframe[column + "_max"] = maximum
     # columnar joined thicket object
     else:
+        df = thicket.dataframe.reset_index(level=1).groupby("node").agg(max)
         for idx, column in columns:
-            maximum = []
-            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                maximum.append(max(thicket.dataframe.loc[node][(idx, column)]))
+            thicket.statsframe.dataframe[(idx, column + "_max")] = df[(idx, column)]
             # check to see if exclusive metric
             if (idx, column) in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append((idx, column + "_max"))
@@ -58,7 +55,6 @@ def maximum(thicket, columns=None):
             else:
                 thicket.statsframe.inc_metrics.append((idx, column + "_max"))
 
-            thicket.statsframe.dataframe[(idx, column + "_max")] = maximum
 
         # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/maximum.py
+++ b/thicket/stats/maximum.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import pandas as pd
-
 from ..utils import verify_thicket_structures
 
 
@@ -54,7 +52,6 @@ def maximum(thicket, columns=None):
             # check to see if inclusive metric
             else:
                 thicket.statsframe.inc_metrics.append((idx, column + "_max"))
-
 
         # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/mean.py
+++ b/thicket/stats/mean.py
@@ -32,32 +32,26 @@ def mean(thicket, columns=None):
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
+        df = thicket.dataframe.reset_index().groupby("node").agg(np.mean)
         for column in columns:
-            mean = []
-            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                mean.append(np.mean(thicket.dataframe.loc[node][column]))
+            thicket.statsframe.dataframe[column + "_mean"] = df[column]
             # check to see if exclusive metric
             if column in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append(column + "_mean")
             # check to see if inclusive metric
             else:
                 thicket.statsframe.inc_metrics.append(column + "_mean")
-
-            thicket.statsframe.dataframe[column + "_mean"] = mean
     # columnar joined thicket object
     else:
+        df = thicket.dataframe.reset_index(level=1).groupby("node").agg(np.mean)
         for idx, column in columns:
-            mean = []
-            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                mean.append(np.mean(thicket.dataframe.loc[node][(idx, column)]))
+            thicket.statsframe.dataframe[(idx, column + "_mean")] = df[(idx, column)]
             # check to see if exclusive metric
             if (idx, column) in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append((idx, column + "_mean"))
             # check to see if inclusive metric
             else:
                 thicket.statsframe.inc_metrics.append((idx, column + "_mean"))
-
-            thicket.statsframe.dataframe[(idx, column + "_mean")] = mean
 
         # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/mean.py
+++ b/thicket/stats/mean.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: MIT
 
 import numpy as np
-import pandas as pd
 
 from ..utils import verify_thicket_structures
 

--- a/thicket/stats/median.py
+++ b/thicket/stats/median.py
@@ -32,10 +32,9 @@ def median(thicket, columns=None):
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
+        df = thicket.dataframe.reset_index().groupby("node").agg(np.median)
         for column in columns:
-            median = []
-            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                median.append(np.median(thicket.dataframe.loc[node][column]))
+            thicket.statsframe.dataframe[column + "_median"] = df[column]
             # check to see if exclusive metric
             if column in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append(column + "_median")
@@ -43,21 +42,17 @@ def median(thicket, columns=None):
             else:
                 thicket.statsframe.inc_metrics.append(column + "_median")
 
-            thicket.statsframe.dataframe[column + "_median"] = median
     # columnar joined thicket object
     else:
+        df = thicket.dataframe.reset_index(level=1).groupby("node").agg(np.median)
         for idx, column in columns:
-            median = []
-            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                median.append(np.median(thicket.dataframe.loc[node][(idx, column)]))
+            thicket.statsframe.dataframe[(idx, column + "_median")] = df[(idx, column)]
             # check to see if exclusive metric
             if (idx, column) in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append((idx, column + "_median"))
             # check to see if inclusive metric
             else:
                 thicket.statsframe.inc_metrics.append((idx, column + "_median"))
-
-            thicket.statsframe.dataframe[(idx, column + "_median")] = median
 
         # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/median.py
+++ b/thicket/stats/median.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: MIT
 
 import numpy as np
-import pandas as pd
 
 from ..utils import verify_thicket_structures
 

--- a/thicket/stats/minimum.py
+++ b/thicket/stats/minimum.py
@@ -33,32 +33,26 @@ def minimum(thicket, columns=None):
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
+        df = thicket.dataframe.reset_index().groupby("node").agg(min)
         for column in columns:
-            minimum = []
-            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                minimum.append(min(thicket.dataframe.loc[node][column]))
+            thicket.statsframe.dataframe[column + "_min"] = df[column]
             # check to see if exclusive metric
             if column in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append(column + "_min")
             # check to see if inclusive metric
             else:
                 thicket.statsframe.inc_metrics.append(column + "_min")
-
-            thicket.statsframe.dataframe[column + "_min"] = minimum
     # columnar joined thicket object
     else:
+        df = thicket.dataframe.reset_index(level=1).groupby("node").agg(min)
         for idx, column in columns:
-            minimum = []
-            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                minimum.append(min(thicket.dataframe.loc[node][(idx, column)]))
+            thicket.statsframe.dataframe[(idx, column + "_min")] = df[(idx, column)]
             # check to see if exclusive metric
             if (idx, column) in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append((idx, column + "_min"))
             # check to see if inclusive metric
             else:
                 thicket.statsframe.inc_metrics.append((idx, column + "_min"))
-
-            thicket.statsframe.dataframe[(idx, column + "_min")] = minimum
 
         # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/minimum.py
+++ b/thicket/stats/minimum.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import pandas as pd
-
 from ..utils import verify_thicket_structures
 
 

--- a/thicket/stats/percentiles.py
+++ b/thicket/stats/percentiles.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import numpy as np
 import pandas as pd
 
 from ..utils import verify_thicket_structures
@@ -42,7 +41,7 @@ def percentiles(thicket, columns=None):
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
         # select numeric columns within thicket (.quantiles) will not work without this step
-        numerics = ['int16', 'int32', 'int64', 'float16', 'float32', 'float64']
+        numerics = ["int16", "int32", "int64", "float16", "float32", "float64"]
         df_num = thicket.dataframe.select_dtypes(include=numerics)
         df = df_num.reset_index().groupby("node").quantile([0.25, 0.50, 0.75])
         for column in columns:
@@ -58,7 +57,7 @@ def percentiles(thicket, columns=None):
                 thicket.statsframe.inc_metrics.append(column + "_percentiles")
     # columnar joined thicket object
     else:
-        numerics = ['int16', 'int32', 'int64', 'float16', 'float32', 'float64']
+        numerics = ["int16", "int32", "int64", "float16", "float32", "float64"]
         df_num = thicket.dataframe.select_dtypes(include=numerics)
         df = df_num.reset_index(level=1).groupby("node").quantile([0.25, 0.50, 0.75])
         percentiles = []

--- a/thicket/stats/std.py
+++ b/thicket/stats/std.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: MIT
 
 import numpy as np
-import pandas as pd
 
 from ..utils import verify_thicket_structures
 

--- a/thicket/stats/std.py
+++ b/thicket/stats/std.py
@@ -34,32 +34,26 @@ def std(thicket, columns=None):
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
+        df = thicket.dataframe.reset_index().groupby("node").agg(np.std)
         for column in columns:
-            std = []
-            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                std.append(np.std(thicket.dataframe.loc[node][column]))
+            thicket.statsframe.dataframe[column + "_std"] = df[column]
             # check to see if exclusive metric
             if column in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append(column + "_std")
             # check to see if inclusive metric
             else:
                 thicket.statsframe.inc_metrics.append(column + "_std")
-
-            thicket.statsframe.dataframe[column + "_std"] = std
     # columnar joined thicket object
     else:
+        df = thicket.dataframe.reset_index(level=1).groupby("node").agg(np.std)
         for idx, column in columns:
-            std = []
-            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                std.append(np.std(thicket.dataframe.loc[node][(idx, column)]))
+            thicket.statsframe.dataframe[(idx, column + "_std")] = df[(idx, column)]
             # check to see if exclusive metric
             if (idx, column) in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append((idx, column + "_std"))
             # check to see if inclusive metric
             else:
                 thicket.statsframe.inc_metrics.append((idx, column + "_std"))
-
-            thicket.statsframe.dataframe[(idx, column + "_std")] = std
 
         # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/variance.py
+++ b/thicket/stats/variance.py
@@ -35,31 +35,26 @@ def variance(thicket, columns=None):
 
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
+        df = thicket.dataframe.reset_index().groupby("node").agg(np.var)
         for column in columns:
-            var = []
-            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                var.append(np.var(thicket.dataframe.loc[node][column]))
+            thicket.statsframe.dataframe[column + "_var"] = df[column]
             # check to see if exclusive metric
             if column in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append(column + "_var")
             # check to see if inclusive metric
             else:
                 thicket.statsframe.inc_metrics.append(column + "_var")
-
-            thicket.statsframe.dataframe[column + "_var"] = var
     # columnar joined thicket object
     else:
+        df = thicket.dataframe.reset_index(level=1).groupby("node").agg(np.var)
         for idx, column in columns:
-            var = []
-            for node in pd.unique(thicket.dataframe.reset_index()["node"].tolist()):
-                var.append(np.var(thicket.dataframe.loc[node][(idx, column)]))
+            thicket.statsframe.dataframe[(idx, column + "_var")] = df[(idx, column)]
             # check to see if exclusive metric
             if (idx, column) in thicket.exc_metrics:
                 thicket.statsframe.exc_metrics.append((idx, column + "_var"))
             # check to see if inclusive metric
             else:
                 thicket.statsframe.inc_metrics.append((idx, column + "_var"))
-            thicket.statsframe.dataframe[(idx, column + "_var")] = var
 
         # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/variance.py
+++ b/thicket/stats/variance.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: MIT
 
 import numpy as np
-import pandas as pd
 
 from ..utils import verify_thicket_structures
 


### PR DESCRIPTION
This PR addresses adding the Pandas groupby functionality to the stats functions. This was done due to possible values being incorrectly ordered when stored within the aggregated statistic table. 

Fixes #16 