### PR TITLE
Add Progress Bar to Reader

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "numpy",
         "pandas >= 1.1",
         "llnl-hatchet",
+        "tqdm",
     ],
     extras_require={
         "extrap": ["extrap", "matplotlib"],

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -224,9 +224,9 @@ class Ensemble:
             combined_th.profile = [new_mappings[prf] for prf in combined_th.profile]
             profile_mapping_cp = combined_th.profile_mapping.copy()
             for k, v in profile_mapping_cp.items():
-                combined_th.profile_mapping[new_mappings[k]] = (
-                    combined_th.profile_mapping.pop(k)
-                )
+                combined_th.profile_mapping[
+                    new_mappings[k]
+                ] = combined_th.profile_mapping.pop(k)
             combined_th.performance_cols = helpers._get_perf_columns(
                 combined_th.dataframe
             )

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -225,7 +225,7 @@ class Ensemble:
             for k, v in profile_mapping_cp.items():
                 combined_th.profile_mapping[
                     new_mappings[k]
-                ] = (combined_th.profile_mapping.pop(k))
+                ] = combined_th.profile_mapping.pop(k)
             combined_th.performance_cols = helpers._get_perf_columns(
                 combined_th.dataframe
             )

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 from hatchet import GraphFrame
 import numpy as np
 import pandas as pd
+import tqdm
 
 import thicket.helpers as helpers
 from .utils import (
@@ -103,7 +104,10 @@ class Ensemble:
         for i in range(len(_thickets) - 1):
             temp_dict = {}
             union_graph = union_graph.union(_thickets[i + 1].graph, temp_dict)
-            # Update both graphs to the union graph
+        pbar = tqdm.tqdm(range(len(_thickets)))
+        for i in pbar:
+            pbar.set_description("Creating Thicket: ")
+            # Set all graphs to the union graph
             _thickets[i].graph = union_graph
             _thickets[i + 1].graph = union_graph
             # Merge the current old_to_new dictionary with the new mappings

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -223,9 +223,9 @@ class Ensemble:
             combined_th.profile = [new_mappings[prf] for prf in combined_th.profile]
             profile_mapping_cp = combined_th.profile_mapping.copy()
             for k, v in profile_mapping_cp.items():
-                combined_th.profile_mapping[new_mappings[k]] = (
-                    combined_th.profile_mapping.pop(k)
-                )
+                combined_th.profile_mapping[
+                    new_mappings[k]
+                ] = (combined_th.profile_mapping.pop(k))
             combined_th.performance_cols = helpers._get_perf_columns(
                 combined_th.dataframe
             )

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -102,12 +102,11 @@ class Ensemble:
         # Unify graphs if "self" and "other" do not have the same graph
         union_graph = _thickets[0].graph
         old_to_new = {}
-        for i in range(len(_thickets) - 1):
+        pbar = tqdm.tqdm(range(len(_thickets) - 1), disable=disable_tqdm)
+        for i in pbar:
+            pbar.set_description("(2/2) Creating Thicket")
             temp_dict = {}
             union_graph = union_graph.union(_thickets[i + 1].graph, temp_dict)
-        pbar = tqdm.tqdm(range(len(_thickets)), disable=disable_tqdm)
-        for i in pbar:
-            pbar.set_description("Creating Thicket: ")
             # Set all graphs to the union graph
             _thickets[i].graph = union_graph
             _thickets[i + 1].graph = union_graph
@@ -224,9 +223,9 @@ class Ensemble:
             combined_th.profile = [new_mappings[prf] for prf in combined_th.profile]
             profile_mapping_cp = combined_th.profile_mapping.copy()
             for k, v in profile_mapping_cp.items():
-                combined_th.profile_mapping[
-                    new_mappings[k]
-                ] = combined_th.profile_mapping.pop(k)
+                combined_th.profile_mapping[new_mappings[k]] = (
+                    combined_th.profile_mapping.pop(k)
+                )
             combined_th.performance_cols = helpers._get_perf_columns(
                 combined_th.dataframe
             )

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -347,7 +347,9 @@ class Ensemble:
         _check_structures()
 
         # Step 1: Unify the thickets. Can be inplace since we are using copies already
-        union_graph, _thickets = Ensemble._unify(thickets_cp, inplace=True, disable_tqdm=disable_tqdm)
+        union_graph, _thickets = Ensemble._unify(
+            thickets_cp, inplace=True, disable_tqdm=disable_tqdm
+        )
         combined_th.graph = union_graph
         thickets_cp = _thickets
 

--- a/thicket/groupby.py
+++ b/thicket/groupby.py
@@ -13,7 +13,7 @@ class GroupBy(dict):
         super(GroupBy, self).__init__(*args, **kwargs)
         self.by = by
 
-    def agg(self, func):
+    def agg(self, func, disable_tqdm=False):
         """Aggregate the Thickets' PerfData numerical columns in a GroupBy object.
 
         Arguments:
@@ -28,7 +28,7 @@ class GroupBy(dict):
 
         values_list = list(agg_tks.values())
         first_tk = values_list[0]  # TODO: Hack to avoid circular import.
-        agg_tk = first_tk.concat_thickets(values_list)
+        agg_tk = first_tk.concat_thickets(values_list, disable_tqdm=disable_tqdm)
 
         return agg_tk
 

--- a/thicket/tests/conftest.py
+++ b/thicket/tests/conftest.py
@@ -24,7 +24,7 @@ def thicket_axis_columns(rajaperf_cali_1trial):
         list: List of original thickets, list of deepcopies of original thickets, and
             column-joined thicket.
     """
-    tk = Thicket.from_caliperreader(rajaperf_cali_1trial)
+    tk = Thicket.from_caliperreader(rajaperf_cali_1trial, disable_tqdm=True)
 
     gb = tk.groupby("tuning")
 
@@ -38,6 +38,7 @@ def thicket_axis_columns(rajaperf_cali_1trial):
         axis="columns",
         headers=headers,
         metadata_key="ProblemSizeRunParam",
+        disable_tqdm=True,
     )
 
     return thickets, thickets_cp, combined_th
