### PR TITLE
Rename make_superthicket

### DIFF
--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -288,11 +288,11 @@ class Ensemble:
         return combined_th
 
     @staticmethod
-    def _index(thickets, superthicket=False):
+    def _index(thickets, from_statsframes=False):
         """Unify a list of thickets into a single thicket
 
         Arguments:
-            superthicket (bool): whether the result is a superthicket
+            from_statsframes (bool): Whether this method was invoked from from_statsframes
 
         Returns:
             unify_graph (hatchet.Graph): unified graph,
@@ -316,7 +316,7 @@ class Ensemble:
 
             return perfdata
 
-        def _superthicket_metadata(metadata):
+        def _from_statsframes_metadata(metadata):
             """Aggregate data in Metadata"""
 
             def _agg_to_set(obj):
@@ -373,8 +373,8 @@ class Ensemble:
         unify_df = _fill_perfdata(unify_df)
 
         # Metadata-specific operations
-        if superthicket:
-            _superthicket_metadata(unify_metadata)
+        if from_statsframes:
+            _from_statsframes_metadata(unify_metadata)
 
         # Sort PerfData
         unify_df.sort_index(inplace=True)

--- a/thicket/tests/test_make_superthicket.py
+++ b/thicket/tests/test_make_superthicket.py
@@ -6,7 +6,7 @@
 from thicket import Thicket as th
 
 
-def test_make_superthicket(mpi_scaling_cali):
+def test_from_statsframes(mpi_scaling_cali):
     th_list = []
     for file in mpi_scaling_cali:
         th_list.append(th.from_caliperreader(file))
@@ -17,10 +17,10 @@ def test_make_superthicket(mpi_scaling_cali):
         t.statsframe.dataframe["test"] = t_val
         t_val += 2
 
-    superthicket = th.make_superthicket(th_list)
+    tk = th.from_statsframes(th_list)
 
     # Check level values
-    assert set(superthicket.dataframe.index.get_level_values("thicket")) == {
+    assert set(tk.dataframe.index.get_level_values("thicket")) == {
         0,
         1,
         2,
@@ -28,14 +28,12 @@ def test_make_superthicket(mpi_scaling_cali):
         4,
     }
     # Check performance data table values
-    assert set(superthicket.dataframe["test"]) == {0, 2, 4, 6, 8}
+    assert set(tk.dataframe["test"]) == {0, 2, 4, 6, 8}
 
-    superthicket_named = th.make_superthicket(
-        th_list, profiles_from_meta="mpi.world.size"
-    )
+    tk_named = th.from_statsframes(th_list, profiles_from_meta="mpi.world.size")
 
     # Check level values
-    assert set(superthicket_named.dataframe.index.get_level_values("thicket")) == {
+    assert set(tk_named.dataframe.index.get_level_values("thicket")) == {
         27,
         64,
         125,
@@ -43,4 +41,4 @@ def test_make_superthicket(mpi_scaling_cali):
         343,
     }
     # Check performance data table values
-    assert set(superthicket_named.dataframe["test"]) == {0, 2, 4, 6, 8}
+    assert set(tk_named.dataframe["test"]) == {0, 2, 4, 6, 8}

--- a/thicket/tests/test_make_superthicket.py
+++ b/thicket/tests/test_make_superthicket.py
@@ -30,7 +30,7 @@ def test_from_statsframes(mpi_scaling_cali):
     # Check performance data table values
     assert set(tk.dataframe["test"]) == {0, 2, 4, 6, 8}
 
-    tk_named = th.from_statsframes(th_list, profiles_from_meta="mpi.world.size")
+    tk_named = th.from_statsframes(th_list, metadata_key="mpi.world.size")
 
     # Check level values
     assert set(tk_named.dataframe.index.get_level_values("thicket")) == {

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -273,7 +273,7 @@ class Thicket(GraphFrame):
 
             valid kwargs:
                 if axis="index":
-                    superthicket (bool): Whether the result is a superthicket
+                    from_statsframes (bool): Whether this method was invoked from from_statsframes
                 if axis="columns":
                     headers (list): List of headers to use for the new columnar multi-index.
                     metadata_key (str): Name of the column from the metadata tables to replace the 'profile'
@@ -284,9 +284,9 @@ class Thicket(GraphFrame):
             (thicket): concatenated thicket
         """
 
