### PR TITLE
Add GroupBy Class and Aggregation Mechanism

### DIFF
--- a/thicket/groupby.py
+++ b/thicket/groupby.py
@@ -5,6 +5,7 @@
 
 from collections import defaultdict
 
+
 class GroupBy(dict):
     def __init__(self, by=None, *args, **kwargs):
         super(GroupBy, self).__init__(*args, **kwargs)
@@ -24,7 +25,7 @@ class GroupBy(dict):
             agg_tks[k] = self.aggregate_thicket(tk=v, func=func)
 
         values_list = list(agg_tks.values())
-        first_tk = values_list[0] # TODO: Hack to avoid circular import.
+        first_tk = values_list[0]  # TODO: Hack to avoid circular import.
         agg_tk = first_tk.concat_thickets(values_list)
 
         return agg_tk
@@ -91,16 +92,29 @@ class GroupBy(dict):
                     raise KeyError(f'"{col}" is not in the PerfData or MetaData.')
 
         # Make new profile and profile_mapping
-        new_profile_label_mapping_df = tk_c.dataframe.reset_index().drop(list(tk_c.dataframe.columns) + ["node"], axis=1).drop_duplicates().set_index("profile")
-        if len(new_profile_label_mapping_df.columns) > 1: # Make tuple values if more than 1 column
-            new_profile_label_mapping_df = new_profile_label_mapping_df.apply(tuple, axis=1)
-        else: # Squeeze single column df into series
+        new_profile_label_mapping_df = (
+            tk_c.dataframe.reset_index()
+            .drop(list(tk_c.dataframe.columns) + ["node"], axis=1)
+            .drop_duplicates()
+            .set_index("profile")
+        )
+        if (
+            len(new_profile_label_mapping_df.columns) > 1
+        ):  # Make tuple values if more than 1 column
+            new_profile_label_mapping_df = new_profile_label_mapping_df.apply(
+                tuple, axis=1
+            )
+        else:  # Squeeze single column df into series
             new_profile_label_mapping_df = new_profile_label_mapping_df.squeeze()
-        new_profile_label_mapping = new_profile_label_mapping_df.to_dict() # Convert df to dict
+        new_profile_label_mapping = (
+            new_profile_label_mapping_df.to_dict()
+        )  # Convert df to dict
         new_profile = list(set(new_profile_label_mapping.values()))
         new_profile_mapping = defaultdict(list)
         for p in tk_c.profile:
-            new_profile_mapping[new_profile_label_mapping[p]].append(tk_c.profile_mapping[p])
+            new_profile_mapping[new_profile_label_mapping[p]].append(
+                tk_c.profile_mapping[p]
+            )
         tk_c.profile = new_profile
         tk_c.profile_mapping = new_profile_mapping
 

--- a/thicket/groupby.py
+++ b/thicket/groupby.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: MIT
 
 from collections import defaultdict
-from pandas.api.types import is_numeric_dtype, is_string_dtype
 
 
 class GroupBy(dict):
@@ -76,10 +75,7 @@ class GroupBy(dict):
             new_profile_idx = "profile"
             gb_cols = ["node"]
         if not aux_cols:
-            aux_cols = []
-            for col in tk.dataframe.columns:
-                if is_string_dtype(tk.dataframe[col]):
-                    aux_cols.append(col)
+            aux_cols = list(tk.dataframe.select_dtypes(exclude="number").columns)
 
         # Get gb_cols into index
         index_names = tk_c.dataframe.index.names
@@ -95,10 +91,7 @@ class GroupBy(dict):
 
         # agg_cols is all numeric columns
         if not agg_cols:
-            agg_cols = []
-            for col in tk.dataframe.columns:
-                if is_numeric_dtype(tk.dataframe[col]):
-                    agg_cols.append(col)
+            agg_cols = list(tk.dataframe.select_dtypes(include="number").columns)
 
         # Compute stats
         snames = list(func.keys())

--- a/thicket/groupby.py
+++ b/thicket/groupby.py
@@ -117,6 +117,13 @@ class GroupBy(dict):
             )
         tk_c.profile = new_profile
         tk_c.profile_mapping = new_profile_mapping
