### PR TITLE
Expand Check to All Inner Indices

### DIFF
--- a/thicket/utils.py
+++ b/thicket/utils.py
@@ -10,10 +10,10 @@ def validate_dataframe(df):
     """Check validity of a Thicket DataFrame."""
 
     def _check_duplicate_inner_idx(df):
-        """Check for duplicate values in the innermost index."""
+        """Check for duplicate values in the innermost indices."""
         for node in set(df.index.get_level_values("node")):
             inner_idx_values = sorted(
-                df.loc[node].index.get_level_values(df.index.nlevels - 2).tolist()
+                df.loc[node].index.tolist()
             )
             inner_idx_values_set = sorted(list(set(inner_idx_values)))
             if inner_idx_values != inner_idx_values_set:

--- a/thicket/utils.py
+++ b/thicket/utils.py
@@ -12,9 +12,7 @@ def validate_dataframe(df):
     def _check_duplicate_inner_idx(df):
         """Check for duplicate values in the innermost indices."""
         for node in set(df.index.get_level_values("node")):
-            inner_idx_values = sorted(
-                df.loc[node].index.tolist()
-            )
+            inner_idx_values = sorted(df.loc[node].index.tolist())
             inner_idx_values_set = sorted(list(set(inner_idx_values)))
             if inner_idx_values != inner_idx_values_set:
                 raise IndexError(


### PR DESCRIPTION
# Summary
This check is designed to check every index besides node, to check for duplicates. The current version only checks a single innermost index.