### PR TITLE
Prevent test failure if Extra-P is not installed

### DIFF
--- a/thicket/tests/test_model_extrap.py
+++ b/thicket/tests/test_model_extrap.py
@@ -21,7 +21,9 @@ except ImportError:
     extrap_avail = False
 
 if not sys.version_info < (3, 8):
-    pytest.skip("requires python3.8 or greater to use extrap module", allow_module_level=True)
+    pytest.skip(
+        "requires python3.8 or greater to use extrap module", allow_module_level=True
+    )
 
 if not extrap_avail:
     pytest.skip("Extra-P package not available", allow_module_level=True)

--- a/thicket/tests/test_model_extrap.py
+++ b/thicket/tests/test_model_extrap.py
@@ -9,11 +9,24 @@ import pytest
 
 from thicket import Thicket
 
+extrap_avail = True
+try:
+    import extrap.entities as xent
+    from extrap.entities.experiment import (
+        Experiment,
+    )  # For some reason it errors if "Experiment" is not explicitly imported
+    from extrap.fileio import io_helper
+    from extrap.modelers.model_generator import ModelGenerator
+except ImportError:
+    extrap_avail = False
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 8),
-    reason="requires python3.8 or greater to use extrap module",
-)
+if not sys.version_info < (3, 8):
+    pytest.skip("requires python3.8 or greater to use extrap module", allow_module_level=True)
+
+if not extrap_avail:
+    pytest.skip("Extra-P package not available", allow_module_level=True)
+
+
 def test_model_extrap(mpi_scaling_cali):
     from thicket.model_extrap import Modeling
 
@@ -55,10 +68,6 @@ def test_model_extrap(mpi_scaling_cali):
     )
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 8),
-    reason="requires python3.8 or greater to use extrap module",
-)
 def test_componentize_functions(mpi_scaling_cali):
     from thicket.model_extrap import Modeling
 

--- a/thicket/tests/test_model_extrap.py
+++ b/thicket/tests/test_model_extrap.py
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: MIT
 
+# Make flake8 ignore unused names in this file
+# flake8: noqa: F401
+
 import sys
 
 import pytest


### PR DESCRIPTION
This simple PR adds a `pytest.skip` command that will skip over the Extra-P tests if Extra-P is not installed. This allows developers to run unit tests locally without needing to install Extra-P