### PR TITLE
Moves stats imports from top-level __init__.py to stats folder

### DIFF
--- a/thicket/__init__.py
+++ b/thicket/__init__.py
@@ -10,17 +10,4 @@ from .ensemble import Ensemble
 from .thicket import Thicket
 from .thicket import InvalidFilter
 from .thicket import EmptyMetadataTable
-from .stats.maximum import maximum
-from .stats.mean import mean
-from .stats.median import median
-from .stats.minimum import minimum
-from .stats.percentiles import percentiles
-from .stats.std import std
-from .stats.variance import variance
-from .stats.calc_boxplot_statistics import calc_boxplot_statistics
-from .stats.correlation_nodewise import correlation_nodewise
-from .stats.check_normality import check_normality
-from .stats.display_boxplot import display_boxplot
-from .stats.display_histogram import display_histogram
-from .stats.display_heatmap import display_heatmap
 from .version import __version__

--- a/thicket/__init__.py
+++ b/thicket/__init__.py
@@ -8,6 +8,13 @@
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
+# Imports of subdirectories to prevent namespace package issues
+# Don't re-export vis so that we don't trigger NPM building on every Thicket import
+from . import (
+    external as external,
+    stats as stats,
+)
+
 from .ensemble import Ensemble
 from .thicket import Thicket
 from .thicket import InvalidFilter

--- a/thicket/__init__.py
+++ b/thicket/__init__.py
@@ -6,6 +6,8 @@
 # make flake8 unused names in this file.
 # flake8: noqa: F401
 
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)
+
 from .ensemble import Ensemble
 from .thicket import Thicket
 from .thicket import InvalidFilter

--- a/thicket/stats/__init__.py
+++ b/thicket/stats/__init__.py
@@ -2,3 +2,27 @@
 # Thicket Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
+
+# make flake8 unused names in this file.
+# flake8: noqa: F401
+
+from .maximum import maximum
+from .mean import mean
+from .median import median
+from .minimum import minimum
+from .percentiles import percentiles
+from .std import std
+from .variance import variance
+from .calc_boxplot_statistics import calc_boxplot_statistics
+from .correlation_nodewise import correlation_nodewise
+from .check_normality import check_normality
+
+try:
+    import seaborn as sns
+except:
+    print("Seaborn not found, so skipping imports of plotting in thicket.stats")
+    print("To enable this plotting, install seaborn or thicket[plotting]")
+else:
+    from .display_boxplot import display_boxplot
+    from .display_histogram import display_histogram
+    from .display_heatmap import display_heatmap

--- a/thicket/tests/test_display.py
+++ b/thicket/tests/test_display.py
@@ -15,7 +15,7 @@ def test_display_histogram(example_cali):
 
     node = pd.unique(tk.dataframe.reset_index()["node"])[4]
 
-    ax = th.display_histogram(thicket=tk, node=node, column="Min time/rank")
+    ax = th.stats.display_histogram(thicket=tk, node=node, column="Min time/rank")
 
     # check title
     assert ax[0][0].get_title() == "Min time/rank"
@@ -25,31 +25,31 @@ def test_display_histogram(example_cali):
         ValueError,
         match="Both 'node' and 'column' must be provided. To see a list of valid columns, run 'Thicket.performance_cols'.",
     ):
-        ax = th.display_histogram(thicket=tk)
+        ax = th.stats.display_histogram(thicket=tk)
     # Check thicket argument must be thicket.Thicket
     with pytest.raises(
         ValueError,
         match="Value passed to 'thicket' argument must be of type thicket.Thicket.",
     ):
-        ax = th.display_histogram(thicket=1, node=node, column="Min time/rank")
+        ax = th.stats.display_histogram(thicket=1, node=node, column="Min time/rank")
     # Check node argument must be hatchet.node.Node
     with pytest.raises(
         ValueError,
         match="Value passed to 'node' argument must be of type hatchet.node.Node.",
     ):