@@ -54,8 +55,12 @@ def stats_thicket_axis_columns(rajaperf_cuda_block128_1M_cali):
         list: List of original thickets, list of deepcopies of original thickets, and
             column-joined thicket.
     """
-    th_cuda128_1 = Thicket.from_caliperreader(rajaperf_cuda_block128_1M_cali[0:4])
-    th_cuda128_2 = Thicket.from_caliperreader(rajaperf_cuda_block128_1M_cali[5:9])
+    th_cuda128_1 = Thicket.from_caliperreader(
+        rajaperf_cuda_block128_1M_cali[0:4], disable_tqdm=True
+    )
+    th_cuda128_2 = Thicket.from_caliperreader(
+        rajaperf_cuda_block128_1M_cali[5:9], disable_tqdm=True
+    )
 
     # To check later if modifications were unexpectedly made
     th_cuda128_1_deep = th_cuda128_1.deepcopy()
@@ -67,6 +72,7 @@ def stats_thicket_axis_columns(rajaperf_cuda_block128_1M_cali):
         thickets=thickets,
         axis="columns",
         headers=["Cuda 1", "Cuda 2"],
+        disable_tqdm=True,
     )
 
     return thickets, thickets_cp, combined_th

--- a/thicket/tests/test_caliperreader.py
+++ b/thicket/tests/test_caliperreader.py
@@ -8,7 +8,7 @@ from thicket import Thicket
 
 def test_from_caliperreader(rajaperf_seq_O3_1M_cali):
     """Sanity test a thicket object with known data."""
-    tk = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali[0])
+    tk = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali[0], disable_tqdm=True)
 
     # Check the object type
     assert isinstance(tk, Thicket)

--- a/thicket/tests/test_concat_thickets.py
+++ b/thicket/tests/test_concat_thickets.py
@@ -16,10 +16,10 @@ from thicket import Thicket
 
 
 def test_concat_thickets_index(mpi_scaling_cali):
-    th_27 = Thicket.from_caliperreader(mpi_scaling_cali[0])
-    th_64 = Thicket.from_caliperreader(mpi_scaling_cali[1])
+    th_27 = Thicket.from_caliperreader(mpi_scaling_cali[0], disable_tqdm=True)
+    th_64 = Thicket.from_caliperreader(mpi_scaling_cali[1], disable_tqdm=True)
 
-    tk = Thicket.concat_thickets([th_27, th_64])
+    tk = Thicket.concat_thickets([th_27, th_64], disable_tqdm=True)
 
     # Check dataframe shape
     tk.dataframe.shape == (90, 7)

--- a/thicket/tests/test_copy.py
+++ b/thicket/tests/test_copy.py
@@ -7,7 +7,7 @@ from thicket import Thicket
 
 
 def test_copy(rajaperf_seq_O3_1M_cali):
-    self = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali[0])
+    self = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali[0], disable_tqdm=True)
     self.exc_metrics.append("value")
     other = self.copy()
 
@@ -68,7 +68,7 @@ def test_copy(rajaperf_seq_O3_1M_cali):
 
 
 def test_deepcopy(rajaperf_seq_O3_1M_cali):
-    self = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali[0])
+    self = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali[0], disable_tqdm=True)
     self.exc_metrics.append("value")
     other = self.deepcopy()
 

--- a/thicket/tests/test_display.py
+++ b/thicket/tests/test_display.py
@@ -11,7 +11,7 @@ import thicket as th
 
 
 def test_display_histogram(rajaperf_seq_O3_1M_cali):
-    tk = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    tk = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
 
     node = pd.unique(tk.dataframe.reset_index()["node"])[4]
 
@@ -79,7 +79,7 @@ def test_display_histogram_columnar_join(thicket_axis_columns):
 
 
 def test_display_heatmap(rajaperf_seq_O3_1M_cali):
-    tk = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    tk = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
 
     th.stats.variance(tk, columns=["Min time/rank"])
 
@@ -152,7 +152,7 @@ def test_display_heatmap_columnar_join(thicket_axis_columns):
 
 
 def test_display_boxplot(rajaperf_seq_O3_1M_cali):
-    tk = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    tk = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
 
     nodes = list(pd.unique(tk.dataframe.reset_index()["node"])[0:2])
 

--- a/thicket/tests/test_ensemble.py
+++ b/thicket/tests/test_ensemble.py
@@ -9,7 +9,7 @@ from thicket import Ensemble
 def test_unify(literal_thickets):
     tk, tk2, tk3 = literal_thickets
 
-    union_graph, _thickets = Ensemble._unify([tk, tk2, tk3])
+    union_graph, _thickets = Ensemble._unify([tk, tk2, tk3], disable_tqdm=True)
 
     ug_hashes = [0, 1, 2, 3, 4, 5, 6]
     tk_hashes = [

--- a/thicket/tests/test_filter_metadata.py
+++ b/thicket/tests/test_filter_metadata.py
@@ -172,7 +172,7 @@ def filter_multiple_or(th, columns_values):
 
 def test_filter_metadata(rajaperf_seq_O3_1M_cali):
     # example thicket
-    th = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    th = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
     # columns and corresponding values to filter by
     columns_values = {"ProblemSizeRunParam": ["30"], "cluster": ["chekov", "quartz"]}
     filter_one_column(th, columns_values)

--- a/thicket/tests/test_filter_stats.py
+++ b/thicket/tests/test_filter_stats.py
@@ -52,7 +52,7 @@ def check_filter_stats(th, columns_values):
 
 def test_filter_stats(rajaperf_seq_O3_1M_cali):
     # example thicket
-    th = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    th = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
     # columns and corresponding values to filter by
     columns_values = {
         "test_string_column": ["less than 20"],

--- a/thicket/tests/test_from_statsframes.py
+++ b/thicket/tests/test_from_statsframes.py
@@ -9,7 +9,7 @@ from thicket import Thicket as th
 def test_from_statsframes(mpi_scaling_cali):
     th_list = []
     for file in mpi_scaling_cali:
-        th_list.append(th.from_caliperreader(file))
+        th_list.append(th.from_caliperreader(file, disable_tqdm=True))
 
     # Add arbitrary value to aggregated statistics table
     t_val = 0
@@ -17,7 +17,7 @@ def test_from_statsframes(mpi_scaling_cali):
         t.statsframe.dataframe["test"] = t_val
         t_val += 2
 
-    tk = th.from_statsframes(th_list)
+    tk = th.from_statsframes(th_list, disable_tqdm=True)
 
     # Check level values
     assert set(tk.dataframe.index.get_level_values("profile")) == {
@@ -30,7 +30,9 @@ def test_from_statsframes(mpi_scaling_cali):
     # Check performance data table values
     assert set(tk.dataframe["test"]) == {0, 2, 4, 6, 8}
 
-    tk_named = th.from_statsframes(th_list, metadata_key="mpi.world.size")
+    tk_named = th.from_statsframes(
+        th_list, metadata_key="mpi.world.size", disable_tqdm=True
+    )
 
     # Check level values
     assert set(tk_named.dataframe.index.get_level_values("mpi.world.size")) == {

--- a/thicket/tests/test_groupby.py
+++ b/thicket/tests/test_groupby.py
@@ -82,7 +82,7 @@ def check_groupby(th, columns_values):
 
 
 def test_aggregate(rajaperf_cuda_block128_1M_cali):
-    tk = Thicket.from_caliperreader(rajaperf_cuda_block128_1M_cali)
+    tk = Thicket.from_caliperreader(rajaperf_cuda_block128_1M_cali, disable_tqdm=True)
     gb = tk.groupby("spot.format.version")
 
     epsilon = 0.000001
@@ -111,15 +111,18 @@ def test_aggregate(rajaperf_cuda_block128_1M_cali):
             < epsilon
         )
 
-    tk_agg = gb.agg(func={"Min time/rank": [np.mean, np.var], "Total time": np.mean})
+    tk_agg = gb.agg(
+        func={"Min time/rank": [np.mean, np.var], "Total time": np.mean},
+        disable_tqdm=True,
+    )
     _check_values(tk_agg)
-    tk_agg = gb.agg(func=[np.mean, np.var])
+    tk_agg = gb.agg(func=[np.mean, np.var], disable_tqdm=True)
     _check_values(tk_agg)
 
 
 def test_groupby(rajaperf_seq_O3_1M_cali):
     # example thicket
-    th = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    th = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
     # use cases for string, numeric, and single value columns
     columns_values = ["user", "launchdate", "cali.channel"]
 
@@ -129,7 +132,7 @@ def test_groupby(rajaperf_seq_O3_1M_cali):
 def test_groupby_concat_thickets_columns(rajaperf_seq_O3_1M_cali):
     """Tests case where the Sub-Thickets of a groupby are used in a columnar join"""
     # example thicket
-    th = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    th = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
 
     # Creates four Sub-Thickets
     column = "unique_col"
@@ -149,6 +152,7 @@ def test_groupby_concat_thickets_columns(rajaperf_seq_O3_1M_cali):
         thickets=thickets,
         axis="columns",
         metadata_key=selected_column,
+        disable_tqdm=True,
     )
 
     test_concat_thickets_columns((thickets, thickets_cp, combined_th))
@@ -157,7 +161,7 @@ def test_groupby_concat_thickets_columns(rajaperf_seq_O3_1M_cali):
 def test_groupby_concat_thickets_columns_subthickets(rajaperf_seq_O3_1M_cali):
     """Tests case where some specific Sub-Thickets of a groupby are used in a columnar join"""
     # example thicket
-    th = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    th = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
 
     # Creates four Sub-Thickets
     column = "unique_col"
@@ -180,6 +184,7 @@ def test_groupby_concat_thickets_columns_subthickets(rajaperf_seq_O3_1M_cali):
         thickets=thickets,
         axis="columns",
         metadata_key=selected_column,
+        disable_tqdm=True,
     )
 
     test_concat_thickets_columns((thickets, thickets_cp, combined_th))

--- a/thicket/tests/test_intersection.py
+++ b/thicket/tests/test_intersection.py
@@ -8,12 +8,12 @@ from thicket import Thicket as th
 
 
 def test_intersection(rajaperf_cali_1trial):
-    tk = th.from_caliperreader(rajaperf_cali_1trial)
+    tk = th.from_caliperreader(rajaperf_cali_1trial, disable_tqdm=True)
 
     intersected_tk = tk.intersection()
 
     intersected_tk_other = th.from_caliperreader(
-        rajaperf_cali_1trial, intersection=True
+        rajaperf_cali_1trial, intersection=True, disable_tqdm=True
     )
 
     # Check other methodology

--- a/thicket/tests/test_model_extrap.py
+++ b/thicket/tests/test_model_extrap.py
@@ -17,7 +17,7 @@ from thicket import Thicket
 def test_model_extrap(mpi_scaling_cali):
     from thicket.model_extrap import Modeling
 
-    t_ens = Thicket.from_caliperreader(mpi_scaling_cali)
+    t_ens = Thicket.from_caliperreader(mpi_scaling_cali, disable_tqdm=True)
 
     # Method 1: Model created using metadata column
     mdl = Modeling(
@@ -62,7 +62,7 @@ def test_model_extrap(mpi_scaling_cali):
 def test_componentize_functions(mpi_scaling_cali):
     from thicket.model_extrap import Modeling
 
-    t_ens = Thicket.from_caliperreader(mpi_scaling_cali)
+    t_ens = Thicket.from_caliperreader(mpi_scaling_cali, disable_tqdm=True)
 
     mdl = Modeling(
         t_ens,

--- a/thicket/tests/test_query.py
+++ b/thicket/tests/test_query.py
@@ -53,7 +53,7 @@ def check_query(th, hnids, query):
 
 def test_query(rajaperf_cuda_block128_1M_cali):
     # test thicket
-    th = Thicket.from_caliperreader(rajaperf_cuda_block128_1M_cali)
+    th = Thicket.from_caliperreader(rajaperf_cuda_block128_1M_cali, disable_tqdm=True)
     # test arguments
     hnids = [0, 1, 2, 3, 4]  # 5, 6, 7 have Nones
     query = (

--- a/thicket/tests/test_stats.py
+++ b/thicket/tests/test_stats.py
@@ -7,7 +7,7 @@ import thicket as th
 
 
 def test_mean(rajaperf_seq_O3_1M_cali):
-    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
 
     assert sorted(th_ens.dataframe.index.get_level_values(0).unique()) == sorted(
         th_ens.statsframe.dataframe.index.values
@@ -45,7 +45,7 @@ def test_mean_columnar_join(thicket_axis_columns):
 
 
 def test_median(rajaperf_seq_O3_1M_cali):
-    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
 
     assert sorted(th_ens.dataframe.index.get_level_values(0).unique()) == sorted(
         th_ens.statsframe.dataframe.index.values
@@ -83,7 +83,7 @@ def test_median_columnar_join(thicket_axis_columns):
 
 
 def test_minimum(rajaperf_seq_O3_1M_cali):
-    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
 
     assert sorted(th_ens.dataframe.index.get_level_values(0).unique()) == sorted(
         th_ens.statsframe.dataframe.index.values
@@ -121,7 +121,7 @@ def test_minimum_columnar_join(thicket_axis_columns):
 
 
 def test_maximum(rajaperf_seq_O3_1M_cali):
-    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
 
     assert sorted(th_ens.dataframe.index.get_level_values(0).unique()) == sorted(
         th_ens.statsframe.dataframe.index.values
@@ -159,7 +159,7 @@ def test_maximum_columnar_join(thicket_axis_columns):
 
 
 def test_std(rajaperf_seq_O3_1M_cali):
-    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
 
     assert sorted(th_ens.dataframe.index.get_level_values(0).unique()) == sorted(
         th_ens.statsframe.dataframe.index.values
@@ -197,7 +197,7 @@ def test_std_columnar_join(thicket_axis_columns):
 
 
 def test_percentiles(rajaperf_seq_O3_1M_cali):
-    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
 
     assert sorted(th_ens.dataframe.index.get_level_values(0).unique()) == sorted(
         th_ens.statsframe.dataframe.index.values
@@ -228,7 +228,7 @@ def test_percentiles(rajaperf_seq_O3_1M_cali):
 
 
 def test_percentiles_none(rajaperf_seq_O3_1M_cali):
-    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
 
     th.stats.percentiles(th_ens, columns=["Min time/rank"], percentiles=None)
 
@@ -238,7 +238,7 @@ def test_percentiles_none(rajaperf_seq_O3_1M_cali):
 
 
 def test_percentiles_single_value(rajaperf_seq_O3_1M_cali):
-    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
 
     th.stats.percentiles(th_ens, columns=["Min time/rank"], percentiles=[0.3])
 
@@ -320,7 +320,7 @@ def test_percentiles_columnar_join(thicket_axis_columns):
 
 
 def test_variance(rajaperf_seq_O3_1M_cali):
-    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
 
     assert sorted(th_ens.dataframe.index.get_level_values(0).unique()) == sorted(
         th_ens.statsframe.dataframe.index.values
@@ -358,7 +358,9 @@ def test_variance_columnar_join(thicket_axis_columns):
 
 
 def test_normality(rajaperf_cuda_block128_1M_cali):
-    th_ens = th.Thicket.from_caliperreader(rajaperf_cuda_block128_1M_cali)
+    th_ens = th.Thicket.from_caliperreader(
+        rajaperf_cuda_block128_1M_cali, disable_tqdm=True
+    )
 
     assert sorted(th_ens.dataframe.index.get_level_values(0).unique()) == sorted(
         th_ens.statsframe.dataframe.index.values
@@ -413,7 +415,9 @@ def test_normality_columnar_join(thicket_axis_columns, stats_thicket_axis_column
 
 
 def test_correlation(rajaperf_cuda_block128_1M_cali):
-    th_ens = th.Thicket.from_caliperreader(rajaperf_cuda_block128_1M_cali)
+    th_ens = th.Thicket.from_caliperreader(
+        rajaperf_cuda_block128_1M_cali, disable_tqdm=True
+    )
 
     assert sorted(th_ens.dataframe.index.get_level_values(0).unique()) == sorted(
         th_ens.statsframe.dataframe.index.values
@@ -453,7 +457,7 @@ def test_correlation_columnar_join(thicket_axis_columns):
 
 
 def test_boxplot(rajaperf_seq_O3_1M_cali):
-    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali)
+    th_ens = th.Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
 
     assert sorted(th_ens.dataframe.index.get_level_values(0).unique()) == sorted(
         th_ens.statsframe.dataframe.index.values

--- a/thicket/tests/test_thicket.py
+++ b/thicket/tests/test_thicket.py
@@ -50,16 +50,16 @@ def test_resolve_missing_indicies():
 def test_statsframe(rajaperf_seq_O3_1M_cali):
     def _test_multiindex():
         """Test statsframe when headers are multiindexed."""
-        th1 = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali[0])
-        th2 = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali[1])
-        th_cj = Thicket.concat_thickets([th1, th2], axis="columns")
+        th1 = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali[0], disable_tqdm=True)
+        th2 = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali[1], disable_tqdm=True)
+        th_cj = Thicket.concat_thickets([th1, th2], axis="columns", disable_tqdm=True)
 
         # Check column format
         assert ("name", "") in th_cj.statsframe.dataframe.columns
 
     _test_multiindex()
 
-    th = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali[-1])
+    th = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali[-1], disable_tqdm=True)
 
     # Arbitrary value insertion in aggregated statistics table.
     th.statsframe.dataframe["test"] = 1
@@ -81,7 +81,7 @@ def test_statsframe(rajaperf_seq_O3_1M_cali):
 
 
 def test_metadata_column_to_perfdata(mpi_scaling_cali):
-    t_ens = Thicket.from_caliperreader(mpi_scaling_cali)
+    t_ens = Thicket.from_caliperreader(mpi_scaling_cali, disable_tqdm=True)
 
     example_column = "jobsize"
     example_column_metrics = [27, 64, 125, 216, 343]
@@ -122,7 +122,9 @@ def test_thicketize_graphframe(rajaperf_seq_O3_1M_cali):
 
 
 def test_unique_metadata_base_cuda(rajaperf_cuda_block128_1M_cali):
-    t_ens = Thicket.from_caliperreader(rajaperf_cuda_block128_1M_cali)
+    t_ens = Thicket.from_caliperreader(
+        rajaperf_cuda_block128_1M_cali, disable_tqdm=True
+    )
 
     res = t_ens.get_unique_metadata()
     assert res["systype_build"] == ["blueos_3_ppc64le_ib_p9"]

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -729,7 +729,7 @@ class Thicket(GraphFrame):
         )
 
     @staticmethod
-    def from_statsframes(th_list, metadata_key=None, disable_tqdm=False):
+    def from_statsframes(tk_list, metadata_key=None, disable_tqdm=False):
         """Compose a list of Thickets with data in their statsframes.
 
         The Thicket's individual aggregated statistics tables are ensembled and become the

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -15,6 +15,7 @@ import pandas as pd
 import numpy as np
 from hatchet import GraphFrame
 from hatchet.query import AbstractQuery, QueryMatcher
