### PR TITLE
Replaces 'th.' for 'th.stats.' in various places

### DIFF
--- a/docs/stats-functions.ipynb
+++ b/docs/stats-functions.ipynb
@@ -502,13 +502,12 @@
       "        thicket (thicket): Thicket object\n",
       "        columns (list): List of hardware/timing metrics to perform median calculation\n",
       "            on. Note, if using a columnar joined thicket a list of tuples must be passed\n",
-      "            in with the format (column index, column name).\n",
-      "\n"
+      "            in with the format (column index, column name).\n"
      ]
     }
    ],
    "source": [
-    "help(th.median)"
+    "help(th.stats.median)"
    ]
   },
   {
@@ -1431,7 +1430,7 @@
     }
    ],
    "source": [
-    "th.maximum(clang_th, columns=metrics)\n",
+    "th.stats.maximum(clang_th, columns=metrics)\n",
     "# view the first 5 entries of the aggregated statistics table\n",
     "clang_th.statsframe.dataframe.head(5)"
    ]
@@ -1623,7 +1622,7 @@
     }
    ],
    "source": [
-    "th.maximum(combined_th, columns=metrics)\n",
+    "th.stats.maximum(combined_th, columns=metrics)\n",
     "combined_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -1848,7 +1847,7 @@
     }
    ],
    "source": [
-    "th.minimum(clang_th, columns=metrics)\n",
+    "th.stats.minimum(clang_th, columns=metrics)\n",
     "clang_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -2071,7 +2070,7 @@
     }
    ],
    "source": [
-    "th.minimum(combined_th, columns=metrics)\n",
+    "th.stats.minimum(combined_th, columns=metrics)\n",
     "combined_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -2326,7 +2325,7 @@
     }
    ],
    "source": [
-    "th.median(clang_th, columns=metrics)\n",
+    "th.stats.median(clang_th, columns=metrics)\n",
     "clang_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -2581,7 +2580,7 @@
     }
    ],
    "source": [
-    "th.median(combined_th, columns=metrics)\n",
+    "th.stats.median(combined_th, columns=metrics)\n",
     "combined_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -2866,7 +2865,7 @@
     }
    ],
    "source": [
-    "th.mean(clang_th, columns=metrics)\n",
+    "th.stats.mean(clang_th, columns=metrics)\n",
     "clang_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -3153,7 +3152,7 @@
     }
    ],
    "source": [
-    "th.mean(combined_th, columns=metrics)\n",
+    "th.stats.mean(combined_th, columns=metrics)\n",
     "combined_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -3468,7 +3467,7 @@
     }
    ],
    "source": [
-    "th.variance(clang_th, columns=metrics)\n",
+    "th.stats.variance(clang_th, columns=metrics)\n",
     "clang_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -3787,7 +3786,7 @@
     }
    ],
    "source": [
-    "th.variance(combined_th, columns=metrics)\n",
+    "th.stats.variance(combined_th, columns=metrics)\n",
     "combined_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -4132,7 +4131,7 @@
     }
    ],
    "source": [
-    "th.std(clang_th, columns=metrics)\n",
+    "th.stats.std(clang_th, columns=metrics)\n",
     "clang_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -4483,7 +4482,7 @@
     }
    ],
    "source": [
-    "th.std(combined_th, columns=metrics)\n",
+    "th.stats.std(combined_th, columns=metrics)\n",
     "combined_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -4864,7 +4863,7 @@
     }
    ],
    "source": [
-    "th.percentiles(clang_th, columns=metrics)\n",
+    "th.stats.percentiles(clang_th, columns=metrics)\n",
     "clang_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -5248,7 +5247,7 @@
     }
    ],
    "source": [
-    "th.percentiles(combined_th, columns=metrics)\n",
+    "th.stats.percentiles(combined_th, columns=metrics)\n",
     "combined_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -5805,7 +5804,7 @@
     }
    ],
    "source": [
-    "th.check_normality(clang_th, columns=metrics)\n",
+    "th.stats.check_normality(clang_th, columns=metrics)\n",
     "clang_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -6525,7 +6524,7 @@
     }
    ],
    "source": [
-    "th.check_normality(combined_th, columns=metrics)\n",
+    "th.stats.check_normality(combined_th, columns=metrics)\n",
     "combined_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -6591,7 +6590,7 @@
    },
    "outputs": [],
    "source": [
-    "th.correlation_nodewise(clang_th, column1=\"time (exc)\", column2=\"Machine clears\", correlation=\"spearman\")"
+    "th.stats.correlation_nodewise(clang_th, column1=\"time (exc)\", column2=\"Machine clears\", correlation=\"spearman\")"
    ]
   },
   {
@@ -6985,7 +6984,7 @@
    },
    "outputs": [],
    "source": [
-    "th.correlation_nodewise(combined_th, column1=(\"Clang\", \"time (exc)\"), column2=(\"GCC\", \"Machine clears\"), correlation=\"spearman\")"
+    "th.stats.correlation_nodewise(combined_th, column1=(\"Clang\", \"time (exc)\"), column2=(\"GCC\", \"Machine clears\"), correlation=\"spearman\")"
    ]
   },
   {
@@ -7985,7 +7984,7 @@
     }
    ],
    "source": [
-    "th.calc_boxplot_statistics(clang_th, columns=metrics)\n",
+    "th.stats.calc_boxplot_statistics(clang_th, columns=metrics)\n",
     "clang_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -8633,7 +8632,7 @@
     }
    ],
    "source": [
-    "th.calc_boxplot_statistics(combined_th, columns=metrics)\n",
+    "th.stats.calc_boxplot_statistics(combined_th, columns=metrics)\n",
     "combined_th.statsframe.dataframe.head(5)"
    ]
   },