-        ax = th.display_histogram(thicket=tk, node=1, column="Min time/rank")
+        ax = th.stats.display_histogram(thicket=tk, node=1, column="Min time/rank")
     # Check column argument
     with pytest.raises(
         ValueError,
         match=r"Value passed to column argument must be of type str \(or tuple\(str\) for column thickets\).",
     ):
-        ax = th.display_histogram(thicket=tk, node=node, column=1)
+        ax = th.stats.display_histogram(thicket=tk, node=node, column=1)
     # Check column argument must exist
     with pytest.raises(
         RuntimeError,
         match=r"Specified column\(s\) not found: \['non-existant-column'\]",
     ):
-        th.display_histogram(thicket=tk, node=node, column="non-existant-column")
+        th.stats.display_histogram(thicket=tk, node=node, column="non-existant-column")
 
     plt.close()
 
@@ -59,7 +59,7 @@ def test_display_histogram_columnar_join(thicket_axis_columns):
 
     node = pd.unique(combined_th.dataframe.reset_index()["node"])[0]
 
-    ax = th.display_histogram(
+    ax = th.stats.display_histogram(
         combined_th, node=node, column=("Cuda128", "Min time/rank")
     )
 
@@ -71,7 +71,7 @@ def test_display_histogram_columnar_join(thicket_axis_columns):
         RuntimeError,
         match=r"Specified column\(s\) not found: \[\('fake_1', 'fake_2'\)\]",
     ):
-        th.display_histogram(
+        th.stats.display_histogram(
             thicket=combined_th, node=node, column=("fake_1", "fake_2")
         )
 
@@ -83,7 +83,7 @@ def test_display_heatmap(example_cali):
 
     th.variance(tk, columns=["Min time/rank"])
 
-    ax = th.display_heatmap(tk, columns=["Min time/rank_var"])
+    ax = th.stats.display_heatmap(tk, columns=["Min time/rank_var"])
 
     # check to make sure that a figure is generated
     assert plt.get_fignums()[0] == 1
@@ -99,25 +99,25 @@ def test_display_heatmap(example_cali):
         ValueError,
         match="Chosen columns must be from the thicket.statsframe.dataframe.",
     ):
-        ax = th.display_heatmap(thicket=tk)
+        ax = th.stats.display_heatmap(thicket=tk)
     # Check thicket argument must be thicket.Thicket
     with pytest.raises(
         ValueError,
         match="Value passed to 'thicket' argument must be of type thicket.Thicket.",
     ):
-        ax = th.display_heatmap(thicket=1, columns=["Min time/rank_var"])
+        ax = th.stats.display_heatmap(thicket=1, columns=["Min time/rank_var"])
     # Check columns argument
     with pytest.raises(
         ValueError,
         match="Value passed to 'columns' argument must be of type list.",
     ):
-        ax = th.display_heatmap(thicket=tk, columns=1)
+        ax = th.stats.display_heatmap(thicket=tk, columns=1)
     # Check column must exist
     with pytest.raises(
         RuntimeError,
         match=r"Specified column\(s\) not found: \['fake_col'\]",
     ):
-        th.display_heatmap(thicket=tk, columns=["fake_col"])
+        th.stats.display_heatmap(thicket=tk, columns=["fake_col"])
 
     plt.close()
 
@@ -127,7 +127,9 @@ def test_display_heatmap_columnar_join(thicket_axis_columns):
 
     th.variance(combined_th, columns=[("Cuda128", "Min time/rank")])
 
-    ax = th.display_heatmap(combined_th, columns=[("Cuda128", "Min time/rank_var")])
+    ax = th.stats.display_heatmap(
+        combined_th, columns=[("Cuda128", "Min time/rank_var")]
+    )
 
     # check to make sure that a figure is generated
     assert plt.get_fignums()[0] == 1
@@ -145,7 +147,7 @@ def test_display_heatmap_columnar_join(thicket_axis_columns):
         RuntimeError,
         match=r"Specified column\(s\) not found: \[\('fake_1', 'fake_2'\)\]",
     ):
