### PR TITLE
Disable Node Ordering if All Profiles Don't Have It

### DIFF
--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -96,6 +96,7 @@ class Ensemble:
         _thickets = thickets
         if not inplace:
             _thickets = [th.deepcopy() for th in thickets]
+        helpers._set_node_ordering(_thickets)
         # Unify graphs if "self" and "other" do not have the same graph
         union_graph = _thickets[0].graph
         old_to_new = {}
@@ -339,8 +340,8 @@ class Ensemble:
         # Step 0B: Pre-check of data structures
         _check_structures()
 
-        # Step 1: Unify the thickets
-        union_graph, _thickets = Ensemble._unify(thickets_cp)
+        # Step 1: Unify the thickets. Can be inplace since we are using copies already
+        union_graph, _thickets = Ensemble._unify(thickets_cp, inplace=True)
         combined_th.graph = union_graph
         thickets_cp = _thickets
 

--- a/thicket/helpers.py
+++ b/thicket/helpers.py
@@ -123,6 +123,21 @@ def _resolve_missing_indicies(th_list):
                 th.dataframe.set_index(idx, append=True, inplace=True)
 
 
+def _set_node_ordering(thickets):
+    """Set node ordering for each thicket in a list. All thickets must have node ordering on, otherwise it will be set to False.
+
+    Arguments:
+        thickets (list): list of Thicket objects
+    """
+    node_order = all([tk.graph.node_ordering for tk in thickets])
+
+    for tk in thickets:
+        if tk.graph.node_ordering:
+            tk.graph.node_ordering = node_order
+            # Have to re-enumerate the traverse
+            tk.graph.enumerate_traverse()
+
+
 def _get_perf_columns(df):
     """Get list of performance dataframe columns that are numeric.
 


### PR DESCRIPTION
# Summary
The value of a `node` ID depend on whether `node_ordering` is True or False. Therefore, if not all profiles were collected with `node_ordering` enabled, we must disable it at runtime to be able to unify the given profiles. If they all have `node_ordering` or all don't have `node_ordering`, this shouldn't impact anything.