+        # Aggregate metadata
+        tk_c.metadata = tk_c.metadata.reset_index()
+        tk_c.metadata["profile"] = tk_c.metadata["profile"].map(
+            new_profile_label_mapping
+        )
+        tk_c.metadata = tk_c.metadata.set_index("profile")
+        tk_c.metadata = tk_c.metadata.groupby("profile").agg(_agg_rows)
 
         # Compute stats
         snames = list(func.keys())

--- a/thicket/groupby.py
+++ b/thicket/groupby.py
@@ -83,7 +83,7 @@ class GroupBy(dict):
             if col not in index_names:
                 if col in tk_c.metadata.columns or col in df_columns:
                     if col not in df_columns:
-                        tk_c.add_column_from_metadata_to_ensemble(col)
+                        tk_c.metadata_column_to_perfdata(col)
                     tk_c.dataframe = tk_c.dataframe.set_index(col, append=True)
                 else:
                     raise KeyError(f'"{col}" is not in the PerfData or MetaData.')

--- a/thicket/groupby.py
+++ b/thicket/groupby.py
@@ -15,10 +15,9 @@ class GroupBy(dict):
 
         Arguments:
             func (dict): Dictionary mapping from {str: function}, where the str will be added to the Thicket's column's name after the aggregation function is applied.
-            index (str, optional): Optional column to group on in addition to "node". Can be from PerfData or MetaData. Default grouping is on "node".
 
         Returns:
