### PR TITLE
Updated percentile.py to allow user defined percentiles, and separating calculated values into separate columns

### DIFF
--- a/thicket/stats/percentiles.py
+++ b/thicket/stats/percentiles.py
@@ -9,12 +9,11 @@ from ..utils import verify_thicket_structures
 
 
 def percentiles(thicket, columns=None, percentiles=[0.25, 0.50, 0.75]):
-    """
-    Calculate the q-th percentile for each node in the performance data table.
+    """Calculate the q-th percentile for each node in the performance data table.
 
     Designed to take in a thicket, and append one or more columns to the aggregated
     statistics table for the q-th percentile calculation for each node. Each percentile
-    calculation is a seperate column in the statistics table, where the column will
+    calculation is a separate column in the statistics table, where the column will
     have the format: columnName_percentiles_percentile
 
     The 25th percentile is the lower quartile, and is the value at which 25% of the
@@ -35,10 +34,8 @@ def percentiles(thicket, columns=None, percentiles=[0.25, 0.50, 0.75]):
             for each column in columns. If no list is specified, the default values,
             [0.25, 0.50, 0.75] are used for calculations
     """
-    if percentiles is None:
-        raise ValueError(
-            "Percentiles can not be None, please specify which percentiles to calculate, or use the default values."
-        )
+    if not percentiles:
+        percentiles = [0.25, 0.50, 0.75]
 
     # Enforce that percentiles are in range of [0.0, 1.0]
     for percentile in percentiles:
@@ -65,8 +62,8 @@ def percentiles(thicket, columns=None, percentiles=[0.25, 0.50, 0.75]):
             calculated_percentiles = []
             for node in pd.unique(df.reset_index()["node"].tolist()):
                 calculated_percentiles.append(list(df.loc[node][column]))
-            for index, percentile in enumerate(percentiles):
 
+            for index, percentile in enumerate(percentiles):
                 column_to_append = column + "_percentiles_" + str(int(percentile * 100))
                 thicket.statsframe.dataframe[column_to_append] = [
                     x[index] for x in calculated_percentiles
@@ -98,7 +95,6 @@ def percentiles(thicket, columns=None, percentiles=[0.25, 0.50, 0.75]):
 
             # Go through each of the percentiles, and make them it's own column
             for index, percentile in enumerate(percentiles):
-
                 column_to_append = (
                     idx_level,
                     "{}_percentiles_{}".format(column, str(int(percentile * 100))),

--- a/thicket/stats/percentiles.py
+++ b/thicket/stats/percentiles.py
@@ -8,7 +8,7 @@ import pandas as pd
 from ..utils import verify_thicket_structures
 
 
-def percentiles(thicket, columns=None):
+def percentiles(thicket, columns=None, percentiles=[.25, .50, .75]):
     """Calculate the q-th percentile for each node in the performance data table.
 
     Designed to take in a thicket, and append one or more columns to the aggregated
