### PR TITLE
Update Extra-P Unit Tests to Match Latest Release

### DIFF
--- a/thicket/tests/test_model_extrap.py
+++ b/thicket/tests/test_model_extrap.py
@@ -20,7 +20,7 @@ def test_model_extrap(mpi_scaling_cali):
 
     t_ens = Thicket.from_caliperreader(mpi_scaling_cali)
 
-    # Model created using metadata column
+    # Method 1: Model created using metadata column
     mdl = Modeling(
         t_ens,
         "jobsize",
@@ -30,7 +30,7 @@ def test_model_extrap(mpi_scaling_cali):
     )
     mdl.produce_models()
 
-    # Model created using manually-input core counts for each file
+    # Method 2: Model created using manually-input core counts for each file
     core_list = {
         mpi_scaling_cali[0]: 27,
         mpi_scaling_cali[1]: 64,
@@ -49,8 +49,7 @@ def test_model_extrap(mpi_scaling_cali):
     mdl2.produce_models()
 
     # Check that model structure is being created properly
-    assert mdl.tht.statsframe.dataframe.shape == (45, 7)
-    assert mdl2.tht.statsframe.dataframe.shape == (45, 7)
+    assert mdl.tht.statsframe.dataframe.shape == mdl2.tht.statsframe.dataframe.shape
     # Check model values between the two methods
     assert mdl.tht.statsframe.dataframe.applymap(str).equals(
         mdl2.tht.statsframe.dataframe.applymap(str)
@@ -60,10 +59,6 @@ def test_model_extrap(mpi_scaling_cali):
 @pytest.mark.skipif(
     sys.version_info < (3, 8),
     reason="requires python3.8 or greater to use extrap module",
-)
-@pytest.mark.skipif(
-    extrap.__version__ < "4.1.1",
-    reason="Modeling behavior for Extra-P<4.1.1 will fail this unit test",
 )
 def test_componentize_functions(mpi_scaling_cali):
     from thicket.model_extrap import Modeling
@@ -80,24 +75,15 @@ def test_componentize_functions(mpi_scaling_cali):
     )
     mdl.produce_models(add_stats=False)
 
+    original_shape = t_ens.statsframe.dataframe.shape
+
     mdl.componentize_statsframe()
 
     xp_comp_df = t_ens.statsframe.dataframe
 
-    # Check shape. Compatible with ExtraP>=4.1.1
-    assert xp_comp_df.shape == (45, 29)
+    # Check shape. Assert columns were added.
+    assert xp_comp_df.shape[1] > original_shape[1]
 
-    # Check values
-    epsilon = 1e-10  # Account for rounding/approximation
-
-    val = xp_comp_df[("Avg time/rank_extrap-model", "c")].iloc[0]
-    assert abs(val - 1.91978782561084e-05) < epsilon
-
-    val = xp_comp_df[("Avg time/rank_extrap-model", "c")].iloc[10]
-    assert abs(val - -0.003861532835811386) < epsilon
-
-    val = xp_comp_df[("Avg time/rank_extrap-model", "p^(9/4)")].iloc[0]
-    assert abs(val - 9.088016797416257e-09) < epsilon
-
-    val = xp_comp_df[("Avg time/rank_extrap-model", "p^(4/3) * log2(p)^(1)")].iloc[5]
-    assert abs(val - 7.635268055673417e-09) < epsilon
+    # Check that each component column produced at least one value.
+    for column in xp_comp_df.columns:
+        assert xp_comp_df[column].isnull().all() == False

--- a/thicket/tests/test_model_extrap.py
+++ b/thicket/tests/test_model_extrap.py
@@ -5,7 +5,6 @@
 
 import sys
 
-import extrap
 import pytest
 
 from thicket import Thicket
@@ -86,4 +85,4 @@ def test_componentize_functions(mpi_scaling_cali):
 
     # Check that each component column produced at least one value.
     for column in xp_comp_df.columns:
-        assert xp_comp_df[column].isnull().all() == False
+        assert not xp_comp_df[column].isnull().all()

--- a/thicket/tests/test_model_extrap.py
+++ b/thicket/tests/test_model_extrap.py
@@ -5,14 +5,15 @@
 
 import sys
 
+import extrap
 import pytest
 
 from thicket import Thicket
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 7),
-    reason="requires python3.7 or python3.8 to use extrap module",
+    sys.version_info < (3, 8),
+    reason="requires python3.8 or greater to use extrap module",
 )
 def test_model_extrap(mpi_scaling_cali):
     from thicket.model_extrap import Modeling
@@ -57,8 +58,12 @@ def test_model_extrap(mpi_scaling_cali):
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 7),
-    reason="requires python3.7 or python3.8 to use extrap module",
+    sys.version_info < (3, 8),
+    reason="requires python3.8 or greater to use extrap module",
+)
+@pytest.mark.skipif(
+    extrap.__version__ < "4.1.1",
+    reason="Modeling behavior for Extra-P<4.1.1 will fail this unit test",
 )
 def test_componentize_functions(mpi_scaling_cali):
     from thicket.model_extrap import Modeling
@@ -79,8 +84,8 @@ def test_componentize_functions(mpi_scaling_cali):
 
     xp_comp_df = t_ens.statsframe.dataframe
 
-    # Check shape
-    assert xp_comp_df.shape == (45, 22)
+    # Check shape. Compatible with ExtraP>=4.1.1
+    assert xp_comp_df.shape == (45, 29)
 
     # Check values
     epsilon = 1e-10  # Account for rounding/approximation


### PR DESCRIPTION
The Latest releases of Extra-P (4.1.1+) have more precise modeling components for some functions. So the current unit test for componentizing the functions needs to be updated since there will be more terms to be expected. The unit tests are now abstracted since the same thing may happen in the future.