### PR TITLE
Improve Validation Checks

### DIFF
--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -16,7 +16,6 @@ from .utils import (
     validate_dataframe,
     verify_sorted_profile,
     verify_thicket_structures,
-    DuplicateIndexError,
 )
 
 
@@ -402,7 +401,7 @@ class Ensemble:
                 estr = str(e)
                 if estr == "cannot handle a non-unique multi-index!":
                     warnings.warn(
-                        f"Non-unique multi-index for DataFrame in _fill_perfdata. Cannot Fill missing rows.",
+                        "Non-unique multi-index for DataFrame in _fill_perfdata. Cannot Fill missing rows.",
                         RuntimeWarning,
                     )
                 else:

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -361,11 +361,11 @@ class Ensemble:
         return combined_th
 
     @staticmethod
-    def _index(thickets, from_statsframes=False):
+    def _index(thickets):
         """Unify a list of thickets into a single thicket
 
         Arguments:
-            from_statsframes (bool): Whether this method was invoked from from_statsframes
+            thickets (list): list of Thicket objects
 
         Returns:
             unify_graph (hatchet.Graph): unified graph,

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -219,9 +219,9 @@ class Ensemble:
             combined_th.profile = [new_mappings[prf] for prf in combined_th.profile]
             profile_mapping_cp = combined_th.profile_mapping.copy()
             for k, v in profile_mapping_cp.items():
-                combined_th.profile_mapping[new_mappings[k]] = (
-                    combined_th.profile_mapping.pop(k)
-                )
+                combined_th.profile_mapping[
+                    new_mappings[k]
+                ] = combined_th.profile_mapping.pop(k)
             combined_th.performance_cols = helpers._get_perf_columns(
                 combined_th.dataframe
             )

--- a/thicket/tests/test_concat_thickets.py
+++ b/thicket/tests/test_concat_thickets.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import pytest
 import re
 
 import hatchet as ht
@@ -13,6 +14,7 @@ from test_filter_metadata import filter_multiple_and
 from test_filter_stats import check_filter_stats
 from test_query import check_query
 from thicket import Thicket
+from thicket.utils import DuplicateIndexError
 
 
 def test_concat_thickets_index(mpi_scaling_cali):
@@ -22,14 +24,17 @@ def test_concat_thickets_index(mpi_scaling_cali):
     tk = Thicket.concat_thickets([th_27, th_64])
 
     # Check dataframe shape
-    tk.dataframe.shape == (90, 7)
-
-    # Check that the two Thickets are equivalent
-    assert tk
+    assert tk.dataframe.shape == (90, 7)
 
     # Check specific values. Row order can vary so use "sum" to check
     node = tk.dataframe.index.get_level_values("node")[8]
     assert sum(tk.dataframe.loc[node, "Min time/rank"]) == 0.000453
+
+    # Check error thrown
+    with pytest.raises(
+        DuplicateIndexError,
+    ):
+        Thicket.from_caliperreader([mpi_scaling_cali[0], mpi_scaling_cali[0]])
 
 
 def test_concat_thickets_columns(thicket_axis_columns):

--- a/thicket/tests/test_concat_thickets.py
+++ b/thicket/tests/test_concat_thickets.py
@@ -3,11 +3,11 @@
 #
 # SPDX-License-Identifier: MIT
 
-import pytest
 import re
 
 import hatchet as ht
 import pandas as pd
+import pytest
 
 from test_filter_metadata import filter_one_column
 from test_filter_metadata import filter_multiple_and

--- a/thicket/tests/test_from_statsframes.py
+++ b/thicket/tests/test_from_statsframes.py
@@ -6,7 +6,7 @@
 import pytest
 
 import thicket as th
-from thicket.utils import DuplicateIndexError
+from thicket.utils import DuplicateValueError
 
 
 def test_single_trial(mpi_scaling_cali):
@@ -59,13 +59,9 @@ def test_multi_trial(rajaperf_cali_alltrials):
 
     stk = th.Thicket.from_statsframes(list(gb.values()), metadata_key="tuning")
 
-    # Check if warning is thrown.
-    with pytest.warns(UserWarning, match=r"Multiple values for name.*"):
-        th.Thicket.from_statsframes(list(gb.values()), metadata_key="launchdate")
-
     # Check error thrown for simulated multi-trial
     with pytest.raises(
-        DuplicateIndexError,
+        DuplicateValueError,
     ):
         th.Thicket.from_statsframes(
             [list(gb.values())[0], list(gb.values())[0]], metadata_key="tuning"

--- a/thicket/tests/test_from_statsframes.py
+++ b/thicket/tests/test_from_statsframes.py
@@ -6,7 +6,7 @@
 from thicket import Thicket as th
 
 
-def test_from_statsframes(mpi_scaling_cali):
+def test_single_trial(mpi_scaling_cali):
     th_list = []
     for file in mpi_scaling_cali:
         th_list.append(th.from_caliperreader(file))
@@ -42,3 +42,18 @@ def test_from_statsframes(mpi_scaling_cali):
     }
     # Check performance data table values
     assert set(tk_named.dataframe["test"]) == {0, 2, 4, 6, 8}
+
+
+def test_multi_trial(rajaperf_cali_alltrials):
+    tk = th.from_caliperreader(rajaperf_cali_alltrials)
+
+    # Simulate multiple trial from grouping by tuning.
+    gb = tk.groupby("tuning")
+
+    # Arbitrary data in statsframe.
+    for _, ttk in gb.items():
+        ttk.statsframe.dataframe["mean"] = 1
+
+    stk = th.from_statsframes(list(gb.values()), metadata_key="tuning")
+
+    assert stk.dataframe.shape == (222, 2)

--- a/thicket/tests/test_from_statsframes.py
+++ b/thicket/tests/test_from_statsframes.py
@@ -6,6 +6,7 @@
 import pytest
 
 import thicket as th
+from thicket.utils import DuplicateIndexError
 
 
 def test_single_trial(mpi_scaling_cali):
@@ -46,11 +47,6 @@ def test_single_trial(mpi_scaling_cali):
     assert set(tk_named.dataframe["test"]) == {0, 2, 4, 6, 8}
 
 
-def check_multi_value_warning(gb):
-    with pytest.warns(UserWarning, match=r"Multiple values for name.*"):
-        th.Thicket.from_statsframes(list(gb.values()), metadata_key="launchdate")
-
-
 def test_multi_trial(rajaperf_cali_alltrials):
     tk = th.Thicket.from_caliperreader(rajaperf_cali_alltrials)
 
@@ -64,6 +60,15 @@ def test_multi_trial(rajaperf_cali_alltrials):
     stk = th.Thicket.from_statsframes(list(gb.values()), metadata_key="tuning")
 
     # Check if warning is thrown.
-    check_multi_value_warning(gb)
+    with pytest.warns(UserWarning, match=r"Multiple values for name.*"):
+        th.Thicket.from_statsframes(list(gb.values()), metadata_key="launchdate")
+
+    # Check error thrown for simulated multi-trial
+    with pytest.raises(
+        DuplicateIndexError,
+    ):
+        th.Thicket.from_statsframes(
+            [list(gb.values())[0], list(gb.values())[0]], metadata_key="tuning"
+        )
 
     assert stk.dataframe.shape == (222, 2)

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -19,7 +19,7 @@ from hatchet.query import AbstractQuery, QueryMatcher
 from thicket.ensemble import Ensemble
 import thicket.helpers as helpers
 from .groupby import GroupBy
-from .utils import verify_thicket_structures
+from .utils import verify_thicket_structures, check_duplicate_metadata_key
 from .external.console import ThicketRenderer
 
 
@@ -340,9 +340,7 @@ class Thicket(GraphFrame):
         """
 
         def _index(thickets):