+import tqdm
 
 from thicket.ensemble import Ensemble
 import thicket.helpers as helpers
@@ -279,7 +280,9 @@ class Thicket(GraphFrame):
         # Parse the input object
         # if a list of files
         if isinstance(obj, (list, tuple)):
-            for file in obj:
+            pbar = tqdm.tqdm(obj)
+            for file in pbar:
+                pbar.set_description("Reading Files: ")
                 ens_list.append(
                     Thicket.thicketize_graphframe(
                         func(file, *extra_args, **kwargs), file
@@ -287,7 +290,9 @@ class Thicket(GraphFrame):
                 )
         # if directory of files
         elif os.path.isdir(obj):
-            for file in os.listdir(obj):
+            pbar = tqdm.tqdm(os.listdir(obj))
+            for file in pbar:
+                pbar.set_description("Reading Files: ")
                 f = os.path.join(obj, file)
                 ens_list.append(
                     Thicket.thicketize_graphframe(func(f, *extra_args, **kwargs), f)

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -369,7 +369,7 @@ class Thicket(GraphFrame):
                 from_statsframes=from_statsframes,
                 disable_tqdm=disable_tqdm,
             )
-            
+
             return Thicket(
                 graph=thicket_parts[0],
                 dataframe=thicket_parts[1],

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -291,13 +291,14 @@ class Thicket(GraphFrame):
         extra_args = []
         if len(args) > 1:
             extra_args = args[1:]
+        pbar_desc = "(1/2) Reading Files"
 
         # Parse the input object
         # if a list of files
         if isinstance(obj, (list, tuple)):
             pbar = tqdm.tqdm(obj, disable=disable_tqdm)
             for file in pbar:
-                pbar.set_description("Reading Files: ")
+                pbar.set_description(pbar_desc)
                 ens_list.append(
                     Thicket.thicketize_graphframe(
                         func(file, *extra_args, **kwargs), file
@@ -307,7 +308,7 @@ class Thicket(GraphFrame):
         elif os.path.isdir(obj):
             pbar = tqdm.tqdm(os.listdir(obj), disable=disable_tqdm)
             for file in pbar:
-                pbar.set_description("Reading Files: ")
+                pbar.set_description(pbar_desc)
                 f = os.path.join(obj, file)
                 ens_list.append(
                     Thicket.thicketize_graphframe(func(f, *extra_args, **kwargs), f)

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -684,7 +684,7 @@ class Thicket(GraphFrame):
         )
 
     @staticmethod
-    def from_statsframes(th_list, metadata_key=None):
+    def from_statsframes(th_list, metadata_key=None, disable_tqdm=False):
         """Compose a list of Thickets with data in their statsframes.
 
         The Thicket's individual aggregated statistics tables are ensembled and become the
@@ -775,7 +775,9 @@ class Thicket(GraphFrame):
             # Append copy to list
             th_copy_list.append(th_copy)
 
-        return Thicket.concat_thickets(th_copy_list, from_statsframes=True)
+        return Thicket.concat_thickets(
+            th_copy_list, from_statsframes=True, disable_tqdm=disable_tqdm
+        )
 
     def to_json(self, ensemble=True, metadata=True, stats=True):
         jsonified_thicket = {}

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -818,7 +818,7 @@ class Thicket(GraphFrame):
             tk_copy_list.append(tk_copy)
 
         return Thicket.concat_thickets(
-            th_copy_list, from_statsframes=True, disable_tqdm=disable_tqdm
+            tk_copy_list, from_statsframes=True, disable_tqdm=disable_tqdm
         )
 
     def to_json(self, ensemble=True, metadata=True, stats=True):


### PR DESCRIPTION
# Summary
Use `tqdm` to add a progress bar to the thicket reader since for larger amount of files (~1000+) in can take in the magnitude of minutes without any indication to the user (we don't want it to seem like it's hanging). The progress bar is in 2 stages for reading the files, and creating the thickets.

![image](https://github.com/LLNL/thicket/assets/32579379/7ee25956-808c-407b-89e9-87e1531aba49)