### PR TITLE
Andrew updated violin plots

### DIFF
--- a/thicket/stats/display_violinplot.py
+++ b/thicket/stats/display_violinplot.py
@@ -35,7 +35,9 @@ def _add_percentile_lines(
     line_styles=None,
     line_colors=None,
 ):
-
+    # Error checking for types passed in by user:
+    # If percentiles is a list, then lines styles must be either a single value, or
+    # a list of values that match the length of the percentiles list. Same with line colors
     if isinstance(percentiles_vals, list):
         if isinstance(line_styles, list) is True:
             if len(percentiles_vals) != len(line_styles):
@@ -136,6 +138,7 @@ def _add_percentile_lines(
                         color=line_colors[idx],
                         linestyle=line_styles[idx],
                     )
+                    
                     # Get the violin structure
                     patch = mpl.patches.PathPatch(
                         graph.collections[violin_idx].get_paths()[0],

--- a/thicket/stats/display_violinplot.py
+++ b/thicket/stats/display_violinplot.py
@@ -29,6 +29,8 @@ def _add_percentile_lines_node(graph, thicket, nodes, columns, percentiles_vals,
                 stats_column = None
                 if type(column) == type(tuple()):
                     stats_column = (str(column[0]), "{}_percentiles_{}".format(column[1], int(percentile * 100)))
+                else:
+                    stats_column = "{}_percentiles_{}".format(column, int(percentile * 100))
                 #Call percentile(...) if the percentile value for the column has not been calculated already
                 if column in thicket.exc_metrics and stats_column not in thicket.statsframe.exc_metrics\
                     or\
@@ -45,7 +47,7 @@ def _add_percentile_lines_node(graph, thicket, nodes, columns, percentiles_vals,
 
     return graph
 
-def display_violinplot(thicket, nodes=[], columns=[], percentile_line_values = [], percentile_line_styles = [], percentile_line_colors = [], **kwargs):
+def display_violinplot(thicket, nodes=[], columns=[], percentiles = [], linestyles = [], linecolors = [], **kwargs):
     """Display a violinplot for each user passed node(s) and column(s). The passed nodes
     and columns must be from the performance data table.
 
@@ -71,6 +73,8 @@ def display_violinplot(thicket, nodes=[], columns=[], percentile_line_values = [
 
     verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)
 
+    filtered_df = None
+
     # thicket object without columnar index
     if thicket.dataframe.columns.nlevels == 1:
         df = pd.melt(
@@ -92,13 +96,6 @@ def display_violinplot(thicket, nodes=[], columns=[], percentile_line_values = [
         filtered_df = df.loc[position].rename(
             columns={"node": "hatchet node", "name": "node"}
         )
-
-        if len(columns) > 1:
-            return sns.violinplot(
-                data=filtered_df, x="node", y=" ", hue="Performance counter", **kwargs
-            )
-        else:
-            return sns.violinplot(data=filtered_df, x="node", y=" ", **kwargs)
     # columnar joined thicket object
     else:
 
@@ -135,35 +132,35 @@ def display_violinplot(thicket, nodes=[], columns=[], percentile_line_values = [
         # will be node names
         filtered_df = df.loc[position].rename(
             columns={"node": "hatchet node", "name": "node"}
-        )
+        )        
 
-        #User specified percentile value lines to plot
-        if len(percentile_line_values) != 0:
-            if len(columns) > 1:
-                return _add_percentile_lines_node(
-                        sns.violinplot( data=filtered_df, x="node", y=" ", hue="Performance counter", **kwargs), 
-                        thicket, 
-                        nodes, 
-                        columns, 
-                        percentile_line_values,
-                        percentile_line_styles,
-                        percentile_line_colors), filtered_df
-            else: 
-                return _add_percentile_lines_node(
-                        sns.violinplot(data=filtered_df, x="node", y=" ", **kwargs),
-                        thicket,
-                        nodes,
-                        columns,
-                        percentile_line_values,
-                        percentile_line_styles,
-                        percentile_line_colors)
-        else: #User did not specify percentiles, just return violinplot
-            if len(columns) > 1:
-                return sns.violinplot(
-                    data=filtered_df, x="node", y=" ", hue="Performance counter", **kwargs
-                ), filtered_df
-            else:
-                return sns.violinplot(data=filtered_df, x="node", y=" ", **kwargs)
+    #User specified percentile value lines to plot
+    if len(percentiles) != 0:
+        if len(columns) > 1:
+            return _add_percentile_lines_node(
+                    sns.violinplot( data=filtered_df, x="node", y=" ", hue="Performance counter", **kwargs), 
+                    thicket, 
+                    nodes, 
+                    columns, 
+                    percentiles,
+                    linestyles,
+                    linecolors), filtered_df
+        else:
+            return _add_percentile_lines_node(
+                    sns.violinplot(data=filtered_df, x="node", y=" ", **kwargs),
+                    thicket,
+                    nodes,
+                    columns,
+                    percentiles,
+                    linestyles,
+                    linecolors)
+    else: #User did not specify percentiles, just return violinplot
+        if len(columns) > 1:
+            return sns.violinplot(
+                data=filtered_df, x="node", y=" ", hue="Performance counter", **kwargs
+            ), filtered_df
+        else:
+            return sns.violinplot(data=filtered_df, x="node", y=" ", **kwargs)
 
 def display_violinplot_thicket(thicket_dictionary, nodes=None, columns=None, **kwargs):
     """Display a boxplot for each user passed node(s) and column(s). The passed nodes

--- a/thicket/stats/display_violinplot.py
+++ b/thicket/stats/display_violinplot.py
@@ -6,77 +6,124 @@
 import pandas as pd
 import seaborn as sns
 import hatchet as ht
-import numpy as np
 import matplotlib as mpl
 
 from .percentiles import percentiles
 from ..utils import verify_thicket_structures
 
+
 def _column_name_mapper(current_cols):
     """
-        Internal function that returns string representation of current_cols
+    Internal function that returns string representation of current_cols
 
-        Parameters:
-            current_cols: 
+    Parameters:
+        current_cols:
     """
     if current_cols[0] in ["node", "name"]:
         return current_cols[0]
 
     return str(current_cols)
 
-def _add_percentile_lines_node(graph, thicket, nodes, columns, percentiles_vals, lines_styles=None, line_colors = None):
+
+def _add_percentile_lines_node(
+    graph,
+    thicket,
+    nodes,
+    columns,
+    percentiles_vals,
+    lines_styles=None,
+    line_colors=None,
+):
 
     violin_idx = -1
 
-    #Default line styles and line colors
-    if lines_styles == None or len(lines_styles) < len(percentiles_vals):
-        lines_styles += ["-"] * (len(percentiles_vals - len(percentiles_vals)))
-    if line_colors == None or len(line_colors) < len(percentiles_vals):
-        line_colors += ["black"] * (len(percentiles_vals) - len(percentiles_vals))
+    # Default line styles and line colors
+    # If the user does not specify enough, default the missing values
+    if lines_styles is None:
+        lines_styles = ["--"] * len(percentiles_vals)
+    elif len(lines_styles) < len(percentiles_vals):
+        lines_styles += ["--"] * (len(percentiles_vals) - len(lines_styles))
+
+    if line_colors is None:
+        line_colors = ["black"] * len(percentiles_vals)
+    elif len(line_colors) < len(percentiles_vals):
+        line_colors += ["black"] * (len(percentiles_vals) - len(line_colors))
 
     for node in nodes:
         for column in columns:
             violin_idx += 1
             for idx, percentile in enumerate(percentiles_vals):
                 stats_column = None
-                #Columnar joined thickets
-                if type(column) == type(tuple()):
-                    stats_column = (str(column[0]), "{}_percentiles_{}".format(column[1], int(percentile * 100)))
-                #Non-columnar joined
+                # Columnar joined thickets
+                if isinstance(column, tuple):
+                    stats_column = (
+                        str(column[0]),
+                        "{}_percentiles_{}".format(column[1], int(percentile * 100)),
+                    )
+                # Non-columnar joined
                 else:
-                    stats_column = "{}_percentiles_{}".format(column, int(percentile * 100))
-                #Call percentile(...) if the percentile value for the column has not been calculated already
-                if column in thicket.exc_metrics and stats_column not in thicket.statsframe.exc_metrics\
-                    or\
-                    column in thicket.inc_metrics and stats_column not in thicket.statsframe.inc_metrics:
-                        percentiles(thicket, [column], [percentile])
+                    stats_column = "{}_percentiles_{}".format(
+                        column, int(percentile * 100)
+                    )
+                # Call percentile(...) if the percentile value for the column has not been calculated already
+                if (
+                    column in thicket.exc_metrics
+                    and stats_column not in thicket.statsframe.exc_metrics
+                    or column in thicket.inc_metrics
+                    and stats_column not in thicket.statsframe.inc_metrics
+                ):
+                    percentiles(thicket, [column], [percentile])
 
                 percentile_value = thicket.statsframe.dataframe[stats_column][node]
 
-                #Plot line
-                added_line = graph.axhline(y=percentile_value, color=line_colors[idx], linestyle = lines_styles[idx])
-                #Get the violin structure
-                patch =  mpl.patches.PathPatch(graph.collections[violin_idx].get_paths()[0], transform = graph.transData)
-                #Clip line to the violin structure
+                # Plot line
+                added_line = graph.axhline(
+                    y=percentile_value,
+                    color=line_colors[idx],
+                    linestyle=lines_styles[idx],
+                )
+                # Get the violin structure
+                patch = mpl.patches.PathPatch(
+                    graph.collections[violin_idx].get_paths()[0],
+                    transform=graph.transData,
+                )
+                # Clip line to the violin structure
                 added_line.set_clip_path(patch)
 
     return graph
 
 
-
-def display_violinplot(thicket, nodes=[], columns=[], percentiles = [], percentile_linestyles = [], percentile_colors = [], **kwargs):
-    """Display a violinplot for each user passed node(s) and column(s). The passed nodes
+def display_violinplot(
+    thicket,
+    nodes=[],
+    columns=[],
+    percentiles=[],
+    percentile_linestyles=[],
+    percentile_colors=[],
+    **kwargs,
+):
+    """
+    Display a violinplot for each user passed node(s) and column(s). The passed nodes
     and columns must be from the performance data table.
 
     Designed to take in a thicket, and display a plot with one or more violinplots
     depending on the number of nodes and columns passed.
 
     Arguments:
-        thicket (thicket): Thicket object
-        nodes (list): List of nodes to view on the x-axis
-        column (list): List of hardware/timing metrics to view on the y-axis. Note, if
+        thicket (thicket)   : Thicket object
+        nodes   (list)      : List of nodes to view on the x-axis
+        columns (list)      : List of hardware/timing metrics to view on the y-axis. Note, if
             using a columnar joined thicket a list of tuples must be passed in with the
             format (column index, column name).
+        percentiles (list)  : List of percentile values to plot for each violin plot.
+            Each value must be between [0.0, 1.0]. If the percentile value is not on the statistic table,
+            the percentile value will be calculated, and put on the statsframe
+        percentile_linestyles (list): List of line styles for the percentiles. If not provided, the default
+            line styles will be "--". If the list does not specify styles for each of the percentiles, the missing
+            styles will default to "--"
+        percentile_colors (list): List of colors to apply for percentile lines. The default value is "black",
+            If the list does not specify colors for each percentile, the missing colors will default to "black"
+        **kwargs: Arguments that can be passed to seaborns plotting function
 
     Returns:
         (matplotlib Axes): Object for managing violinplot.
@@ -136,126 +183,296 @@ def display_violinplot(thicket, nodes=[], columns=[], percentiles = [], percenti
         # will be node names
         filtered_df = df.loc[position].rename(
             columns={"node": "hatchet node", "name": "node"}
-        )        
+        )
 
-    #User specified percentile value lines to plot
+    # User specified percentile value lines to plot
     if len(percentiles) != 0:
+        graph = None
         if len(columns) > 1:
-            return _add_percentile_lines_node(
-                    sns.violinplot( data=filtered_df, x="node", y=" ", hue="Performance counter", **kwargs), 
-                    thicket, 
-                    nodes, 
-                    columns, 
-                    percentiles,
-                    linestyles,
-                    linecolors), filtered_df
+            graph = sns.violinplot(
+                data=filtered_df, x="node", y=" ", hue="Performance counter", **kwargs
+            )
         else:
-            return _add_percentile_lines_node(
-                    sns.violinplot(data=filtered_df, x="node", y=" ", **kwargs),
-                    thicket,
-                    nodes,
-                    columns,
-                    percentiles,
-                    linestyles,
-                    linecolors)
-    else: #User did not specify percentiles, just return violinplot
+            graph = sns.violinplot(data=filtered_df, x="node", y=" ", **kwargs)
+
+        return _add_percentile_lines_node(
+            graph,
+            thicket,
+            nodes,
+            columns,
+            percentiles,
+            percentile_linestyles,
+            percentile_colors,
+        )
+    # User did not specify percentiles, just return violinplot
+    else:
         if len(columns) > 1:
             return sns.violinplot(
                 data=filtered_df, x="node", y=" ", hue="Performance counter", **kwargs
-            ), filtered_df
+            )
         else:
             return sns.violinplot(data=filtered_df, x="node", y=" ", **kwargs)
 
 
+def _add_percentile_lines_thicket(
+    graph,
+    thickets,
+    nodes,
+    columns,
+    x_order,
+    percentiles_vals,
+    lines_styles=None,
+    line_colors=None,
+):
 
-def display_violinplot_thicket(thickets, nodes=None, columns=None, x_order = [], percentiles = [], percentile_linestyles = [], percentile_colors = [], **kwargs):
-    """Display a boxplot for each user passed node(s) and column(s). The passed nodes
-    and columns must be from the performance data table.
+    # Default line styles and line colors
+    # If the user does not specify enough, default the missing values
+    if lines_styles is None:
+        lines_styles = ["--"] * len(percentiles_vals)
+    elif len(lines_styles) < len(percentiles_vals):
+        lines_styles += ["--"] * (len(percentiles_vals) - len(lines_styles))
 
-    Designed to take in a thicket, and display a plot with one or more boxplots
-    depending on the number of nodes and columns passed.
+    if line_colors is None:
+        line_colors = ["black"] * len(percentiles_vals)
+    elif len(line_colors) < len(percentiles_vals):
+        line_colors += ["black"] * (len(percentiles_vals) - len(line_colors))
+
+    violin_idx = -1
+
+    for thicket_key in x_order:
+        thicket = thickets[thicket_key]
+        node = nodes[thicket_key]
+        columns_in = columns[thicket_key]
+
+        for column in columns_in:
+            violin_idx += 1
+            for idx, percentile in enumerate(percentiles_vals):
+                stats_column = None
+                # Columnar joined thickets
+                if isinstance(column, tuple):
+                    stats_column = (
+                        str(column[0]),
+                        "{}_percentiles_{}".format(column[1], int(percentile * 100)),
+                    )
+                # Non-columnar joined
+                else:
+                    stats_column = "{}_percentiles_{}".format(
+                        column, int(percentile * 100)
+                    )
+                # Call percentile(...) if the percentile value for the column has not been calculated already
+                if (
+                    column in thicket.exc_metrics
+                    and stats_column not in thicket.statsframe.exc_metrics
+                    or column in thicket.inc_metrics
+                    and stats_column not in thicket.statsframe.inc_metrics
+                ):
+                    percentiles(thicket, [column], [percentile])
+
+                percentile_value = thicket.statsframe.dataframe[stats_column][node]
+
+                # Plot line
+                added_line = graph.axhline(
+                    y=percentile_value,
+                    color=line_colors[idx],
+                    linestyle=lines_styles[idx],
+                )
+                # Get the violin structure
+                patch = mpl.patches.PathPatch(
+                    graph.collections[violin_idx].get_paths()[0],
+                    transform=graph.transData,
+                )
+                # Clip line to the violin structure
+                added_line.set_clip_path(patch)
+
+    return graph
+
+
+def display_violinplot_thicket(
+    thickets,
+    nodes=None,
+    columns=None,
+    x_order=None,
+    percentiles=[],
+    percentile_linestyles=[],
+    percentile_colors=[],
+    **kwargs,
+):
+    """
+    Display violinplots for each thicket passed in, where each thicket will have
+    a corresponding node specified in nodes. For each node, a violin will be plotted for
+    each column specified in the columns dictionary.
 
     Arguments:
-        thicket (dictionary): Thicket object
-        nodes (dictionaryu): List of nodes to view on the x-axis
-        column (dictionary): List of hardware/timing metrics to view on the y-axis. Note, if
-            using a columnar joined thicket a list of tuples must be passed in with the
-            format (column index, column name).
+        thickets (dict)  : Dictionary of thickets. The thickets in the dictionary must either be
+            all columnar joined thickets, or all non-columnar joined thickets, but not a mix of both.
+        nodes    (dict)  : Dictionary of a node to plot for each thicket in the thickets
+            dictionary. The keys must match for both the thickets dictionary and the nodes dictionary
+        columns  (dict)  : Dictionary of columns to plot for each thicket in the thickets
+            dictionary. The keys must match for both the thickets dictionary and the columns dictionary
+        x_order (list) : List of keys to use for plotting order. If this is none, the thickets that get
+            plotted will be in whatever order thickets.keys() returns.
+        percentiles (list)  : List of percentile values to plot for each violin plot.
+            Each value must be between [0.0, 1.0]. If the percentile value is not on the statistic table,
+            the percentile value will be calculated, and put on the statsframe. An internal call to percentiles(...)
+            will be done for you.
+        percentile_linestyles (list): List of line styles for the percentiles. If not provided, the default
+            line styles will be "--". If the list does not specify styles for each of the percentiles, the missing
+            styles will default to "--"
+        percentile_colors (list): List of colors to apply for percentile line. The default value is "black",
+            If the list does not specify colors for each percentile, the missing colors will default to "black"
+        **kwargs: Arguments that can be passed to seaborns violinplot function
 
     Returns:
-        (matplotlib Axes): Object for managing boxplot.
+        (matplotlib Axes): Object for managing violinplot.
     """
 
-    def column_name_mapper(current_cols):
-        if current_cols[0] in ["node", "name"]:
-            return current_cols[0]
+    # Ensure thickets, nodes, and columns are all dictionaries
+    if not isinstance(thickets, dict):
+        raise ValueError("thickets must be a dictionary of thickets")
 
-        return str(current_cols)
-
-    if nodes is None:
-        raise ValueError("Nodes must be a dictionary, specifying nodes for each Thicket passed in")
-
-    if columns is None:
-        raise ValueError("Columns must be a dictionary, specifying columns for each Thicket passed in")
-
-    #Ensures that both nodes and columns is a list of lists
-    if isinstance(dictionary, dict) == False or all(isinstance(n, list) for n in nodes.items()) == False:
-        raise ValueError("Nodes must be a list of lists, specifying nodes for each Thicket passed in")
-    
-    if isinstance(columns, dict) == False or all(isinstance(c, list) for c in columns.items()) == False:
-        raise ValueError("Nodes must be a list of lists, specifying nodes for each Thicket passed in")
-    
-    #Ensures that each Thicket has corresponding nodes, and columns. Otherwise throw an error
-    if len(thicket_dictionary) != len(columns):
-        raise ValueError("Length of columns does not match number of thickets")
-    if len(thicket_dictionary) != len(nodes):
-        raise ValueError("Length of nodes does not match number of thickets")
-
-    #Verify that each node in the nodes lists are node types
-    for node_list in nodes:
-        if not all(isinstance(n, ht.node.Node) for n in node_list):
-            raise ValueError(
-                "Value(s) passed to node argument must be of type hatchet.node.Node."
-            )
-
-    for idx, thicket in enumerate(thicket_dictionary.items()):
-        verify_thicket_structures(thicket[1].dataframe, index=["node"], columns=columns[idx])
-    
-    filtered_dfs = [None] * len(thicket_dictionary) #Holds the final dataframe for each thicket that we will plot
-    sub_dataframes = [None] * len(thicket_dictionary) #Holds the intermediate dataframe for each thicket
-
-    for curr_thicket_indx, thicket in enumerate(thicket_dictionary.items()):
-        cols = [str(c) for c in columns[curr_thicket_indx]]
-        sub_dataframes[curr_thicket_indx] = thicket[1].dataframe[[("name", ""), *columns[curr_thicket_indx]]].reset_index()
-        sub_dataframes[curr_thicket_indx].columns = sub_dataframes[curr_thicket_indx].columns.to_flat_index().map(column_name_mapper)
-        sub_dataframes[curr_thicket_indx]["name"] = thicket[1].dataframe["name"].tolist()
-        
-        melted_df = pd.melt(
-            sub_dataframes[curr_thicket_indx],
-            id_vars=["node", "name"],
-            value_vars=cols,
-            var_name="Performance counter",
-            value_name=" ",
+    if not isinstance(nodes, dict):
+        raise ValueError(
+            "Nodes must be a dictionary, specifying a node for each Thicket passed in"
         )
 
-        position = []
+    if isinstance(columns, dict) is False:
+        raise ValueError(
+            "columns must be a dictionary, specifying columns for each Thicket passed in"
+        )
 
-        #Grab the indices of the nodes that we are interested in
-        for node in nodes[curr_thicket_indx]:
+    if all(isinstance(c, list) for c in columns.values()) is False:
+        raise ValueError("Columns dictionary must have list of columns as values")
+
+    # Ensure that if x_order is not None, that it is a list!
+    if x_order is not None and isinstance(x_order, list) is False:
+        raise ValueError("x_order must be a list of keys")
+
+    # Ensure equal number of thickets and corresponding nodes and columns
+    if len(thickets) != len(nodes):
+        raise ValueError("Length of nodes must match number of thickets")
+
+    if len(thickets) != len(columns):
+        raise ValueError("Length of columns must match number of thickets")
+
+    # Verify that each node in the nodes lists are node types
+    if all(isinstance(n, ht.node.Node) for n in list(nodes.values())) is False:
+        raise ValueError(
+            "Value(s) passed to nodes argument must be of type hatchet.node.Node."
+        )
+
+    # Verify each thicket has corresponding columns
+    for idx, key in enumerate(thickets.keys()):
+        verify_thicket_structures(
+            thickets[key].dataframe, index=["node"], columns=columns[key]
+        )
+
+    # Check to see if ALL the keys across dictionaries are the same, and if x_order is not None
+    # the keys must match the thickets dictionary keys
+    if set(thickets.keys()) != set(nodes.keys()):
+        raise ValueError(
+            "Keys in nodes dictionary do not match keys in thickets dictionary"
+        )
+    if set(thickets.keys()) != set(columns.keys()):
+        raise ValueError(
+            "Keys in columns dictionary do not match keys in thickets dictionary"
+        )
+    if x_order is not None and set(thickets.keys()) != set(x_order):
+        raise ValueError(
+            "Keys listed in x_order do not match keys in thickets dictionary"
+        )
+
+    # Now check that all the thickets are either all columnar joined thickets, OR, they are all non-columnar joined thickets
+    # We should not be comparing thickets that are not of the same type.
+    columnar_joined_found = False
+    noncolumnar_joined_found = False
+
+    for thicket in thickets.values():
+        if thicket.dataframe.columns.nlevels == 1:
+            noncolumnar_joined_found = True
+        elif thicket.dataframe.columns.nlevels == 2:
+            columnar_joined_found = True
+
+        if noncolumnar_joined_found and columnar_joined_found:
+            raise ValueError(
+                "Thickets dictionary can not contain both columnar joined thickets and non-columnar joined thickets"
+            )
+
+    # Get thicket key order
+    x_order = list(thickets.keys()) if x_order is None else x_order
+
+    # Holds the final dataframe for each thicket that we will plot
+    filtered_dfs = [None] * len(thickets)
+
+    # Holds the intermediate dataframe for each thicket
+    sub_dataframe = None
+
+    for thicket_idx, key in enumerate(x_order):
+
+        thicket = thickets[key]
+        node = nodes[key]
+        in_columns = columns[key]
+
+        # non-columnar joined thicket
+        if thicket.dataframe.columns.nlevels == 1:
+            melted_df = pd.melt(
+                thicket.dataframe.reset_index(),
+                id_vars=["node", "name"],
+                value_vars=in_columns,
+                var_name="Performance counter",
+                value_name=" ",
+            )
+
             idx_c = melted_df.index[melted_df["node"] == node]
-            for pos in idx_c:
-                position.append(pos)
+            position = [p for p in idx_c]
+            filtered_dfs[thicket_idx] = melted_df.loc[position].rename(
+                columns={"node": "hatchet node", "name": "node"}
+            )
+            thicket_name = [str(key)] * len(filtered_dfs[thicket_idx]["node"])
+            filtered_dfs[thicket_idx]["node"] = thicket_name
+        # Columnar joined thicket
+        else:
 
-        # rename columns such that the x-axis label is "node" and not "name", tick marks
-        # will be node names
-        # This is where we grab the actual data for a node that was passed in!
-        filtered_dfs[curr_thicket_indx] = melted_df.loc[position].rename( columns={"node": "hatchet node", "name": "node"})
-        thicket_name = [str(thicket[0]) + str()] * len(filtered_dfs[curr_thicket_indx]["node"])
-        filtered_dfs[curr_thicket_indx]["node"] = thicket_name
-        #display(filtered_dfs[curr_thicket_indx])
+            cols = [str(c) for c in in_columns]
+            sub_dataframe = thicket.dataframe[[("name", ""), *in_columns]].reset_index()
+            sub_dataframe.columns = sub_dataframe.columns.to_flat_index().map(
+                _column_name_mapper
+            )
+            sub_dataframe["name"] = thicket.dataframe["name"].tolist()
+
+            melted_df = pd.melt(
+                sub_dataframe,
+                id_vars=["node", "name"],
+                value_vars=cols,
+                var_name="Performance counter",
+                value_name=" ",
+            )
+
+            idx_c = melted_df.index[melted_df["node"] == node]
+            position = [p for p in idx_c]
+            filtered_dfs[thicket_idx] = melted_df.loc[position].rename(
+                columns={"node": "hatchet node", "name": "node"}
+            )
+            thicket_name = [str(key)] * len(filtered_dfs[thicket_idx]["node"])
+            filtered_dfs[thicket_idx]["node"] = thicket_name
 
     master_df = pd.concat(filtered_dfs, ignore_index=True)
-   
-    #display(master_df)
 
-    return sns.violinplot( data=master_df, x="node", y=" ", hue="Performance counter", **kwargs)
+    graph = sns.violinplot(
+        data=master_df, x="node", y=" ", hue="Performance counter", inner=None, **kwargs
+    )
+
+    # No percentiles to plot!
+    if len(percentiles) == 0:
+        return graph
+    # Percentiles need to be plotted
+    else:
+        return _add_percentile_lines_thicket(
+            graph,
+            thickets,
+            nodes,
+            columns,
+            x_order,
+            percentiles,
+            percentile_linestyles,
+            percentile_colors,
+        )

--- a/thicket/stats/display_violinplot.py
+++ b/thicket/stats/display_violinplot.py
@@ -11,7 +11,6 @@ import matplotlib as mpl
 from .percentiles import percentiles
 from ..utils import verify_thicket_structures
 
-
 def _column_name_mapper(current_cols):
     """
     Internal function that returns string representation of current_cols
@@ -25,70 +24,125 @@ def _column_name_mapper(current_cols):
     return str(current_cols)
 
 
-def _add_percentile_lines_node(
+def _add_percentile_lines(
     graph,
-    thicket,
+    graphType,
+    thickets,
     nodes,
     columns,
+    x_order,
     percentiles_vals,
-    lines_styles=None,
+    line_styles=None,
     line_colors=None,
 ):
 
+    if isinstance(percentiles_vals, list):
+        if isinstance(line_styles, list) is True:
+            if len(percentiles_vals) != len(line_styles):
+                raise ValueError("Length of line styles does not match length of percentiles")
+        elif line_styles == None:
+            line_styles = ["--"] * len(percentiles_vals)
+        elif isinstance(line_styles, str):
+            line_styles = [line_styles] * len(percentiles_vals)
+        else:
+            raise ValueError("line_styles must be either None, list, or a str")
+
+        if isinstance(line_colors, list) is True:
+            if len(percentiles_vals) != len(line_colors):
+                raise ValueError("Length of line colors does not match length of percentiles")
+        # Default line color
+        elif line_colors == None:
+            line_colors = ["black"] * len(percentiles_vals)
+        elif isinstance(line_colors, str):
+            line_colors = [line_colors] * len(percentiles_vals)
+        else:
+            raise ValueError("line_colors must be either None, list, or a str")
+    
+    # A single value was passed into percentiles, line color/style must then be either a single
+    #   str value, or None. Otherwise throw an error
+    elif isinstance(percentiles_vals, float):
+        if isinstance(line_styles, str) is True:
+            line_styles = [line_styles]
+        elif line_styles == None:
+            line_styles = ["--"]
+        else:
+            raise ValueError("Percentiles was specified as a single value, line_style must be either a str, or None")
+
+        if isinstance(line_colors, str) is True:
+            line_colors = [line_colors]
+        elif line_colors == None:
+            line_colors = ["black"]
+        else:
+            raise ValueError("Percentiles was specified as a single value, line_colors must be either a str, or None")
+        
+        percentiles_vals = [percentiles_vals]
+    
+    else:
+        raise ValueError("percentiles_vals must be either a list of floats, or a single float value!")
+
     violin_idx = -1
 
-    # Default line styles and line colors
-    # If the user does not specify enough, default the missing values
-    if lines_styles is None:
-        lines_styles = ["--"] * len(percentiles_vals)
-    elif len(lines_styles) < len(percentiles_vals):
-        lines_styles += ["--"] * (len(percentiles_vals) - len(lines_styles))
+    # Check the type of the graph being developed.
+    # If this function was called from display_violinplot(...)
+    # Graph type should be "NODE", and we set dummy dictionaries
+    # of the inputs in order to work with the display_violinplot_thickets(...)
+    # structure of this function
+    if graphType == "NODE":
+        thickets = {"IGNORE" : thickets}
+        nodes = {"IGNORE": nodes}
+        columns = {"IGNORE": columns}
+        x_order = ["IGNORE"]
 
-    if line_colors is None:
-        line_colors = ["black"] * len(percentiles_vals)
-    elif len(line_colors) < len(percentiles_vals):
-        line_colors += ["black"] * (len(percentiles_vals) - len(line_colors))
+    for thicket_key in x_order:
+        thicket = thickets[thicket_key]
+        nodes_in = nodes[thicket_key]
+        columns_in = columns[thicket_key]
 
-    for node in nodes:
-        for column in columns:
-            violin_idx += 1
-            for idx, percentile in enumerate(percentiles_vals):
-                stats_column = None
-                # Columnar joined thickets
-                if isinstance(column, tuple):
-                    stats_column = (
-                        str(column[0]),
-                        "{}_percentiles_{}".format(column[1], int(percentile * 100)),
+        # Make a list of a singular node since display_violinplot_thicket(...) takes
+        # in a dictionary where the value is a singluar Node. display_violinplot(...)
+        # Takes in a list of thickets, so the conversion doesn't need to happen. 
+        if graphType == "THICKET":
+            nodes_in = [nodes_in]
+
+        for node in nodes_in:
+            for column in columns_in:
+                violin_idx += 1
+                for idx, percentile in enumerate(percentiles_vals):
+                    stats_column = None
+                    # Columnar joined thickets
+                    if isinstance(column, tuple):
+                        stats_column = (
+                            str(column[0]),
+                            "{}_percentiles_{}".format(column[1], int(percentile * 100)),
+                        )
+                    # Non-columnar joined
+                    else:
+                        stats_column = "{}_percentiles_{}".format(
+                            column, int(percentile * 100)
+                        )
+                    
+                    # Call percentile(...) if the percentile value for the column has not been calculated already
+                    if stats_column not in thicket.statsframe.dataframe.columns.tolist():
+                        percentiles(thicket, [column], [percentile])
+
+                    percentile_value = thicket.statsframe.dataframe[stats_column][node]
+
+                    # Customizing plotting code was taken from a stack overflow post:
+                    #    https://stackoverflow.com/a/67333021
+
+                    # Plot line
+                    added_line = graph.axhline(
+                        y=percentile_value,
+                        color=line_colors[idx],
+                        linestyle=line_styles[idx],
                     )
-                # Non-columnar joined
-                else:
-                    stats_column = "{}_percentiles_{}".format(
-                        column, int(percentile * 100)
+                    # Get the violin structure
+                    patch = mpl.patches.PathPatch(
+                        graph.collections[violin_idx].get_paths()[0],
+                        transform=graph.transData,
                     )
-                # Call percentile(...) if the percentile value for the column has not been calculated already
-                if (
-                    column in thicket.exc_metrics
-                    and stats_column not in thicket.statsframe.exc_metrics
-                    or column in thicket.inc_metrics
-                    and stats_column not in thicket.statsframe.inc_metrics
-                ):
-                    percentiles(thicket, [column], [percentile])
-
-                percentile_value = thicket.statsframe.dataframe[stats_column][node]
-
-                # Plot line
-                added_line = graph.axhline(
-                    y=percentile_value,
-                    color=line_colors[idx],
-                    linestyle=lines_styles[idx],
-                )
-                # Get the violin structure
-                patch = mpl.patches.PathPatch(
-                    graph.collections[violin_idx].get_paths()[0],
-                    transform=graph.transData,
-                )
-                # Clip line to the violin structure
-                added_line.set_clip_path(patch)
+                    # Clip line to the violin structure
+                    added_line.set_clip_path(patch)
 
     return graph
 
@@ -97,9 +151,9 @@ def display_violinplot(
     thicket,
     nodes=[],
     columns=[],
-    percentiles=[],
-    percentile_linestyles=[],
-    percentile_colors=[],
+    percentiles=None,
+    percentile_linestyles=None,
+    percentile_colors=None,
     **kwargs,
 ):
     """
@@ -185,107 +239,31 @@ def display_violinplot(
             columns={"node": "hatchet node", "name": "node"}
         )
 
-    # User specified percentile value lines to plot
-    if len(percentiles) != 0:
-        graph = None
-        if len(columns) > 1:
-            graph = sns.violinplot(
-                data=filtered_df, x="node", y=" ", hue="Performance counter", **kwargs
-            )
-        else:
-            graph = sns.violinplot(data=filtered_df, x="node", y=" ", **kwargs)
+    graph = None
 
-        return _add_percentile_lines_node(
+    if len(columns) > 1:
+        graph =  sns.violinplot(
+            data=filtered_df, x="node", y=" ", hue="Performance counter", **kwargs
+        )
+    else:
+        graph = sns.violinplot(data=filtered_df, x="node", y=" ", **kwargs)
+    
+    # User specified percentile value lines to plot
+    if percentiles is not None:
+        return _add_percentile_lines(
             graph,
+            "NODE",
             thicket,
             nodes,
             columns,
+            [],
             percentiles,
             percentile_linestyles,
             percentile_colors,
         )
     # User did not specify percentiles, just return violinplot
     else:
-        if len(columns) > 1:
-            return sns.violinplot(
-                data=filtered_df, x="node", y=" ", hue="Performance counter", **kwargs
-            )
-        else:
-            return sns.violinplot(data=filtered_df, x="node", y=" ", **kwargs)
-
-
-def _add_percentile_lines_thicket(
-    graph,
-    thickets,
-    nodes,
-    columns,
-    x_order,
-    percentiles_vals,
-    lines_styles=None,
-    line_colors=None,
-):
-
-    # Default line styles and line colors
-    # If the user does not specify enough, default the missing values
-    if lines_styles is None:
-        lines_styles = ["--"] * len(percentiles_vals)
-    elif len(lines_styles) < len(percentiles_vals):
-        lines_styles += ["--"] * (len(percentiles_vals) - len(lines_styles))
-
-    if line_colors is None:
-        line_colors = ["black"] * len(percentiles_vals)
-    elif len(line_colors) < len(percentiles_vals):
-        line_colors += ["black"] * (len(percentiles_vals) - len(line_colors))
-
-    violin_idx = -1
-
-    for thicket_key in x_order:
-        thicket = thickets[thicket_key]
-        node = nodes[thicket_key]
-        columns_in = columns[thicket_key]
-
-        for column in columns_in:
-            violin_idx += 1
-            for idx, percentile in enumerate(percentiles_vals):
-                stats_column = None
-                # Columnar joined thickets
-                if isinstance(column, tuple):
-                    stats_column = (
-                        str(column[0]),
-                        "{}_percentiles_{}".format(column[1], int(percentile * 100)),
-                    )
-                # Non-columnar joined
-                else:
-                    stats_column = "{}_percentiles_{}".format(
-                        column, int(percentile * 100)
-                    )
-                # Call percentile(...) if the percentile value for the column has not been calculated already
-                if (
-                    column in thicket.exc_metrics
-                    and stats_column not in thicket.statsframe.exc_metrics
-                    or column in thicket.inc_metrics
-                    and stats_column not in thicket.statsframe.inc_metrics
-                ):
-                    percentiles(thicket, [column], [percentile])
-
-                percentile_value = thicket.statsframe.dataframe[stats_column][node]
-
-                # Plot line
-                added_line = graph.axhline(
-                    y=percentile_value,
-                    color=line_colors[idx],
-                    linestyle=lines_styles[idx],
-                )
-                # Get the violin structure
-                patch = mpl.patches.PathPatch(
-                    graph.collections[violin_idx].get_paths()[0],
-                    transform=graph.transData,
-                )
-                # Clip line to the violin structure
-                added_line.set_clip_path(patch)
-
-    return graph
-
+        return graph
 
 def display_violinplot_thicket(
     thickets,
@@ -407,7 +385,6 @@ def display_violinplot_thicket(
     sub_dataframe = None
 
     for thicket_idx, key in enumerate(x_order):
-
         thicket = thickets[key]
         node = nodes[key]
         in_columns = columns[key]
@@ -431,7 +408,6 @@ def display_violinplot_thicket(
             filtered_dfs[thicket_idx]["node"] = thicket_name
         # Columnar joined thicket
         else:
-
             cols = [str(c) for c in in_columns]
             sub_dataframe = thicket.dataframe[[("name", ""), *in_columns]].reset_index()
             sub_dataframe.columns = sub_dataframe.columns.to_flat_index().map(
@@ -466,8 +442,9 @@ def display_violinplot_thicket(
         return graph
     # Percentiles need to be plotted
     else:
-        return _add_percentile_lines_thicket(
+        return _add_percentile_lines(
             graph,
+            "THICKET",
             thickets,
             nodes,
             columns,

--- a/thicket/stats/display_violinplot.py
+++ b/thicket/stats/display_violinplot.py
@@ -170,7 +170,7 @@ def display_violinplot_thicket(thicket_dictionary, nodes=None, columns=None, **k
     for curr_thicket_indx, thicket in enumerate(thicket_dictionary.items()):
         cols = [str(c) for c in columns[curr_thicket_indx]]
         sub_dataframes[curr_thicket_indx] = thicket[1].dataframe[[("name", ""), *columns[curr_thicket_indx]]].reset_index()
-        sub_dataframes[curr_thicket_indx].columns = sub_dataframes[idx].columns.to_flat_index().map(column_name_mapper)
+        sub_dataframes[curr_thicket_indx].columns = sub_dataframes[curr_thicket_indx].columns.to_flat_index().map(column_name_mapper)
         sub_dataframes[curr_thicket_indx]["name"] = thicket[1].dataframe["name"].tolist()
         
         melted_df = pd.melt(
@@ -191,16 +191,14 @@ def display_violinplot_thicket(thicket_dictionary, nodes=None, columns=None, **k
 
         # rename columns such that the x-axis label is "node" and not "name", tick marks
         # will be node names
-        #This is where we grab the actual data for a node that was passed in!
-        filtered_dfs[idx] = melted_df.loc[position].rename( columns={"node": "hatchet node", "name": "node"})
-        thicket_name = [str(thicket[0])] * len(filtered_dfs[idx]["node"])
-        filtered_dfs[idx]["node"] = thicket_name
-        display(filtered_dfs[idx])
+        # This is where we grab the actual data for a node that was passed in!
+        filtered_dfs[curr_thicket_indx] = melted_df.loc[position].rename( columns={"node": "hatchet node", "name": "node"})
+        thicket_name = [str(thicket[0]) + str()] * len(filtered_dfs[curr_thicket_indx]["node"])
+        filtered_dfs[curr_thicket_indx]["node"] = thicket_name
+        #display(filtered_dfs[curr_thicket_indx])
 
     master_df = pd.concat(filtered_dfs, ignore_index=True)
-    if set_y_axis_log == True:
-        master_df[" "] = np.log(master_df[" "])
-    # 
-    display(master_df)
+   
+    #display(master_df)
 
     return sns.violinplot( data=master_df, x="node", y=" ", hue="Performance counter", **kwargs)

--- a/thicket/stats/display_violinplot.py
+++ b/thicket/stats/display_violinplot.py
@@ -7,14 +7,16 @@ import pandas as pd
 import seaborn as sns
 import hatchet as ht
 import plotly.express as px
+import numpy as np
 
+from .percentiles import percentiles
 from ..utils import verify_thicket_structures
 
 def display_violinplot(thicket, nodes=[], columns=[], **kwargs):
-    """Display a boxplot for each user passed node(s) and column(s). The passed nodes
+    """Display a violinplot for each user passed node(s) and column(s). The passed nodes
     and columns must be from the performance data table.
 
-    Designed to take in a thicket, and display a plot with one or more boxplots
+    Designed to take in a thicket, and display a plot with one or more violinplots
     depending on the number of nodes and columns passed.
 
     Arguments:
@@ -25,10 +27,9 @@ def display_violinplot(thicket, nodes=[], columns=[], **kwargs):
             format (column index, column name).
 
     Returns:
-        (matplotlib Axes): Object for managing boxplot.
+        (matplotlib Axes): Object for managing violinplot.
     """
 
-    print(kwargs)
     for node in nodes:
         if not isinstance(node, ht.node.Node):
             raise ValueError(
@@ -66,9 +67,6 @@ def display_violinplot(thicket, nodes=[], columns=[], **kwargs):
         else:
             return sns.violinplot(data=filtered_df, x="node", y=" ", **kwargs)
     # columnar joined thicket object
-
-    #Pave meeting: Discuss what melting function is doing, 
-
     else:
 
         """
@@ -105,13 +103,104 @@ def display_violinplot(thicket, nodes=[], columns=[], **kwargs):
         filtered_df = df.loc[position].rename(
             columns={"node": "hatchet node", "name": "node"}
         )
-        # print(filtered_df)
-        # print(filtered_df.columns)
         if len(columns) > 1:
-            #return px.violin(filtered_df)
-            #return px.violin(filtered_df, x="node", y=' ', box=True, points="all", hover_data=['Category'], title='Violin Plot')
             return sns.violinplot(
                 data=filtered_df, x="node", y=" ", hue="Performance counter", **kwargs
-            )
+            ), filtered_df
         else:
             return sns.violinplot(data=filtered_df, x="node", y=" ", **kwargs)
+
+
+def display_violinplot_thicket(thicket_dictionary, nodes=None, columns=None, **kwargs):
+    """Display a boxplot for each user passed node(s) and column(s). The passed nodes
+    and columns must be from the performance data table.
+
+    Designed to take in a thicket, and display a plot with one or more boxplots
+    depending on the number of nodes and columns passed.
+
+    Arguments:
+        thicket (thicket): Thicket object
+        nodes (list): List of nodes to view on the x-axis
+        column (list): List of hardware/timing metrics to view on the y-axis. Note, if
+            using a columnar joined thicket a list of tuples must be passed in with the
+            format (column index, column name).
+
+    Returns:
+        (matplotlib Axes): Object for managing boxplot.
+    """
+
+    def column_name_mapper(current_cols):
+        if current_cols[0] in ["node", "name"]:
+            return current_cols[0]
+
+        return str(current_cols)
+
+    if nodes is None:
+        raise ValueError("Nodes must be a list of lists, specifying nodes for each Thicket passed in")
+
+    if columns is None:
+        raise ValueError("Columns must be a list of lists, specifying columns for each Thicket passed in")
+
+    #Ensures that both nodes and columns is a list of lists
+    if isinstance(nodes, list) == False or all(isinstance(n, list) for n in nodes) == False:
+        raise ValueError("Nodes must be a list of lists, specifying nodes for each Thicket passed in")
+    
+    if isinstance(columns, list) == False or all(isinstance(c, list) for c in columns) == False:
+        raise ValueError("Nodes must be a list of lists, specifying nodes for each Thicket passed in")
+    
+    #Ensures that each Thicket has corresponding nodes, and columns. Otherwise throw an error
+    if len(thicket_dictionary) != len(columns):
+        raise ValueError("Length of columns does not match number of thickets")
+    if len(thicket_dictionary) != len(nodes):
+        raise ValueError("Length of nodes does not match number of thickets")
+
+    #Verify that each node in the nodes lists are node types
+    for node_list in nodes:
+        if not all(isinstance(n, ht.node.Node) for n in node_list):
+            raise ValueError(
+                "Value(s) passed to node argument must be of type hatchet.node.Node."
+            )
+
+    for idx, thicket in enumerate(thicket_dictionary.items()):
+        verify_thicket_structures(thicket[1].dataframe, index=["node"], columns=columns[idx])
+    
+    filtered_dfs = [None] * len(thicket_dictionary) #Holds the final dataframe for each thicket that we will plot
+    sub_dataframes = [None] * len(thicket_dictionary) #Holds the intermediate dataframe for each thicket
+
+    for curr_thicket_indx, thicket in enumerate(thicket_dictionary.items()):
+        cols = [str(c) for c in columns[curr_thicket_indx]]
+        sub_dataframes[curr_thicket_indx] = thicket[1].dataframe[[("name", ""), *columns[curr_thicket_indx]]].reset_index()
+        sub_dataframes[curr_thicket_indx].columns = sub_dataframes[idx].columns.to_flat_index().map(column_name_mapper)
+        sub_dataframes[curr_thicket_indx]["name"] = thicket[1].dataframe["name"].tolist()
+        
+        melted_df = pd.melt(
+            sub_dataframes[curr_thicket_indx],
+            id_vars=["node", "name"],
+            value_vars=cols,
+            var_name="Performance counter",
+            value_name=" ",
+        )
+
+        position = []
+
+        #Grab the indices of the nodes that we are interested in
+        for node in nodes[curr_thicket_indx]:
+            idx_c = melted_df.index[melted_df["node"] == node]
+            for pos in idx_c:
+                position.append(pos)
+
+        # rename columns such that the x-axis label is "node" and not "name", tick marks
+        # will be node names
+        #This is where we grab the actual data for a node that was passed in!
+        filtered_dfs[idx] = melted_df.loc[position].rename( columns={"node": "hatchet node", "name": "node"})
+        thicket_name = [str(thicket[0])] * len(filtered_dfs[idx]["node"])
+        filtered_dfs[idx]["node"] = thicket_name
+        display(filtered_dfs[idx])
+
+    master_df = pd.concat(filtered_dfs, ignore_index=True)
+    if set_y_axis_log == True:
+        master_df[" "] = np.log(master_df[" "])
+    # 
+    display(master_df)
+
+    return sns.violinplot( data=master_df, x="node", y=" ", hue="Performance counter", **kwargs)

--- a/thicket/stats/display_violinplot.py
+++ b/thicket/stats/display_violinplot.py
@@ -1,0 +1,117 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Thicket Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import pandas as pd
+import seaborn as sns
+import hatchet as ht
+import plotly.express as px
+
+from ..utils import verify_thicket_structures
+
+def display_violinplot(thicket, nodes=[], columns=[], **kwargs):
+    """Display a boxplot for each user passed node(s) and column(s). The passed nodes
+    and columns must be from the performance data table.
+
+    Designed to take in a thicket, and display a plot with one or more boxplots
+    depending on the number of nodes and columns passed.
+
+    Arguments:
+        thicket (thicket): Thicket object
+        nodes (list): List of nodes to view on the x-axis
+        column (list): List of hardware/timing metrics to view on the y-axis. Note, if
+            using a columnar joined thicket a list of tuples must be passed in with the
+            format (column index, column name).
+
+    Returns:
+        (matplotlib Axes): Object for managing boxplot.
+    """
+
+    print(kwargs)
+    for node in nodes:
+        if not isinstance(node, ht.node.Node):
+            raise ValueError(
+                "Value(s) passed to node argument must be of type hatchet.node.Node."
+            )
+
+    verify_thicket_structures(thicket.dataframe, index=["node"], columns=columns)
+
+    # thicket object without columnar index
+    if thicket.dataframe.columns.nlevels == 1:
+        df = pd.melt(
+            thicket.dataframe.reset_index(),
+            id_vars=["node", "name"],
+            value_vars=columns,
+            var_name="Performance counter",
+            value_name=" ",
+        )
+
+        position = []
+        for node in nodes:
+            idx = df.index[df["node"] == node]
+            for pos in idx:
+                position.append(pos)
+
+        # rename columns such that the x-axis label is "node" and not "name", tick marks
+        # will be node names
+        filtered_df = df.loc[position].rename(
+            columns={"node": "hatchet node", "name": "node"}
+        )
+
+        if len(columns) > 1:
+            return sns.violinplot(
+                data=filtered_df, x="node", y=" ", hue="Performance counter", **kwargs
+            )
+        else:
+            return sns.violinplot(data=filtered_df, x="node", y=" ", **kwargs)
+    # columnar joined thicket object
+
+    #Pave meeting: Discuss what melting function is doing, 
+
+    else:
+
+        """
+            New code that allows for columns to be selected from different indexes of a columnar joined thicket
+        """
+        def column_name_mapper(current_cols):
+            if current_cols[0] in ["node", "name"]:
+                return current_cols[0]
+
+            return str(current_cols)
+
+        cols = [str(c) for c in columns]
+        df_subset = thicket.dataframe[[("name", ""), *columns]].reset_index()
+        df_subset.columns = df_subset.columns.to_flat_index().map(column_name_mapper)
+        df_subset["name"] = thicket.dataframe["name"].tolist()
+        # End new code
+        
+        df = pd.melt(
+            df_subset,
+            id_vars=["node", "name"],
+            value_vars=cols,
+            var_name="Performance counter",
+            value_name=" ",
+        )
+
+        position = []
+        for node in nodes:
+            idx = df.index[df["node"] == node]
+            for pos in idx:
+                position.append(pos)
+
+        # rename columns such that the x-axis label is "node" and not "name", tick marks
+        # will be node names
+        filtered_df = df.loc[position].rename(
+            columns={"node": "hatchet node", "name": "node"}
+        )
+        # print(filtered_df)
+        # print(filtered_df.columns)
+        if len(columns) > 1:
+            #return px.violin(filtered_df)
+            #return px.violin(filtered_df, x="node", y=' ', box=True, points="all", hover_data=['Category'], title='Violin Plot')
+            return sns.violinplot(
+                data=filtered_df, x="node", y=" ", hue="Performance counter", **kwargs
+            )
+        else:
+            return sns.violinplot(data=filtered_df, x="node", y=" ", **kwargs)

--- a/thicket/stats/display_violinplot.py
+++ b/thicket/stats/display_violinplot.py
@@ -29,10 +29,10 @@ def _add_percentile_lines_node(graph, thicket, nodes, columns, percentiles_vals,
     violin_idx = -1
 
     #Default line styles and line colors
-    if lines_styles == None or len(lines_styles) != len(nodes):
-        lines_styles = ["-"] * len(percentiles_vals)
-    if line_colors == None or len(line_colors) != len(nodes):
-        line_colors = ["black"] * len(percentiles_vals)
+    if lines_styles == None or len(lines_styles) < len(percentiles_vals):
+        lines_styles += ["-"] * (len(percentiles_vals - len(percentiles_vals)))
+    if line_colors == None or len(line_colors) < len(percentiles_vals):
+        line_colors += ["black"] * (len(percentiles_vals) - len(percentiles_vals))
 
     for node in nodes:
         for column in columns:
@@ -62,7 +62,9 @@ def _add_percentile_lines_node(graph, thicket, nodes, columns, percentiles_vals,
 
     return graph
 
-def display_violinplot(thicket, nodes=[], columns=[], percentiles = [], linestyles = [], linecolors = [], **kwargs):
+
+
+def display_violinplot(thicket, nodes=[], columns=[], percentiles = [], percentile_linestyles = [], percentile_colors = [], **kwargs):
     """Display a violinplot for each user passed node(s) and column(s). The passed nodes
     and columns must be from the performance data table.
 
@@ -164,7 +166,9 @@ def display_violinplot(thicket, nodes=[], columns=[], percentiles = [], linestyl
         else:
             return sns.violinplot(data=filtered_df, x="node", y=" ", **kwargs)
 
-def display_violinplot_thicket(thicket_dictionary, nodes=None, columns=None, **kwargs):
+
+
+def display_violinplot_thicket(thickets, nodes=None, columns=None, x_order = [], percentiles = [], percentile_linestyles = [], percentile_colors = [], **kwargs):
     """Display a boxplot for each user passed node(s) and column(s). The passed nodes
     and columns must be from the performance data table.
 
@@ -172,9 +176,9 @@ def display_violinplot_thicket(thicket_dictionary, nodes=None, columns=None, **k
     depending on the number of nodes and columns passed.
 
     Arguments:
-        thicket (thicket): Thicket object
-        nodes (list): List of nodes to view on the x-axis
-        column (list): List of hardware/timing metrics to view on the y-axis. Note, if
+        thicket (dictionary): Thicket object
+        nodes (dictionaryu): List of nodes to view on the x-axis
+        column (dictionary): List of hardware/timing metrics to view on the y-axis. Note, if
             using a columnar joined thicket a list of tuples must be passed in with the
             format (column index, column name).
 
@@ -189,18 +193,19 @@ def display_violinplot_thicket(thicket_dictionary, nodes=None, columns=None, **k
         return str(current_cols)
 
     if nodes is None:
-        raise ValueError("Nodes must be a list of lists, specifying nodes for each Thicket passed in")
+        raise ValueError("Nodes must be a dictionary, specifying nodes for each Thicket passed in")
 
     if columns is None:
-        raise ValueError("Columns must be a list of lists, specifying columns for each Thicket passed in")
+        raise ValueError("Columns must be a dictionary, specifying columns for each Thicket passed in")
 
     #Ensures that both nodes and columns is a list of lists
-    if isinstance(nodes, list) == False or all(isinstance(n, list) for n in nodes) == False:
+    if isinstance(dictionary, dict) == False or all(isinstance(n, list) for n in nodes.items()) == False:
         raise ValueError("Nodes must be a list of lists, specifying nodes for each Thicket passed in")
     
-    if isinstance(columns, list) == False or all(isinstance(c, list) for c in columns) == False:
+    if isinstance(columns, dict) == False or all(isinstance(c, list) for c in columns.items()) == False:
         raise ValueError("Nodes must be a list of lists, specifying nodes for each Thicket passed in")
     
+    return
     #Ensures that each Thicket has corresponding nodes, and columns. Otherwise throw an error
     if len(thicket_dictionary) != len(columns):
         raise ValueError("Length of columns does not match number of thickets")

--- a/thicket/stats/percentiles.py
+++ b/thicket/stats/percentiles.py
@@ -8,7 +8,7 @@ import pandas as pd
 from ..utils import verify_thicket_structures
 
 
-def percentiles(thicket, columns=None, percentiles=[.25, .50, .75]):
+def percentiles(thicket, columns=None, percentiles=[0.25, 0.50, 0.75]):
     """
     Calculate the q-th percentile for each node in the performance data table.
 
@@ -39,11 +39,13 @@ def percentiles(thicket, columns=None, percentiles=[.25, .50, .75]):
         raise ValueError(
             "Percentiles can not be None, please specify which percentiles to calculate, or use the default values."
         )
-    
-    #Enforce that percentiles are in range of [0.0, 1.0]
+
+    # Enforce that percentiles are in range of [0.0, 1.0]
     for percentile in percentiles:
         if percentile < 0.0 or percentile > 1.0:
-            raise ValueError("Percentile {} is out of range of [0.0, 1.0]".format(percentile))
+            raise ValueError(
+                "Percentile {} is out of range of [0.0, 1.0]".format(percentile)
+            )
 
     if columns is None:
         raise ValueError(
@@ -64,39 +66,58 @@ def percentiles(thicket, columns=None, percentiles=[.25, .50, .75]):
             for node in pd.unique(df.reset_index()["node"].tolist()):
                 calculated_percentiles.append(list(df.loc[node][column]))
             for index, percentile in enumerate(percentiles):
-                
+
                 column_to_append = column + "_percentiles_" + str(int(percentile * 100))
-                thicket.statsframe.dataframe[column_to_append] = [x[index] for x in calculated_percentiles]
-                
+                thicket.statsframe.dataframe[column_to_append] = [
+                    x[index] for x in calculated_percentiles
+                ]
+
                 # check to see if exclusive metric and that the metric is not already in the metrics list
-                if column in thicket.exc_metrics and column_to_append not in thicket.statsframe.exc_metrics:
+                if (
+                    column in thicket.exc_metrics
+                    and column_to_append not in thicket.statsframe.exc_metrics
+                ):
                     thicket.statsframe.exc_metrics.append(column_to_append)
                 # check to see if inclusive metric
-                elif column in thicket.inc_metrics and column_to_append not in thicket.statsframe.inc_metrics:
+                elif (
+                    column in thicket.inc_metrics
+                    and column_to_append not in thicket.statsframe.inc_metrics
+                ):
                     thicket.statsframe.inc_metrics.append(column_to_append)
-                
+
     # columnar joined thicket object
     else:
         df_num = thicket.dataframe.select_dtypes(include=numerics)[columns]
         df = df_num.reset_index(level=1).groupby("node").quantile(percentiles)
         for idx, column in columns:
             calculated_percentiles = []
-            
-            #Get all the calculated values into a list for each node
+
+            # Get all the calculated values into a list for each node
             for node in pd.unique(df.reset_index()["node"].tolist()):
                 calculated_percentiles.append(list(df.loc[node][(idx, column)]))
-            
-            #Go through each of the percentiles, and make them it's own column
+
+            # Go through each of the percentiles, and make them it's own column
             for index, percentile in enumerate(percentiles):
-                
-                column_to_append = (idx, column + "_percentiles_" + str(int(percentile * 100)))
-                thicket.statsframe.dataframe[column_to_append] = [x[index] for x in calculated_percentiles]
-                
+
+                column_to_append = (
+                    idx,
+                    column + "_percentiles_" + str(int(percentile * 100)),
+                )
+                thicket.statsframe.dataframe[column_to_append] = [
+                    x[index] for x in calculated_percentiles
+                ]
+
                 # check to see if exclusive metric
-                if (idx, column) in thicket.exc_metrics and column_to_append not in thicket.statsframe.exc_metrics:
+                if (
+                    (idx, column) in thicket.exc_metrics
+                    and column_to_append not in thicket.statsframe.exc_metrics
+                ):
                     thicket.statsframe.exc_metrics.append(column_to_append)
                 # check to see if inclusive metric
-                elif (idx, column) in thicket.inc_metrics and column_to_append not in thicket.statsframe.inc_metrics:
+                elif (
+                    (idx, column) in thicket.inc_metrics
+                    and column_to_append not in thicket.statsframe.inc_metrics
+                ):
                     thicket.statsframe.inc_metrics.append(column_to_append)
 
         # sort columns in index

--- a/thicket/stats/percentiles.py
+++ b/thicket/stats/percentiles.py
@@ -8,7 +8,7 @@ import pandas as pd
 from ..utils import verify_thicket_structures
 
 
-def percentiles(thicket, columns=None):
+def percentiles(thicket, columns=None, percentiles=[.25, .50, .75]):
     """Calculate the q-th percentile for each node in the performance data table.
 
     Designed to take in a thicket, and append one or more columns to the aggregated
@@ -29,6 +29,14 @@ def percentiles(thicket, columns=None):
             calculation on. Note if using a columnar joined thicket a list of tuples
             must be passed in with the format (column index, column name).
     """
+    if percentiles is None:
+        raise ValueError(
+            "Percentiles is empty, please specify which percentiles to calculate"
+        )
+    for percentile in percentiles:
+        if percentile < 0.0 or percentile > 1.0:
+            raise ValueError("Percentile {} is out of range of [0.0, 1.0]".format(percentile))
+
     if columns is None:
         raise ValueError(
             "To see a list of valid columns, run 'Thicket.performance_cols'."
@@ -40,36 +48,48 @@ def percentiles(thicket, columns=None):
     if thicket.dataframe.columns.nlevels == 1:
         # select numeric columns within thicket (.quantiles) will not work without this step
         numerics = ["int16", "int32", "int64", "float16", "float32", "float64"]
-        df_num = thicket.dataframe.select_dtypes(include=numerics)
-        df = df_num.reset_index().groupby("node").quantile([0.25, 0.50, 0.75])
+        df_num = thicket.dataframe.select_dtypes(include=numerics)[columns]
+        df = df_num.reset_index().groupby("node").quantile(percentiles)
         for column in columns:
-            percentiles = []
+            calculated_percentiles = []
             for node in pd.unique(df.reset_index()["node"].tolist()):
-                percentiles.append(list(df.loc[node][column]))
-            thicket.statsframe.dataframe[column + "_percentiles"] = percentiles
-            # check to see if exclusive metric
-            if column in thicket.exc_metrics:
-                thicket.statsframe.exc_metrics.append(column + "_percentiles")
-            # check to see if inclusive metric
-            else:
-                thicket.statsframe.inc_metrics.append(column + "_percentiles")
+                calculated_percentiles.append(list(df.loc[node][column]))
+            for index, percentile in enumerate(percentiles):
+                
+                column_to_append = column + "_percentiles_" + str(int(percentile * 100))
+                thicket.statsframe.dataframe[column_to_append] = [x[index] for x in calculated_percentiles]
+                
+                # check to see if exclusive metric and that the metric is not already in the metrics list
+                if column in thicket.exc_metrics and column_to_append not in thicket.statsframe.exc_metrics:
+                    thicket.statsframe.exc_metrics.append(column_to_append)
+                # check to see if inclusive metric
+                elif column in thicket.inc_metrics and column_to_append not in thicket.statsframe.inc_metrics:
+                    thicket.statsframe.inc_metrics.append(column_to_append)
+                
     # columnar joined thicket object
     else:
         numerics = ["int16", "int32", "int64", "float16", "float32", "float64"]
-        df_num = thicket.dataframe.select_dtypes(include=numerics)
-        df = df_num.reset_index(level=1).groupby("node").quantile([0.25, 0.50, 0.75])
-        percentiles = []
+        df_num = thicket.dataframe.select_dtypes(include=numerics)[columns]
+        df = df_num.reset_index(level=1).groupby("node").quantile(percentiles)
         for idx, column in columns:
-            percentiles = []
+            calculated_percentiles = []
+            
+            #Get all the calculated values into a list for each node
             for node in pd.unique(df.reset_index()["node"].tolist()):
-                percentiles.append(list(df.loc[node][(idx, column)]))
-            thicket.statsframe.dataframe[(idx, column + "_percentiles")] = percentiles
-            # check to see if exclusive metric
-            if (idx, column) in thicket.exc_metrics:
-                thicket.statsframe.exc_metrics.append((idx, column + "_percentiles"))
-            # check to see if inclusive metric
-            else:
-                thicket.statsframe.inc_metrics.append((idx, column + "_percentiles"))
+                calculated_percentiles.append(list(df.loc[node][(idx, column)]))
+            
+            #Go through each of the percentiles, and make them it's own column
+            for index, percentile in enumerate(percentiles):
+                
+                column_to_append = (idx, column + "_percentiles_" + str(int(percentile * 100)))
+                thicket.statsframe.dataframe[column_to_append] = [x[index] for x in calculated_percentiles]
+                
+                # check to see if exclusive metric
+                if (idx, column) in thicket.exc_metrics and column_to_append not in thicket.statsframe.exc_metrics:
+                    thicket.statsframe.exc_metrics.append(column_to_append)
+                # check to see if inclusive metric
+                elif (idx, column) in thicket.inc_metrics and column_to_append not in thicket.statsframe.inc_metrics:
+                    thicket.statsframe.inc_metrics.append(column_to_append)
 
         # sort columns in index
         thicket.statsframe.dataframe = thicket.statsframe.dataframe.sort_index(axis=1)


### PR DESCRIPTION
Created two functions in order to plot violin plots.

The first function is designed to take in a singular thicket object, and plot user defined nodes and columns. The x-axis would be each node, and the y-axis would be the column metric specified by the user

The second function is designed to take in more than one thicket object, were we plot a node for each thicket, and the y-axis would be the data for each node. There are a few key things that are enforced. First, all thickets passed in needs to have the same columnar index level. Each thicket only gets one node to plot.

Both functions support custom percentile lines that would be user defined, as well as line styles and line colors. 

This PR needs to go after PR #103 