-        th.display_heatmap(thicket=combined_th, columns=[("fake_1", "fake_2")])
+        th.stats.display_heatmap(thicket=combined_th, columns=[("fake_1", "fake_2")])
 
     plt.close()
 
@@ -155,7 +157,7 @@ def test_display_boxplot(example_cali):
 
     nodes = list(pd.unique(tk.dataframe.reset_index()["node"])[0:2])
 
-    ax = th.display_boxplot(tk, nodes=nodes, columns=["Min time/rank"])
+    ax = th.stats.display_boxplot(tk, nodes=nodes, columns=["Min time/rank"])
 
     # check to make sure that a figure is generated
     assert plt.get_fignums()[0] == 1
@@ -169,37 +171,39 @@ def test_display_boxplot(example_cali):
         ValueError,
         match="Both 'nodes' and 'columns' must be provided. To see a list of valid columns, run 'Thicket.performance_cols'.",
     ):
-        ax = th.display_boxplot(thicket=tk)
+        ax = th.stats.display_boxplot(thicket=tk)
     # Check thicket argument must be thicket.Thicket
     with pytest.raises(
         ValueError,
         match="Value passed to 'thicket' argument must be of type thicket.Thicket.",
     ):
-        ax = th.display_boxplot(thicket=1, nodes=nodes, columns=["Min time/rank"])
+        ax = th.stats.display_boxplot(thicket=1, nodes=nodes, columns=["Min time/rank"])
     # Check nodes argument must be list
     with pytest.raises(
         ValueError,
         match="Value passed to 'nodes' argument must be of type list.",
     ):
-        ax = th.display_boxplot(thicket=tk, nodes=1, columns=["Min time/rank"])
+        ax = th.stats.display_boxplot(thicket=tk, nodes=1, columns=["Min time/rank"])
     # Check columns argument
     with pytest.raises(
         ValueError,
         match="Value passed to 'columns' argument must be of type list.",
     ):
-        ax = th.display_boxplot(thicket=tk, nodes=nodes, columns=1)
+        ax = th.stats.display_boxplot(thicket=tk, nodes=nodes, columns=1)
     # Check column argument must exist
     with pytest.raises(
         RuntimeError,
         match=r"Specified column\(s\) not found: \['non-existant-column'\]",
     ):
-        th.display_boxplot(thicket=tk, nodes=nodes, columns=["non-existant-column"])
+        th.stats.display_boxplot(
+            thicket=tk, nodes=nodes, columns=["non-existant-column"]
+        )
     # Check nodes argument contains hatchet nodes
     with pytest.raises(
         ValueError,
         match=r"Value\(s\) passed to node argument must be of type hatchet.node.Node.",
     ):
-        ax = th.display_boxplot(thicket=tk, nodes=[1], columns=["Min time/rank"])
+        ax = th.stats.display_boxplot(thicket=tk, nodes=[1], columns=["Min time/rank"])
 
     plt.close()
 
@@ -209,7 +213,7 @@ def test_display_boxplot_columnar_join(thicket_axis_columns):
 
     nodes = pd.unique(combined_th.dataframe.reset_index()["node"])[0:1].tolist()
 
-    ax = th.display_boxplot(
+    ax = th.stats.display_boxplot(
         combined_th, nodes=nodes, columns=[("Cuda128", "Min time/rank")]
     )
 
@@ -225,7 +229,7 @@ def test_display_boxplot_columnar_join(thicket_axis_columns):
         RuntimeError,
         match=r"Specified column\(s\) not found: \[\('fake_1', 'fake_2'\)\]",
     ):