@@ -8770,7 +8769,7 @@
    "source": [
     "plt.figure(figsize=(30, 30))\n",
     "metrics = [\"time (exc)_std\", \"time (exc)_var\"]\n",
-    "th.display_heatmap(th_stats_name, columns=metrics)"
+    "th.stats.display_heatmap(th_stats_name, columns=metrics)"
    ]
   },
   {
@@ -8841,7 +8840,7 @@
    "source": [
     "plt.figure(figsize=(30, 30))\n",
     "metrics = [(\"Clang\", \"time (exc)_std\"), (\"Clang\", \"time (exc)_var\")]\n",
-    "th.display_heatmap(combined_th, columns=metrics)"
+    "th.stats.display_heatmap(combined_th, columns=metrics)"
    ]
   },
   {
@@ -8884,7 +8883,7 @@
    "outputs": [],
    "source": [
     "#metrics = [(\"Clang\", \"time (exc)_std\"), (\"GCC\", \"Machine clears_var\")]\n",
-    "#th.display_heatmap(combined_th, columns=metrics)"
+    "#th.stats.display_heatmap(combined_th, columns=metrics)"
    ]
   },
   {
@@ -9006,7 +9005,7 @@
    ],
    "source": [
     "plt.figure(figsize=(30, 30))\n",
-    "th.display_histogram(clang_th, node=n, column=\"Machine clears\")"
+    "th.stats.display_histogram(clang_th, node=n, column=\"Machine clears\")"
    ]
   },
   {
@@ -9085,7 +9084,7 @@
    ],
    "source": [
     "plt.figure(figsize=(30, 30))\n",
-    "th.display_histogram(combined_th, node=n, column=(\"Clang\", \"Machine clears\"))"
+    "th.stats.display_histogram(combined_th, node=n, column=(\"Clang\", \"Machine clears\"))"
    ]
   },
   {
@@ -9128,7 +9127,7 @@
    "outputs": [],
    "source": [
     "#n = \"not_hatchet_node\"\n",
-    "#th.display_histogram(combined_th, node=n, column=(\"Clang\", \"Machine clears\"))"
+    "#th.stats.display_histogram(combined_th, node=n, column=(\"Clang\", \"Machine clears\"))"
    ]
   },
   {
@@ -9239,7 +9238,7 @@
    ],
    "source": [
     "plt.figure(figsize=(30, 30))\n",
-    "th.display_boxplot(clang_th, nodes=n, columns=[\"Machine clears\", \"Frontend latency\"])"
+    "th.stats.display_boxplot(clang_th, nodes=n, columns=[\"Machine clears\", \"Frontend latency\"])"
    ]
   },
   {
@@ -9309,7 +9308,7 @@
    ],
    "source": [
     "plt.figure(figsize=(30, 30))\n",
-    "th.display_boxplot(combined_th, nodes=n, columns=[(\"Clang\", \"time (exc)\"), (\"Clang\", \"Machine clears\")])"
+    "th.stats.display_boxplot(combined_th, nodes=n, columns=[(\"Clang\", \"time (exc)\"), (\"Clang\", \"Machine clears\")])"
    ]
   },
   {
@@ -9351,7 +9350,7 @@
    },
    "outputs": [],
    "source": [
-    "#th.display_boxplot(combined_th, nodes=n, columns=[(\"Clang\", \"time (exc)\"), (\"GCC\", \"Machine clears\")])"
+    "#th.stats.display_boxplot(combined_th, nodes=n, columns=[(\"Clang\", \"time (exc)\"), (\"GCC\", \"Machine clears\")])"
    ]
   }
  ],

--- a/thicket/stats/ttest.py
+++ b/thicket/stats/ttest.py
@@ -48,8 +48,8 @@ def __ttest(thicket, columns, alpha=0.05, *args, **kwargs):
     # alpha/2 is done for a two tail t-test
     tvalue = t.ppf(q=1 - alpha / 2, df=nobs_column1 + nobs_column2 - len(columns))
 
-    th.mean(thicket, columns)
-    th.std(thicket, columns)
+    th.stats.mean(thicket, columns)
+    th.stats.std(thicket, columns)
 
     # thicket object with columnar index
     if thicket.dataframe.columns.nlevels > 1:


### PR DESCRIPTION
Pretty much just what the title says. This PR just changes some `th.<function>` calls to `th.stats.<function>` due to #132