### PR TITLE
Rename add_column_from_metadata_to_ensemble function

### DIFF
--- a/docs/thicket_rajaperf_clustering.ipynb
+++ b/docs/thicket_rajaperf_clustering.ipynb
@@ -542,9 +542,9 @@
     "    thicket.metadata[\"opt_level_int\"] = thicket.metadata[\"rajaperf_compiler_options\"].apply(\n",
     "        check_for_optimization_level_int\n",
     "    )\n",
-    "    thicket.add_column_from_metadata_to_ensemble(\"opt_level\")\n",
-    "    thicket.add_column_from_metadata_to_ensemble(\"opt_level_int\")\n",
-    "    thicket.add_column_from_metadata_to_ensemble(\"compiler\")\n",
+    "    thicket.metadata_column_to_perfdata(\"opt_level\")\n",
+    "    thicket.metadata_column_to_perfdata(\"opt_level_int\")\n",
+    "    thicket.metadata_column_to_perfdata(\"compiler\")\n",
     "    return [\"opt_level\", \"opt_level_int\", \"compiler\"], thicket"
    ]
   },

--- a/docs/thicket_rajaperf_clustering.ipynb
+++ b/docs/thicket_rajaperf_clustering.ipynb
@@ -542,9 +542,9 @@
     "    thicket.metadata[\"opt_level_int\"] = thicket.metadata[\"rajaperf_compiler_options\"].apply(\n",
     "        check_for_optimization_level_int\n",
     "    )\n",
-    "    thicket.metadata_column_to_perfdata(\"opt_level\")\n",
-    "    thicket.metadata_column_to_perfdata(\"opt_level_int\")\n",
-    "    thicket.metadata_column_to_perfdata(\"compiler\")\n",
+    "    thicket.add_column_from_metadata_to_ensemble(\"opt_level\")\n",
+    "    thicket.add_column_from_metadata_to_ensemble(\"opt_level_int\")\n",
+    "    thicket.add_column_from_metadata_to_ensemble(\"compiler\")\n",
     "    return [\"opt_level\", \"opt_level_int\", \"compiler\"], thicket"
    ]
   },

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -176,7 +176,7 @@ class Ensemble:
                 new_profiles = [i for i in range(len(thickets_cp[0].profile))]
                 for i in range(len(thickets_cp)):
                     thickets_cp[i].metadata["new_profiles"] = new_profiles
-                    thickets_cp[i].add_column_from_metadata_to_ensemble(
+                    thickets_cp[i].metadata_column_to_perfdata(
                         "new_profiles", drop=True
                     )
                     thickets_cp[i].dataframe.reset_index(level="profile", inplace=True)
@@ -198,7 +198,7 @@ class Ensemble:
                     )
             else:  # Change second-level index to be from metadata's "metadata_key" column
                 for i in range(len(thickets_cp)):
-                    thickets_cp[i].add_column_from_metadata_to_ensemble(metadata_key)
+                    thickets_cp[i].metadata_column_to_perfdata(metadata_key)
                     thickets_cp[i].dataframe.reset_index(level="profile", inplace=True)
                     new_mappings.update(
                         pd.Series(

--- a/thicket/tests/test_thicket.py
+++ b/thicket/tests/test_thicket.py
@@ -104,7 +104,7 @@ def test_statsframe(example_cali):
     assert bool(re.search("1.000.*CalcFBHourglassForceForElems", tree_output))
 
 
-def test_add_column_from_metadata(mpi_scaling_cali):
+def test_metadata_column_to_perfdata(mpi_scaling_cali):
     t_ens = Thicket.from_caliperreader(mpi_scaling_cali)
 
     example_column = "jobsize"

--- a/thicket/tests/test_thicket.py
+++ b/thicket/tests/test_thicket.py
@@ -117,7 +117,7 @@ def test_add_column_from_metadata(mpi_scaling_cali):
     # Assume second level index is profile
     assert t_ens.dataframe.index.names[1] == "profile"
 
-    t_ens.add_column_from_metadata_to_ensemble(example_column)
+    t_ens.metadata_column_to_perfdata(example_column)
 
     # Column should be in performance data table
     assert example_column in t_ens.dataframe

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -378,9 +378,7 @@ class Thicket(GraphFrame):
         # make and return thicket?
         return th
 
-    def metadata_column_to_perfdata(
-        self, metadata_key, overwrite=False, drop=False
-    ):
+    def metadata_column_to_perfdata(self, metadata_key, overwrite=False, drop=False):
         """Add a column from the metadata table to the performance data table.
 
         Arguments:

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -378,7 +378,7 @@ class Thicket(GraphFrame):
         # make and return thicket?
         return th
 
-    def add_column_from_metadata_to_ensemble(
+    def metadata_column_to_perfdata(
         self, metadata_key, overwrite=False, drop=False
     ):
         """Add a column from the metadata table to the performance data table.


### PR DESCRIPTION
Rename `add_column_from_metadata_to_ensemble` to `metadata_column_to_perfdata`. Current name is too long.