### PR TITLE
Fix Error Message in Stats Functions

### DIFF
--- a/thicket/stats/calc_boxplot_statistics.py
+++ b/thicket/stats/calc_boxplot_statistics.py
@@ -31,7 +31,7 @@ def calc_boxplot_statistics(thicket, columns=[], quartiles=[0.25, 0.5, 0.75], **
 
     if len(columns) == 0:
         raise ValueError(
-            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+            "To see a list of valid columns, run 'Thicket.performance_cols'."
         )
 
     verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)

--- a/thicket/stats/check_normality.py
+++ b/thicket/stats/check_normality.py
@@ -28,7 +28,7 @@ def check_normality(thicket, columns=None):
     """
     if columns is None:
         raise ValueError(
-            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+            "To see a list of valid columns, run 'Thicket.performance_cols'."
         )
 
     verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)

--- a/thicket/stats/correlation_nodewise.py
+++ b/thicket/stats/correlation_nodewise.py
@@ -30,7 +30,7 @@ def correlation_nodewise(thicket, column1=None, column2=None, correlation="pears
     """
     if column1 is None or column2 is None:
         raise ValueError(
-            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+            "To see a list of valid columns, run 'Thicket.performance_cols'."
         )
 
     verify_thicket_structures(

--- a/thicket/stats/display_heatmap.py
+++ b/thicket/stats/display_heatmap.py
@@ -23,7 +23,7 @@ def display_heatmap(thicket, columns=None, **kwargs):
     """
     if columns is None:
         raise ValueError(
-            "To see a list of valid columns, run Thicket.get_perf_columns()."
+            "To see a list of valid columns, run 'Thicket.performance_cols'."
         )
 
     verify_thicket_structures(

--- a/thicket/stats/display_histogram.py
+++ b/thicket/stats/display_histogram.py
@@ -26,7 +26,7 @@ def display_histogram(thicket, node=None, column=None, **kwargs):
     """
     if column is None or node is None:
         raise ValueError(
-            "To see a list of valid columns, run Thicket.get_perf_columns()."
+            "To see a list of valid columns, run 'Thicket.performance_cols'."
         )
 
     if not isinstance(node, ht.node.Node):

--- a/thicket/stats/maximum.py
+++ b/thicket/stats/maximum.py
@@ -22,7 +22,7 @@ def maximum(thicket, columns=None):
     """
     if columns is None:
         raise ValueError(
-            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+            "To see a list of valid columns, run 'Thicket.performance_cols'."
         )
 
     verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)

--- a/thicket/stats/mean.py
+++ b/thicket/stats/mean.py
@@ -22,7 +22,7 @@ def mean(thicket, columns=None):
     """
     if columns is None:
         raise ValueError(
-            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+            "To see a list of valid columns, run 'Thicket.performance_cols'."
         )
 
     verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)

--- a/thicket/stats/median.py
+++ b/thicket/stats/median.py
@@ -22,7 +22,7 @@ def median(thicket, columns=None):
     """
     if columns is None:
         raise ValueError(
-            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+            "To see a list of valid columns, run 'Thicket.performance_cols'."
         )
 
     verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)

--- a/thicket/stats/minimum.py
+++ b/thicket/stats/minimum.py
@@ -22,7 +22,7 @@ def minimum(thicket, columns=None):
     """
     if columns is None:
         raise ValueError(
-            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+            "To see a list of valid columns, run 'Thicket.performance_cols'."
         )
 
     verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)

--- a/thicket/stats/percentiles.py
+++ b/thicket/stats/percentiles.py
@@ -31,7 +31,7 @@ def percentiles(thicket, columns=None):
     """
     if columns is None:
         raise ValueError(
-            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+            "To see a list of valid columns, run 'Thicket.performance_cols'."
         )
 
     verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)

--- a/thicket/stats/std.py
+++ b/thicket/stats/std.py
@@ -24,7 +24,7 @@ def std(thicket, columns=None):
     """
     if columns is None:
         raise ValueError(
-            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+            "To see a list of valid columns, run 'Thicket.performance_cols'."
         )
 
     verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)

--- a/thicket/stats/variance.py
+++ b/thicket/stats/variance.py
@@ -25,7 +25,7 @@ def variance(thicket, columns=None):
     """
     if columns is None:
         raise ValueError(
-            "To see a list of valid columns, please run Thicket.get_perf_columns()."
+            "To see a list of valid columns, run 'Thicket.performance_cols'."
         )
 
     verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)


### PR DESCRIPTION
Old error message suggested running a command which did not work. The user would need to call `helpers._get_perf_columns(Thicket.dataframe)`. We already populate `Thicket.performance_cols` with this value so direct the user to use this variable instead.