### PR TITLE
Enable Inner Index Naming in from_statsframes

### DIFF
--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -320,26 +320,6 @@ class Ensemble:
 
             return perfdata
 
-        def _from_statsframes_metadata(metadata):
-            """Aggregate data in Metadata"""
-
-            def _agg_to_set(obj):
-                """Aggregate values in 'obj' into a set to remove duplicates."""
-                if len(obj) <= 1:
-                    return obj
-                else:
-                    _set = set(obj)
-                    # If len == 1 just use the value, otherwise return the set
-                    if len(_set) == 1:
-                        return _set.pop()
-                    else:
-                        return _set
-
-            # Rename index to "thicket"
-            metadata.index.rename("thicket", inplace=True)
-            # Execute aggregation
-            metadata = metadata.groupby("thicket").agg(_agg_to_set)
-
         # Add missing indicies to thickets
         helpers._resolve_missing_indicies(thickets)
 
@@ -375,10 +355,6 @@ class Ensemble:
 
         # Insert missing rows in dataframe
         unify_df = _fill_perfdata(unify_df)
-
-        # Metadata-specific operations
-        if from_statsframes:
-            _from_statsframes_metadata(unify_metadata)
 
         # Sort PerfData
         unify_df.sort_index(inplace=True)

--- a/thicket/tests/test_from_statsframes.py
+++ b/thicket/tests/test_from_statsframes.py
@@ -20,7 +20,7 @@ def test_from_statsframes(mpi_scaling_cali):
     tk = th.from_statsframes(th_list)
 
     # Check level values
-    assert set(superthicket.dataframe.index.get_level_values("profile")) == {
+    assert set(tk.dataframe.index.get_level_values("profile")) == {
         0,
         1,
         2,
@@ -30,11 +30,11 @@ def test_from_statsframes(mpi_scaling_cali):
     # Check performance data table values
     assert set(tk.dataframe["test"]) == {0, 2, 4, 6, 8}
 
-    superthicket_named = th.make_superthicket(th_list, metadata_key="mpi.world.size")
+    tk_named = th.from_statsframes(th_list, metadata_key="mpi.world.size")
 
     # Check level values
     assert set(
-        superthicket_named.dataframe.index.get_level_values("mpi.world.size")
+        tk_named.dataframe.index.get_level_values("mpi.world.size")
     ) == {
         27,
         64,

--- a/thicket/tests/test_from_statsframes.py
+++ b/thicket/tests/test_from_statsframes.py
@@ -33,9 +33,7 @@ def test_from_statsframes(mpi_scaling_cali):
     tk_named = th.from_statsframes(th_list, metadata_key="mpi.world.size")
 
     # Check level values
-    assert set(
-        tk_named.dataframe.index.get_level_values("mpi.world.size")
-    ) == {
+    assert set(tk_named.dataframe.index.get_level_values("mpi.world.size")) == {
         27,
         64,
         125,

--- a/thicket/tests/test_make_superthicket.py
+++ b/thicket/tests/test_make_superthicket.py
@@ -30,7 +30,7 @@ def test_from_statsframes(mpi_scaling_cali):
     # Check performance data table values
     assert set(tk.dataframe["test"]) == {0, 2, 4, 6, 8}
 
-    tk_named = th.from_statsframes(th_list, metadata_key="mpi.world.size")
+    superthicket_named = th.make_superthicket(th_list, metadata_key="mpi.world.size")
 
     # Check level values
     assert set(

--- a/thicket/tests/test_make_superthicket.py
+++ b/thicket/tests/test_make_superthicket.py
@@ -20,7 +20,7 @@ def test_from_statsframes(mpi_scaling_cali):
     tk = th.from_statsframes(th_list)
 
     # Check level values
-    assert set(tk.dataframe.index.get_level_values("thicket")) == {
+    assert set(superthicket.dataframe.index.get_level_values("profile")) == {
         0,
         1,
         2,
@@ -33,7 +33,7 @@ def test_from_statsframes(mpi_scaling_cali):
     tk_named = th.from_statsframes(th_list, metadata_key="mpi.world.size")
 
     # Check level values
-    assert set(tk_named.dataframe.index.get_level_values("thicket")) == {
+    assert set(superthicket_named.dataframe.index.get_level_values("mpi.world.size")) == {
         27,
         64,
         125,

--- a/thicket/tests/test_make_superthicket.py
+++ b/thicket/tests/test_make_superthicket.py
@@ -33,7 +33,9 @@ def test_from_statsframes(mpi_scaling_cali):
     tk_named = th.from_statsframes(th_list, metadata_key="mpi.world.size")
 
     # Check level values
-    assert set(superthicket_named.dataframe.index.get_level_values("mpi.world.size")) == {
+    assert set(
+        superthicket_named.dataframe.index.get_level_values("mpi.world.size")
+    ) == {
         27,
         64,
         125,

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -642,10 +642,10 @@ class Thicket(GraphFrame):
 
             th_id = th_names[i]
 
-            if profiles_from_meta is None:
+            if metadata_key is None:
                 idx_name = "profile"
             else:
-                idx_name = profiles_from_meta
+                idx_name = metadata_key
 
             # Modify graph
             # Necessary so node ids match up


### PR DESCRIPTION
# Description
- Improve aggregating function on metadata if values are `dict`.
- Move aggregating function out of `_index`
- Change variable name `profiles_from_meta` to `metadata_key`
- Dictate inner index naming by `metadata_key`