-        th.display_boxplot(
+        th.stats.display_boxplot(
             thicket=combined_th, nodes=nodes, columns=[("fake_1", "fake_2")]
         )
 

--- a/thicket/tests/test_display.py
+++ b/thicket/tests/test_display.py
@@ -81,7 +81,7 @@ def test_display_histogram_columnar_join(thicket_axis_columns):
 def test_display_heatmap(example_cali):
     tk = th.Thicket.from_caliperreader(example_cali)
 
-    th.variance(tk, columns=["Min time/rank"])
+    th.stats.variance(tk, columns=["Min time/rank"])
 
     ax = th.stats.display_heatmap(tk, columns=["Min time/rank_var"])
 
@@ -125,7 +125,7 @@ def test_display_heatmap(example_cali):
 def test_display_heatmap_columnar_join(thicket_axis_columns):
     thicket_list, thicket_list_cp, combined_th = thicket_axis_columns
 
-    th.variance(combined_th, columns=[("Cuda128", "Min time/rank")])
+    th.stats.variance(combined_th, columns=[("Cuda128", "Min time/rank")])
 
     ax = th.stats.display_heatmap(
         combined_th, columns=[("Cuda128", "Min time/rank_var")]

--- a/thicket/tests/test_stats.py
+++ b/thicket/tests/test_stats.py
@@ -15,7 +15,7 @@ def test_mean(example_cali):
 
     assert list(th_ens.statsframe.dataframe.columns) == ["name"]
 
-    th.mean(th_ens, columns=["Min time/rank"])
+    th.stats.mean(th_ens, columns=["Min time/rank"])
 
     assert "Min time/rank_mean" in th_ens.statsframe.dataframe.columns
     assert (
@@ -34,7 +34,7 @@ def test_mean_columnar_join(thicket_axis_columns):
 
     assert list(combined_th.statsframe.dataframe.columns) == [("name", "")]
 
-    th.mean(combined_th, columns=[(idx, "Min time/rank")])
+    th.stats.mean(combined_th, columns=[(idx, "Min time/rank")])
 
     assert (idx, "Min time/rank_mean") in combined_th.statsframe.dataframe.columns
     assert (
@@ -53,7 +53,7 @@ def test_median(example_cali):
 
     assert list(th_ens.statsframe.dataframe.columns) == ["name"]
 
-    th.median(th_ens, columns=["Min time/rank"])
+    th.stats.median(th_ens, columns=["Min time/rank"])
 
     assert "Min time/rank_median" in th_ens.statsframe.dataframe.columns
     assert (
@@ -72,7 +72,7 @@ def test_median_columnar_join(thicket_axis_columns):
 
     assert list(combined_th.statsframe.dataframe.columns) == [("name", "")]
 
-    th.median(combined_th, columns=[(idx, "Min time/rank")])
+    th.stats.median(combined_th, columns=[(idx, "Min time/rank")])
 
     assert (idx, "Min time/rank_median") in combined_th.statsframe.dataframe.columns
     assert (
@@ -91,7 +91,7 @@ def test_minimum(example_cali):
 
     assert list(th_ens.statsframe.dataframe.columns) == ["name"]
 
-    th.minimum(th_ens, columns=["Min time/rank"])
+    th.stats.minimum(th_ens, columns=["Min time/rank"])
 
     assert "Min time/rank_min" in th_ens.statsframe.dataframe.columns
     assert (
@@ -110,7 +110,7 @@ def test_minimum_columnar_join(thicket_axis_columns):
 
     assert list(combined_th.statsframe.dataframe.columns) == [("name", "")]
 
-    th.minimum(combined_th, columns=[(idx, "Min time/rank")])
+    th.stats.minimum(combined_th, columns=[(idx, "Min time/rank")])
 
     assert (idx, "Min time/rank_min") in combined_th.statsframe.dataframe.columns
     assert (
@@ -129,7 +129,7 @@ def test_maximum(example_cali):
 
     assert list(th_ens.statsframe.dataframe.columns) == ["name"]
 
-    th.maximum(th_ens, columns=["Min time/rank"])
+    th.stats.maximum(th_ens, columns=["Min time/rank"])
 
     assert "Min time/rank_max" in th_ens.statsframe.dataframe.columns
     assert (
@@ -148,7 +148,7 @@ def test_maximum_columnar_join(thicket_axis_columns):
 
     assert list(combined_th.statsframe.dataframe.columns) == [("name", "")]
 
-    th.maximum(combined_th, columns=[(idx, "Min time/rank")])
+    th.stats.maximum(combined_th, columns=[(idx, "Min time/rank")])
 
     assert (idx, "Min time/rank_max") in combined_th.statsframe.dataframe.columns
     assert (
@@ -167,7 +167,7 @@ def test_std(example_cali):
 
     assert list(th_ens.statsframe.dataframe.columns) == ["name"]
 
-    th.std(th_ens, columns=["Min time/rank"])
+    th.stats.std(th_ens, columns=["Min time/rank"])
 
     assert "Min time/rank_std" in th_ens.statsframe.dataframe.columns
     assert (
@@ -186,7 +186,7 @@ def test_std_columnar_join(thicket_axis_columns):
 
     assert list(combined_th.statsframe.dataframe.columns) == [("name", "")]
 
-    th.std(combined_th, columns=[(idx, "Min time/rank")])
+    th.stats.std(combined_th, columns=[(idx, "Min time/rank")])
 
     assert (idx, "Min time/rank_std") in combined_th.statsframe.dataframe.columns
     assert (
@@ -204,7 +204,7 @@ def test_percentiles(example_cali):
     )
     assert list(th_ens.statsframe.dataframe.columns) == ["name"]
 
-    th.percentiles(th_ens, columns=["Min time/rank"])
+    th.stats.percentiles(th_ens, columns=["Min time/rank"])
 
     assert "Min time/rank_percentiles_25" in th_ens.statsframe.dataframe.columns
     assert "Min time/rank_percentiles_50" in th_ens.statsframe.dataframe.columns
@@ -230,7 +230,7 @@ def test_percentiles(example_cali):
 def test_percentiles_none(example_cali):
     th_ens = th.Thicket.from_caliperreader(example_cali)
 
-    th.percentiles(th_ens, columns=["Min time/rank"], percentiles=None)
+    th.stats.percentiles(th_ens, columns=["Min time/rank"], percentiles=None)
 
     assert "Min time/rank_percentiles_25" in th_ens.statsframe.dataframe.columns
     assert "Min time/rank_percentiles_50" in th_ens.statsframe.dataframe.columns
@@ -240,7 +240,7 @@ def test_percentiles_none(example_cali):
 def test_percentiles_single_value(example_cali):
     th_ens = th.Thicket.from_caliperreader(example_cali)
 
-    th.percentiles(th_ens, columns=["Min time/rank"], percentiles=[0.3])
+    th.stats.percentiles(th_ens, columns=["Min time/rank"], percentiles=[0.3])
 
     assert "Min time/rank_percentiles_30" in th_ens.statsframe.dataframe.columns
 
@@ -261,7 +261,7 @@ def test_percentiles_columnar_join(thicket_axis_columns):
 
     assert list(combined_th.statsframe.dataframe.columns) == [("name", "")]
 
-    th.percentiles(combined_th, columns=[(idx, "Min time/rank")])
+    th.stats.percentiles(combined_th, columns=[(idx, "Min time/rank")])
 
     assert (
         idx,
@@ -301,7 +301,9 @@ def test_percentiles_columnar_join(thicket_axis_columns):
         "Min time/rank_percentiles_75",
     ) in combined_th.statsframe.show_metric_columns()
 
-    th.percentiles(combined_th, columns=[(idx, "Min time/rank")], percentiles=[0.4])
+    th.stats.percentiles(
+        combined_th, columns=[(idx, "Min time/rank")], percentiles=[0.4]
+    )
 
     assert (
         idx,
@@ -326,7 +328,7 @@ def test_variance(example_cali):
 
     assert list(th_ens.statsframe.dataframe.columns) == ["name"]
 
-    th.variance(th_ens, columns=["Min time/rank"])
+    th.stats.variance(th_ens, columns=["Min time/rank"])
 
     assert "Min time/rank_var" in th_ens.statsframe.dataframe.columns
     assert (
@@ -345,7 +347,7 @@ def test_variance_columnar_join(thicket_axis_columns):
 
     assert list(combined_th.statsframe.dataframe.columns) == [("name", "")]
 
-    th.variance(combined_th, columns=[(idx, "Min time/rank")])
+    th.stats.variance(combined_th, columns=[(idx, "Min time/rank")])
 
     assert (idx, "Min time/rank_var") in combined_th.statsframe.dataframe.columns
     assert (
@@ -364,7 +366,7 @@ def test_normality(rajaperf_basecuda_xl_cali):
 
     assert list(th_ens.statsframe.dataframe.columns) == ["name"]
 
-    th.check_normality(th_ens, columns=["Min time/rank"])
+    th.stats.check_normality(th_ens, columns=["Min time/rank"])
 
     assert th_ens.statsframe.dataframe["Min time/rank_normality"][0] in {
         "True",
@@ -391,7 +393,7 @@ def test_normality_columnar_join(thicket_axis_columns, stats_thicket_axis_column
     assert list(combined_th.statsframe.dataframe.columns) == [("name", "")]
 
     for idx in ["Cuda 1", "Cuda 2"]:
-        th.check_normality(scombined_th, columns=[(idx, "Min time/rank")])
+        th.stats.check_normality(scombined_th, columns=[(idx, "Min time/rank")])
 
         assert (
             idx,
@@ -419,7 +421,7 @@ def test_correlation(rajaperf_basecuda_xl_cali):
 
     assert list(th_ens.statsframe.dataframe.columns) == ["name"]
 
-    th.correlation_nodewise(
+    th.stats.correlation_nodewise(
         th_ens, column1="Min time/rank", column2="Max time/rank", correlation="pearson"
     )
 
@@ -437,7 +439,7 @@ def test_correlation_columnar_join(thicket_axis_columns):
 
     assert list(combined_th.statsframe.dataframe.columns) == [("name", "")]
 
-    th.correlation_nodewise(
+    th.stats.correlation_nodewise(
         combined_th,
         column1=(idx[0], "Min time/rank"),
         column2=(idx[1], "Max time/rank"),
@@ -459,7 +461,7 @@ def test_boxplot(example_cali):
 
     assert list(th_ens.statsframe.dataframe.columns) == ["name"]
 
-    th.calc_boxplot_statistics(
+    th.stats.calc_boxplot_statistics(
         th_ens, columns=["Min time/rank"], quartiles=[0.25, 0.50, 0.75]
     )
 
@@ -543,7 +545,7 @@ def test_boxplot_columnar_join(thicket_axis_columns):
 
     assert list(combined_th.statsframe.dataframe.columns) == [("name", "")]
 
-    th.calc_boxplot_statistics(
+    th.stats.calc_boxplot_statistics(
         combined_th, columns=[(idx, "Min time/rank")], quartiles=[0.25, 0.50, 0.75]
     )
 


### PR DESCRIPTION
Previously, all of our stats functionality was exported through `thicket/__init__.py`. This goes against user expectations from tools like SciPy, and it lead to issues with the optional dependency on seaborn.

To fix this, I have moved all the stats re-exports into `thicket/stats/__init__.py`. So, now, to import e.g., `mean`, users would use one of the following:
```python
# Option 1
from thicket.stats import mean
# Option 2
import thicket as th
th.stats.mean(...)
```

Additionally, this PR wraps all the "display" imports from stats in a try-except-else block that will only import the display functionality of stats when seaborn is present. If it is not present, users will get the following printout:
```bash
Seaborn not found, so skipping imports of plotting in thicket.stats
To enable this plotting, install seaborn or thicket[plotting]
```