-            (self): Aggregated GroupBy object.
+            (Thicket): Aggregated Thicket object.
         """
         agg_tks = {}
         for k, v in self.items():
@@ -36,7 +35,6 @@ class GroupBy(dict):
         Arguments:
             tk (Thicket): Thicket object to aggregate.
             func (dict): See agg()
-            index (str, optional): See agg()
 
         Returns:
             (Thicket): New Thicket object with aggregated attributes.

--- a/thicket/groupby.py
+++ b/thicket/groupby.py
@@ -1,3 +1,8 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Thicket Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
 from collections import defaultdict
 from pandas.api.types import is_numeric_dtype, is_string_dtype
 

--- a/thicket/groupby.py
+++ b/thicket/groupby.py
@@ -1,0 +1,150 @@
+from collections import defaultdict
+from pandas.api.types import is_numeric_dtype, is_string_dtype
+
+
+class GroupBy(dict):
+    def __init__(self, *args, **kwargs):
+        super(GroupBy, self).__init__(*args, **kwargs)
+
+    def agg(self, func, gb_col=None, agg_cols=None, aux_cols=None):
+        """Aggregate the Thickets in a GroupBy object.
+
+        Arguments:
+            func (dict): Mapping from str -> function, where the str will be added to the Thicket's column's name after the aggregation function is applied.
+            gb_cols (str, optional): Optional column to group on in addition to "node". can be from PerfData or MetaData. Default grouping is on "node".
+            gb_cols (list(str), optional): Specify which numerical columns to aggregate.
+            aux_cols (list(str), optional): Additional existing columns from the previous Thicket.dataframe to pull into the new aggregated dataframe.
+
+        Returns:
+            (self): Aggregated GroupBy object.
+        """
+        for k, v in self.items():
+            self[k] = GroupBy.aggregate_thicket(
+                tk=v, func=func, gb_col=gb_col, agg_cols=agg_cols, aux_cols=aux_cols
+            )
+        return self
+
+    @staticmethod
+    def aggregate_thicket(tk, func, gb_col=None, agg_cols=None, aux_cols=None):
+        """Aggregate a Thicket's numerical columns given a statistical function.
+
+        Arguments:
+            tk (Thicket): Thicket object to aggregate.
+            func (dict): See agg()
+            gb_cols(str, optional):: See agg()
+            aux_cols (list(str), optional): See agg()
+
+        Returns:
+            (Thicket): New Thicket object with aggregated attributes.
+        """
+
+        def rename_col(total_cols, tname):
+            tcols = {}
+            for col in total_cols:
+                tcols[col] = col + "_" + tname
+            return tcols
+
+        def _agg_rows(col_series):
+            """Aggregate values in 'col_series' into a set to remove duplicates."""
+            if len(col_series) <= 1:
+                return col_series
+            else:
+                if isinstance(col_series.iloc[0], list) or isinstance(
+                    col_series.iloc[0], set
+                ):
+                    _set = set(tuple(i) for i in col_series)
+                else:
+                    _set = set(col_series)
+                if len(_set) == 1:
+                    return _set.pop()
+                else:
+                    return _set
+
+        # Make copy
+        tk_c = tk.deepcopy()
+
+        # Set variables
+        if gb_col:
+            new_profile_idx = gb_col
+            gb_cols = ["node", gb_col]
+        else:
+            new_profile_idx = "profile"
+            gb_cols = ["node"]
+        if not aux_cols:
+            aux_cols = []
+            for col in tk.dataframe.columns:
+                if is_string_dtype(tk.dataframe[col]):
+                    aux_cols.append(col)
+
+        # Get gb_cols into index
+        index_names = tk_c.dataframe.index.names
+        df_columns = tk_c.dataframe.columns
+        for col in gb_cols:
+            if col not in index_names:
+                if col in tk_c.metadata.columns or col in df_columns:
+                    if col not in df_columns:
+                        tk_c.add_column_from_metadata_to_ensemble(col)
+                    tk_c.dataframe = tk_c.dataframe.set_index(col, append=True)
+                else:
+                    raise KeyError(f'"{col}" is not in the PerfData or MetaData.')
+
+        # agg_cols is all numeric columns
+        if not agg_cols:
+            agg_cols = []
+            for col in tk.dataframe.columns:
+                if is_numeric_dtype(tk.dataframe[col]):
+                    agg_cols.append(col)
+
+        # Compute stats
+        snames = list(func.keys())
+        sfuncs = list(func.values())
+        agg_df = tk_c.dataframe[agg_cols].groupby(gb_cols).agg(sfuncs[0])
+        agg_df = agg_df.rename(columns=rename_col(agg_cols, snames[0]))
+        for i in range(1, len(func)):
+            t_agg_df = tk_c.dataframe[agg_cols].groupby(gb_cols).agg(sfuncs[i])
+            t_agg_df = t_agg_df.rename(columns=rename_col(agg_cols, snames[i]))
+            agg_df = agg_df.merge(
+                right=t_agg_df,
+                on=gb_cols,
+            )
+
+        # Create new df with auxilliary columns
+        all_cols = gb_cols.copy()
+        all_cols.extend(aux_cols)
+        aux_df = (
+            tk_c.dataframe.reset_index()[all_cols]
+            .drop_duplicates(all_cols)
+            .set_index(gb_cols)
+        )
+        agg_df = agg_df.merge(right=aux_df, how="left", on=gb_cols)
+
+        # Create profile and profile mapping
+        if new_profile_idx == "profile":
+            new_profiles = [0]
+            new_profile_mapping = defaultdict(list)
+            new_profile_mapping[0] = list(tk_c.profile_mapping.keys())
+            # Aggregate metadata dataframe
+            tk_c.metadata = tk_c.metadata.reset_index(drop=True)
+            tk_c.metadata["profile"] = 0
+            tk_c.metadata = tk_c.metadata.set_index("profile")
+            tk_c.metadata = tk_c.metadata.groupby("profile").agg(_agg_rows)
+        else:
+            mapping_to_new_profiles = (
+                tk_c.dataframe.reset_index()[["profile", new_profile_idx]]
+                .drop_duplicates()
+                .set_index("profile")
+                .to_dict()[new_profile_idx]
+            )
+            new_profile_mapping = defaultdict(list)
+            for k, v in mapping_to_new_profiles.items():
+                new_profile_mapping[v].append(tk_c.profile_mapping[k])
+            new_profiles = list(new_profile_mapping.keys())
+            # Aggregate metadata dataframe
+            tk_c.metadata = tk_c.metadata.groupby(new_profile_idx).agg(_agg_rows)
+
+        # Set other attributes
+        tk_c.dataframe = agg_df
+        tk_c.profile = new_profiles
+        tk_c.profile_mapping = new_profile_mapping
+
+        return tk_c

--- a/thicket/groupby.py
+++ b/thicket/groupby.py
@@ -21,9 +21,7 @@ class GroupBy(dict):
             (self): Aggregated GroupBy object.
         """
         for k, v in self.items():
