### PR TITLE
fix readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,8 @@
 
 # Required
 version: 2
+build:
+  os: "ubuntu-22.04"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,15 +4,22 @@
 
 # Required
 version: 2
+
 build:
   os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
 
-# Optionally build your docs in additional formats such as PDF and ePub
-formats: []
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+  - requirements: docs/requirements.txt
 
-conda:
-  environment: docs/environment.yml
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
```
Your builds will stop working soon!
"build.image" config key is deprecated and it will be removed soon. [Read our blog post to know how to migrate to new key "build.os"](https://blog.readthedocs.com/use-build-os-config/) and ensure your project continues building successfully.
```