### PR TITLE
Fixes several bugs in reader_dispatch

### DIFF
--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -224,23 +224,32 @@ class Thicket(GraphFrame):
         """
         ens_list = []
         obj = args[0]  # First arg should be readable object
+        extra_args = []
+        if len(args) > 1:
+            extra_args = args[1:]
 
         # Parse the input object
         # if a list of files
-        if type(obj) == list:
+        if isinstance(obj, (list, tuple)):
             for file in obj:
-                ens_list.append(Thicket.thicketize_graphframe(func(file), file))
+                ens_list.append(
+                    Thicket.thicketize_graphframe(
+                        func(file, *extra_args, **kwargs), file
+                    )
+                )
         # if directory of files
         elif os.path.isdir(obj):
             for file in os.listdir(obj):
                 f = os.path.join(obj, file)
-                ens_list.append(Thicket.thicketize_graphframe(func(f), f))
+                ens_list.append(
+                    Thicket.thicketize_graphframe(func(f, *extra_args, **kwargs), f)
+                )
         # if single file
         elif os.path.isfile(obj):
             return Thicket.thicketize_graphframe(func(*args, **kwargs), args[0])
         # Error checking
         else:
-            if type(obj) == str and not os.path.isfile(obj):
+            if isinstance(obj, str) and not os.path.isfile(obj):
                 raise FileNotFoundError("File '" + obj + "' not found.")
             else:
                 raise TypeError(


### PR DESCRIPTION
This PR fixes two bugs in `Thicket.reader_dispatch`.

First, it fixes type checking in the function. Currently, `reader_dispatch` uses `type(var) = expected_type`. This syntax may work in some cases. However, there is no guarantee it will work for all types, and the Python Software Foundation has reserved the right to completely invalidate this syntax in the future. This PR fixes this type checking by switching it to the more correct `isinstance(var, expected_type)` syntax.

Additionally, this PR fixes a bug in `Thicket.reader_dispatch` that would cause extra positional and keyword arguments to not be forwarded to the corresponding Hatchet function if the user passed in a list or tuple of filenames. This is particularly problematic for `Thicket.from_caliper` because it means the `query` argument is not forwarded to Hatchet, causing `Thicket.from_caliper` to fail in all cases.