-            self[k] = GroupBy.aggregate_thicket(
-                tk=v, func=func, gb_col=gb_col
-            )
+            self[k] = GroupBy.aggregate_thicket(tk=v, func=func, gb_col=gb_col)
         return self
 
     @staticmethod

--- a/thicket/groupby.py
+++ b/thicket/groupby.py
@@ -74,11 +74,6 @@ class GroupBy(dict):
             if isinstance(self.by, str):
                 other_indices = [other_indices]
             perf_indices.extend(other_indices)
-        # agg_cols is all numeric columns
-        agg_cols = list(tk.dataframe.select_dtypes(include="number").columns)
-        # other_cols is agg_cols complement
-        other_cols = list(tk.dataframe.select_dtypes(exclude="number").columns)
-
         # Get perf_indices into index
         index_names = tk_c.dataframe.index.names
         df_columns = tk_c.dataframe.columns
@@ -90,6 +85,10 @@ class GroupBy(dict):
                     tk_c.dataframe = tk_c.dataframe.set_index(col, append=True)
                 else:
                     raise KeyError(f'"{col}" is not in the PerfData or MetaData.')
+        # agg_cols is all numeric columns
+        agg_cols = list(tk_c.dataframe.select_dtypes(include="number").columns)
+        # other_cols is agg_cols complement
+        other_cols = list(tk_c.dataframe.select_dtypes(exclude="number").columns)
 
         # Make new profile and profile_mapping
         new_profile_label_mapping_df = (

--- a/thicket/groupby.py
+++ b/thicket/groupby.py
@@ -14,8 +14,8 @@ class GroupBy(dict):
         """Aggregate the Thickets' PerfData numerical columns in a GroupBy object.
 
         Arguments:
-            func (dict): Mapping from str -> function, where the str will be added to the Thicket's column's name after the aggregation function is applied.
-            gb_cols (str, optional): Optional column to group on in addition to "node". can be from PerfData or MetaData. Default grouping is on "node".
+            func (dict): Dictionary mapping from {str: function}, where the str will be added to the Thicket's column's name after the aggregation function is applied.
+            gb_col (str, optional): Optional column to group on in addition to "node". Can be from PerfData or MetaData. Default grouping is on "node".
 
         Returns:
             (self): Aggregated GroupBy object.
@@ -33,12 +33,14 @@ class GroupBy(dict):
         Arguments:
             tk (Thicket): Thicket object to aggregate.
             func (dict): See agg()
+            gb_col (str, optional): See agg()
 
         Returns:
             (Thicket): New Thicket object with aggregated attributes.
         """
 
         def rename_col(total_cols, tname):
+            """Helper function for renaming columns"""
             tcols = {}
             for col in total_cols:
                 tcols[col] = col + "_" + tname

--- a/thicket/helpers.py
+++ b/thicket/helpers.py
@@ -154,7 +154,6 @@ def _sync_nodes_frame(gh, df):
     TODO: This function may be superior to _sync_nodes and may be able to replace it.
     Need to investigate.
     """
-
     # TODO: Graph function to list conversion: move to Hatchet?
     gh_node_list = []
     for gh_node in gh.traverse():

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -922,7 +922,7 @@ class Thicket(GraphFrame):
         print(len(sub_thickets), " thickets created...")
         print(sub_thickets)
 
-        return GroupBy(sub_thickets)
+        return GroupBy(by, sub_thickets)
 
     def filter_stats(self, filter_function):
         """Filter thicket object based on a stats column.

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -18,6 +18,7 @@ from hatchet.query import AbstractQuery, QueryMatcher
 
 from thicket.ensemble import Ensemble
 import thicket.helpers as helpers
+from .groupby import GroupBy
 from .utils import verify_thicket_structures
 from .external.console import ThicketRenderer
 
@@ -921,7 +922,7 @@ class Thicket(GraphFrame):
         print(len(sub_thickets), " thickets created...")
         print(sub_thickets)
 
-        return sub_thickets
+        return GroupBy(sub_thickets)
 
     def filter_stats(self, filter_function):
         """Filter thicket object based on a stats column.


### PR DESCRIPTION
# Summary
This PR adds a new `GroupBy` object to Thicket, which will be returned as a result of using `Thicket.groupby`. This object also has an aggregation mechanism `GroupBy.agg()` that can be used to aggregate the Thickets in the Groupby object into a single Thicket.
