### PR TITLE
Revert "add extrap import in init.py (#79)"

### DIFF
--- a/thicket/__init__.py
+++ b/thicket/__init__.py
@@ -6,7 +6,6 @@
 # make flake8 unused names in this file.
 # flake8: noqa: F401
 
-from .model_extrap import Modeling
 from .thicket import Thicket
 from .thicket import InvalidFilter
 from .thicket import EmptyMetadataTable


### PR DESCRIPTION
This reverts commit 5b4f8bac928f78f5fdea01dc7ee755cd6f5dd0d7. Extra-p is not a required dependency. Fixes #82 