-            thicket_parts = Ensemble._index(
-                thickets=thickets
-            )
+            thicket_parts = Ensemble._index(thickets=thickets)
 
             return Thicket(
                 graph=thicket_parts[0],
@@ -682,6 +680,7 @@ class Thicket(GraphFrame):
             for i in range(len(tk_list)):
                 tk_names.append(i)
         else:  # metadata_key was provided.
+            check_duplicate_metadata_key(tk_list, metadata_key)
             idx_name = metadata_key  # Set index name to metadata_key
             for tk in tk_list:
                 # Get name from metadata table

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -330,9 +330,6 @@ class Thicket(GraphFrame):
             calltree (str): calltree to use -> "union" or "intersection"
 
         Keyword Arguments:
-            from_statsframes (bool): (if axis="index") Whether this method was invoked from from_statsframes
-
-        Keyword Arguments:
             headers (list): (if axis="columns") List of headers to use for the new columnar multi-index
             metadata_key (str): (if axis="columns") Name of the column from the metadata tables to replace the 'profile'
                 index. If no argument is provided, it is assumed that there is no profile-wise
@@ -342,9 +339,9 @@ class Thicket(GraphFrame):
             (thicket): concatenated thicket
         """
 
-        def _index(thickets, from_statsframes=False):
+        def _index(thickets):
             thicket_parts = Ensemble._index(
-                thickets=thickets, from_statsframes=from_statsframes
+                thickets=thickets
             )
 
             return Thicket(
@@ -740,7 +737,7 @@ class Thicket(GraphFrame):
             # Append copy to list
             tk_copy_list.append(tk_copy)
 
-        return Thicket.concat_thickets(tk_copy_list, from_statsframes=True)
+        return Thicket.concat_thickets(tk_copy_list)
 
     def to_json(self, ensemble=True, metadata=True, stats=True):
         jsonified_thicket = {}

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -692,7 +692,7 @@ class Thicket(GraphFrame):
 
                 if len(set(name_list)) > 1:
                     warnings.warn(
-                        f"Multiple values for name {name_list} at thicket.metadata[{metadata_key}]. Only the first will be used."
+                        f"Multiple values for name {name_list} at thicket.metadata['{metadata_key}']. Only the first value will be used for the new DataFrame index."
                     )
                 tk_names.append(name_list[0])
 

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -657,7 +657,7 @@ class Thicket(GraphFrame):
         """Compose a list of Thickets with data in their statsframes.
 
         The Thicket's individual aggregated statistics tables are ensembled and become the
-        new Thickets performance data table.
+        new Thickets performance data table. This also results in aggregation of the metadata.
 
         Arguments:
             tk_list (list): list of thickets
@@ -702,8 +702,7 @@ class Thicket(GraphFrame):
 
             tk_id = tk_names[i]
 
-            # Modify graph
-            # Necessary so node ids match up
+            # Modify graph. Necessary so node ids match up
             tk_copy.graph = tk_copy.statsframe.graph
 
             # Modify the performance data table

--- a/thicket/utils.py
+++ b/thicket/utils.py
@@ -6,6 +6,19 @@
 from collections import OrderedDict
 
 
+# Define custom errors for external checks
+class DuplicateIndexError(IndexError):
+    pass
+
+
+class MissingHNIDError(ValueError):
+    pass
+
+
+class InvalidNameError(ValueError):
+    pass
+
+
 def check_same_frame(n1, n2):
     if n1.frame != n2.frame:
         raise ValueError(
@@ -22,8 +35,8 @@ def validate_dataframe(df):
             inner_idx_values = sorted(df.loc[node].index.tolist())
             inner_idx_values_set = sorted(list(set(inner_idx_values)))
             if inner_idx_values != inner_idx_values_set:
-                raise IndexError(
-                    f"The Thicket.dataframe's index has duplicate values. {inner_idx_values}"
+                raise DuplicateIndexError(
+                    f"Duplicate index {set(inner_idx_values)} found in DataFrame index.\nCheck that each Thicket.dataframe.index is unique. If metadata_key provided, check that each key is unique. Multiple-trial data must be aggregated before using this function (see Thicket.groupby.agg())."
                 )
 
     def _check_missing_hnid(df):
@@ -32,7 +45,7 @@ def validate_dataframe(df):
         set_of_nodes = set(df.index.get_level_values("node"))
         for node in set_of_nodes:
             if hash(node) != i:
-                raise ValueError(
+                raise MissingHNIDError(
                     f"The Thicket.dataframe's index is either not sorted or has a missing node. {hash(node)} ({node}) != {i}"
                 )
             i += 1
@@ -44,7 +57,7 @@ def validate_dataframe(df):
             node_name = node.frame["name"]
             for name in names:
                 if name != node_name and name is not None:
-                    raise ValueError(
+                    raise InvalidNameError(
                         f"Value in the Thicket.dataframe's 'name' column is not valid. {name} != {node_name}"
                     )
 

--- a/thicket/utils.py
+++ b/thicket/utils.py
@@ -31,6 +31,15 @@ def check_same_frame(n1, n2):
 
 
 def check_duplicate_metadata_key(thickets, metadata_key):
+    """Check for duplicate values in the metadata of a list of Thickets for column 'metadata_key'.
+    
+    Arguments:
+        thickets (list): list of Thickets to check
+        metadata_key (str): metadata key to check for duplicates
+
+    Returns:
+        Raises an error if any duplicate metadata values are found
+    """
     duplicates_dict = defaultdict(list)
     for i in range(len(thickets)):
         for j in range(i, len(thickets)):

--- a/thicket/utils.py
+++ b/thicket/utils.py
@@ -32,7 +32,7 @@ def check_same_frame(n1, n2):
 
 def check_duplicate_metadata_key(thickets, metadata_key):
     """Check for duplicate values in the metadata of a list of Thickets for column 'metadata_key'.
-    
+
     Arguments:
         thickets (list): list of Thickets to check
         metadata_key (str): metadata key to check for duplicates


### PR DESCRIPTION
# Summary
Currently if a unification operation results in a duplicate index in the perfdata multi-index, users will hit an error during the `_fill_perfdata` function. By moving the validation check before this function, which checks for duplicates, we can provide a clearer error message, which results in faster debugging for us and the user.

# Example
## New
### For cases without metadata_key
```
DuplicateIndexError: Duplicate index {798655681} found in DataFrame index.
```
### For cases with metadata_key
```
DuplicateValueError: Different Thicket.metadata[metadata_key] may not contain duplicate values.
thickets[0].metadata['tuning'] and thickets[1].metadata['tuning'] have the same values: [{'block_128'}]
```
## Old
```
ValueError: cannot handle a non-unique multi-index!
```