-        def _index(thickets, superthicket=False):
+        def _index(thickets, from_statsframes=False):
             thicket_parts = Ensemble._index(
-                thickets=thickets, superthicket=superthicket
+                thickets=thickets, from_statsframes=from_statsframes
             )
 
             return Thicket(
@@ -328,7 +328,7 @@ class Thicket(GraphFrame):
         )
 
     @staticmethod
-    def unify_ensemble(th_list, superthicket=False):
+    def unify_ensemble(th_list, from_statsframes=False):
         raise ValueError(
             "unify_ensemble is deprecated. Use 'concat_thickets(axis='index'...)' instead."
         )
@@ -597,11 +597,11 @@ class Thicket(GraphFrame):
         )
 
     @staticmethod
-    def make_superthicket(th_list, profiles_from_meta=None):
-        """Convert a list of thickets into a 'superthicket'.
+    def from_statsframes(th_list, profiles_from_meta=None):
+        """Compose a list of Thickets with data in their statsframes.
 
-        Their individual aggregated statistics table are ensembled and become the
-        superthicket's performance data table.
+        The Thicket's individual aggregated statistics tables are ensembled and become the
+        new Thickets performance data table.
 
         Arguments:
             th_list (list): list of thickets
@@ -611,7 +611,7 @@ class Thicket(GraphFrame):
                 differ in value.
 
         Returns:
-            (thicket): superthicket
+            (thicket): New Thicket object.
         """
         # Pre-check of data structures
         for th in th_list:
@@ -667,7 +667,7 @@ class Thicket(GraphFrame):
             # Append copy to list
             th_copy_list.append(th_copy)
 
-        return Thicket.concat_thickets(th_copy_list, superthicket=True)
+        return Thicket.concat_thickets(th_copy_list, from_statsframes=True)
 
     def to_json(self, ensemble=True, metadata=True, stats=True):
         jsonified_thicket = {}

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -597,7 +597,7 @@ class Thicket(GraphFrame):
         )
 
     @staticmethod
-    def from_statsframes(th_list, profiles_from_meta=None):
+    def from_statsframes(th_list, metadata_key=None):
         """Compose a list of Thickets with data in their statsframes.
 
         The Thicket's individual aggregated statistics tables are ensembled and become the
@@ -605,7 +605,7 @@ class Thicket(GraphFrame):
 
         Arguments:
             th_list (list): list of thickets
-            profiles_from_meta (str, optional): name of the metadata column to use as
+            metadata_key (str, optional): name of the metadata column to use as
                 the new second-level index. Uses the first value so this only makes
                 sense if provided column is all equal values and each thicket's columns
                 differ in value.
@@ -624,17 +624,17 @@ class Thicket(GraphFrame):
 
         # Setup names list
         th_names = []
-        if profiles_from_meta is None:
+        if metadata_key is None:
             for i in range(len(th_list)):
                 th_names.append(i)
-        else:  # profiles_from_meta was provided.
+        else:  # metadata_key was provided.
             for th in th_list:
                 # Get name from metadata table
-                name_list = th.metadata[profiles_from_meta].tolist()
+                name_list = th.metadata[metadata_key].tolist()
 
                 if len(name_list) > 1:
                     warnings.warn(
-                        f"Multiple values for name {name_list} at thicket.metadata[{profiles_from_meta}]. Only the first will be used."
+                        f"Multiple values for name {name_list} at thicket.metadata[{metadata_key}]. Only the first will be used."
                     )
                 th_names.append(name_list[0])
 


### PR DESCRIPTION
Rename `make_superthicket` to `from_statsframes`. "Superthicket" is made-up jargon so we are moving away from this name. Also rename variable `profiles_from_meta` to `metadata_key` to match the ensemble functions.