@@ -29,6 +29,14 @@ def percentiles(thicket, columns=None):
             calculation on. Note if using a columnar joined thicket a list of tuples
             must be passed in with the format (column index, column name).
     """
+    if percentiles is None:
+        raise ValueError(
+            "Percentiles is empty, please specify which percentiles to calculate"
+        )
+    for percentile in percentiles:
+        if percentile < 0.0 or percentile > 1.0:
+            raise ValueError("Percentile {} is out of range of [0.0, 1.0]".format(percentile))
+
     if columns is None:
         raise ValueError(
             "To see a list of valid columns, run 'Thicket.performance_cols'."
@@ -40,36 +48,48 @@ def percentiles(thicket, columns=None):
     if thicket.dataframe.columns.nlevels == 1:
         # select numeric columns within thicket (.quantiles) will not work without this step
         numerics = ["int16", "int32", "int64", "float16", "float32", "float64"]
-        df_num = thicket.dataframe.select_dtypes(include=numerics)
-        df = df_num.reset_index().groupby("node").quantile([0.25, 0.50, 0.75])
+        df_num = thicket.dataframe.select_dtypes(include=numerics)[columns]
+        df = df_num.reset_index().groupby("node").quantile(percentiles)
         for column in columns:
-            percentiles = []
+            calculated_percentiles = []
             for node in pd.unique(df.reset_index()["node"].tolist()):
-                percentiles.append(list(df.loc[node][column]))
-            thicket.statsframe.dataframe[column + "_percentiles"] = percentiles
-            # check to see if exclusive metric
-            if column in thicket.exc_metrics:
-                thicket.statsframe.exc_metrics.append(column + "_percentiles")
-            # check to see if inclusive metric
-            else:
-                thicket.statsframe.inc_metrics.append(column + "_percentiles")
+                calculated_percentiles.append(list(df.loc[node][column]))
+            for index, percentile in enumerate(percentiles):
+                
+                column_to_append = column + "_percentiles_" + str(int(percentile * 100))
+                thicket.statsframe.dataframe[column_to_append] = [x[index] for x in calculated_percentiles]
+                
+                # check to see if exclusive metric and that the metric is not already in the metrics list
+                if column in thicket.exc_metrics and column_to_append not in thicket.statsframe.exc_metrics:
+                    thicket.statsframe.exc_metrics.append(column_to_append)
+                # check to see if inclusive metric
+                elif column in thicket.inc_metrics and column_to_append not in thicket.statsframe.inc_metrics:
+                    thicket.statsframe.inc_metrics.append(column_to_append)
+                
     # columnar joined thicket object
     else:
         numerics = ["int16", "int32", "int64", "float16", "float32", "float64"]
-        df_num = thicket.dataframe.select_dtypes(include=numerics)
-        df = df_num.reset_index(level=1).groupby("node").quantile([0.25, 0.50, 0.75])
-        percentiles = []
+        df_num = thicket.dataframe.select_dtypes(include=numerics)[columns]
+        df = df_num.reset_index(level=1).groupby("node").quantile(percentiles)
         for idx, column in columns:
-            percentiles = []
+            calculated_percentiles = []
+            
+            #Get all the calculated values into a list for each node
             for node in pd.unique(df.reset_index()["node"].tolist()):
-                percentiles.append(list(df.loc[node][(idx, column)]))
-            thicket.statsframe.dataframe[(idx, column + "_percentiles")] = percentiles
-            # check to see if exclusive metric
-            if (idx, column) in thicket.exc_metrics:
-                thicket.statsframe.exc_metrics.append((idx, column + "_percentiles"))
-            # check to see if inclusive metric
-            else:
-                thicket.statsframe.inc_metrics.append((idx, column + "_percentiles"))
+                calculated_percentiles.append(list(df.loc[node][(idx, column)]))
+            
+            #Go through each of the percentiles, and make them it's own column
+            for index, percentile in enumerate(percentiles):
+                
+                column_to_append = (idx, column + "_percentiles_" + str(int(percentile * 100)))
+                thicket.statsframe.dataframe[column_to_append] = [x[index] for x in calculated_percentiles]
+                
+                # check to see if exclusive metric
+                if (idx, column) in thicket.exc_metrics and column_to_append not in thicket.statsframe.exc_metrics:
+                    thicket.statsframe.exc_metrics.append(column_to_append)
+                # check to see if inclusive metric
+                elif (idx, column) in thicket.inc_metrics and column_to_append not in thicket.statsframe.inc_metrics:
+                    thicket.statsframe.inc_metrics.append(column_to_append)
 
         # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)

--- a/thicket/stats/percentiles.py
+++ b/thicket/stats/percentiles.py
@@ -14,7 +14,7 @@ def percentiles(thicket, columns=None, percentiles=[0.25, 0.50, 0.75]):
     Designed to take in a thicket, and append one or more columns to the aggregated
     statistics table for the q-th percentile calculation for each node. Each percentile
     calculation is a separate column in the statistics table, where the column will
-    have the format: columnName_percentiles_percentile
+    have the format: {columnName}_percentiles_{percentile}.
 
     The 25th percentile is the lower quartile, and is the value at which 25% of the
     answers lie below that value.

--- a/thicket/tests/test_stats.py
+++ b/thicket/tests/test_stats.py
@@ -226,6 +226,20 @@ def test_percentiles(example_cali):
     assert "Min time/rank_percentiles_50" in th_ens.statsframe.show_metric_columns()
     assert "Min time/rank_percentiles_75" in th_ens.statsframe.show_metric_columns()
 
+
+def test_percentiles_none(example_cali):
+    th_ens = th.Thicket.from_caliperreader(example_cali)
+
+    th.percentiles(th_ens, columns=["Min time/rank"], percentiles=None)
+
+    assert "Min time/rank_percentiles_25" in th_ens.statsframe.dataframe.columns
+    assert "Min time/rank_percentiles_50" in th_ens.statsframe.dataframe.columns
+    assert "Min time/rank_percentiles_75" in th_ens.statsframe.dataframe.columns
+
+
+def test_percentiles_single_value(example_cali):
+    th_ens = th.Thicket.from_caliperreader(example_cali)
+
     th.percentiles(th_ens, columns=["Min time/rank"], percentiles=[0.3])
 
     assert "Min time/rank_percentiles_30" in th_ens.statsframe.dataframe.columns

--- a/thicket/tests/test_stats.py
+++ b/thicket/tests/test_stats.py
@@ -206,14 +206,39 @@ def test_percentiles(example_cali):
 
     th.percentiles(th_ens, columns=["Min time/rank"])
 
-    assert "Min time/rank_percentiles" in th_ens.statsframe.dataframe.columns
-    assert len(th_ens.statsframe.dataframe["Min time/rank_percentiles"][0]) == 3
+    assert "Min time/rank_percentiles_25" in th_ens.statsframe.dataframe.columns
+    assert "Min time/rank_percentiles_50" in th_ens.statsframe.dataframe.columns
+    assert "Min time/rank_percentiles_75" in th_ens.statsframe.dataframe.columns
 
     assert (
-        "Min time/rank_percentiles"
+        "Min time/rank_percentiles_25"
         in th_ens.statsframe.exc_metrics + th_ens.statsframe.inc_metrics
     )
-    assert "Min time/rank_percentiles" in th_ens.statsframe.show_metric_columns()
+    assert (
+        "Min time/rank_percentiles_50"
+        in th_ens.statsframe.exc_metrics + th_ens.statsframe.inc_metrics
+    )
+    assert (
+        "Min time/rank_percentiles_75"
+        in th_ens.statsframe.exc_metrics + th_ens.statsframe.inc_metrics
+    )
+    assert "Min time/rank_percentiles_25" in th_ens.statsframe.show_metric_columns()
+    assert "Min time/rank_percentiles_50" in th_ens.statsframe.show_metric_columns()
+    assert "Min time/rank_percentiles_75" in th_ens.statsframe.show_metric_columns()
+
+
+    th.percentiles(th_ens, columns=["Min time/rank"], percentiles=[.3])
+    
+    assert "Min time/rank_percentiles_30" in th_ens.statsframe.dataframe.columns
+    
+    assert (
+        "Min time/rank_percentiles_30"
+        in th_ens.statsframe.exc_metrics + th_ens.statsframe.inc_metrics
+    )
+
+    assert "Min time/rank_percentiles_30" in th_ens.statsframe.show_metric_columns()
+
+
 
 
 def test_percentiles_columnar_join(thicket_axis_columns):
@@ -229,16 +254,57 @@ def test_percentiles_columnar_join(thicket_axis_columns):
 
     assert (
         idx,
-        "Min time/rank_percentiles",
+        "Min time/rank_percentiles_25",
     ) in combined_th.statsframe.dataframe.columns
     assert (
         idx,
-        "Min time/rank_percentiles",
+        "Min time/rank_percentiles_50",
+    ) in combined_th.statsframe.dataframe.columns
+    assert (
+        idx,
+        "Min time/rank_percentiles_75",
+    ) in combined_th.statsframe.dataframe.columns
+    assert (
+        idx,
+        "Min time/rank_percentiles_25",
     ) in combined_th.statsframe.exc_metrics + combined_th.statsframe.inc_metrics
     assert (
         idx,
-        "Min time/rank_percentiles",
+        "Min time/rank_percentiles_50",
+    ) in combined_th.statsframe.exc_metrics + combined_th.statsframe.inc_metrics
+    assert (
+        idx,
+        "Min time/rank_percentiles_75",
+    ) in combined_th.statsframe.exc_metrics + combined_th.statsframe.inc_metrics
+
+    assert (
+        idx,
+        "Min time/rank_percentiles_25",
     ) in combined_th.statsframe.show_metric_columns()
+    assert (
+        idx,
+        "Min time/rank_percentiles_50",
+    ) in combined_th.statsframe.show_metric_columns()
+    assert (
+        idx,
+        "Min time/rank_percentiles_75",
+    ) in combined_th.statsframe.show_metric_columns()
+    
+    th.percentiles(combined_th, columns=[(idx, "Min time/rank")], percentiles=[.4])
+        
+    assert (
+        idx,
+        "Min time/rank_percentiles_40",
+    ) in combined_th.statsframe.dataframe.columns
+    assert (
+        idx,
+        "Min time/rank_percentiles_40",
+    ) in combined_th.statsframe.exc_metrics + combined_th.statsframe.inc_metrics
+    assert (
+        idx,
+        "Min time/rank_percentiles_40",
+    ) in combined_th.statsframe.show_metric_columns()
+
 
 
 def test_variance(example_cali):

--- a/thicket/tests/test_stats.py
+++ b/thicket/tests/test_stats.py
@@ -226,19 +226,16 @@ def test_percentiles(example_cali):
     assert "Min time/rank_percentiles_50" in th_ens.statsframe.show_metric_columns()
     assert "Min time/rank_percentiles_75" in th_ens.statsframe.show_metric_columns()
 
+    th.percentiles(th_ens, columns=["Min time/rank"], percentiles=[0.3])
 
-    th.percentiles(th_ens, columns=["Min time/rank"], percentiles=[.3])
-    
     assert "Min time/rank_percentiles_30" in th_ens.statsframe.dataframe.columns
-    
+
     assert (
         "Min time/rank_percentiles_30"
         in th_ens.statsframe.exc_metrics + th_ens.statsframe.inc_metrics
     )
 
     assert "Min time/rank_percentiles_30" in th_ens.statsframe.show_metric_columns()
-
-
 
 
 def test_percentiles_columnar_join(thicket_axis_columns):
@@ -289,9 +286,9 @@ def test_percentiles_columnar_join(thicket_axis_columns):
         idx,
         "Min time/rank_percentiles_75",
     ) in combined_th.statsframe.show_metric_columns()
-    
-    th.percentiles(combined_th, columns=[(idx, "Min time/rank")], percentiles=[.4])
-        
+
+    th.percentiles(combined_th, columns=[(idx, "Min time/rank")], percentiles=[0.4])
+
     assert (
         idx,
         "Min time/rank_percentiles_40",
@@ -304,7 +301,6 @@ def test_percentiles_columnar_join(thicket_axis_columns):
         idx,
         "Min time/rank_percentiles_40",
     ) in combined_th.statsframe.show_metric_columns()
-
 
 
 def test_variance(example_cali):


### PR DESCRIPTION
I've updated percentile.py in order for the user to define what percentile values they would like calculated. If the user does not specify what percentile values to calculate, it uses the default values [.25, .50, .75].

Another fix made is that for each calculated percentile for each column, the calculated value is put into it's own separate column in the statistics frame with the format: column_percentiles_percentile instead of all the values in a list. 