### PR TITLE
Enable concat_thickets columns Profile Length Mismatch

### DIFF
--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -83,6 +83,15 @@ class Ensemble:
             if metadata_key:
                 for th in thickets:
                     verify_thicket_structures(th.metadata, columns=[metadata_key])
+            # Check length of profiles match if metadata key is not provided
+            if metadata_key is None:
+                for i in range(len(thickets) - 1):
+                    if len(thickets[i].profile) != len(thickets[i + 1].profile):
+                        raise ValueError(
+                            "Length of all thicket profiles must match if 'metadata_key' is not provided. {} != {}".format(
+                                len(thickets[i].profile), len(thickets[i + 1].profile)
+                            )
+                        )
             # Ensure all thickets profiles are sorted. Must be true when metadata_key=None to
             # guarantee performance data table and metadata table match up.
             if metadata_key is None:

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -83,14 +83,6 @@ class Ensemble:
             if metadata_key:
                 for th in thickets:
                     verify_thicket_structures(th.metadata, columns=[metadata_key])
-            # Check length of profiles match
-            for i in range(len(thickets) - 1):
-                if len(thickets[i].profile) != len(thickets[i + 1].profile):
-                    raise ValueError(
-                        "Length of all thicket profiles must match. {} != {}".format(
-                            len(thickets[i].profile), len(thickets[i + 1].profile)
-                        )
-                    )
             # Ensure all thickets profiles are sorted. Must be true when metadata_key=None to
             # guarantee performance data table and metadata table match up.
             if metadata_key is None:


### PR DESCRIPTION
This PR allows thickets with different amounts of profiles to be `concat_thicket(axis=columns)` only when `metadata_key` is provided. This is because when it isn't provided there is no way to match the different indices solely based on the profile hashes, since they are all disjoint.

There is no new feature as a part of this PR, it is simply a relaxation of the error check.