### PR TITLE
Add Pickle Reader/Writer Interface

### DIFF
--- a/thicket/tests/test_pickle.py
+++ b/thicket/tests/test_pickle.py
@@ -1,0 +1,22 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Thicket Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import thicket as th
+
+def test_pickle(rajaperf_cali_1trial, tmpdir):
+    """Test pickling and unpickling of Thicket object."""
+
+    # Create thicket
+    tk = th.Thicket.from_caliperreader(rajaperf_cali_1trial)
+
+    # Create temporary pickle file and write to it
+    pkl_file = tmpdir.join("tk.pkl")
+    tk.to_pickle(pkl_file)
+
+    # Read from pickle file
+    ptk = th.Thicket.from_pickle(pkl_file)
+
+    # Compare original and pickled thicket
+    assert tk == ptk

--- a/thicket/tests/test_pickle.py
+++ b/thicket/tests/test_pickle.py
@@ -5,6 +5,7 @@
 
 import thicket as th
 
+
 def test_pickle(rajaperf_cali_1trial, tmpdir):
     """Test pickling and unpickling of Thicket object."""
 

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -5,6 +5,7 @@
 
 import copy
 import os
+import pickle
 import sys
 import json
 import warnings
@@ -200,6 +201,15 @@ class Thicket(GraphFrame):
             th.dataframe.set_index(index_names, inplace=True)
 
         return th
+
+    @staticmethod
+    def from_pickle(filename, **kwargs):
+        """Read in a Thicket from a pickle file."""
+        return pickle.load(open(filename, "rb"), **kwargs)
+
+    def to_pickle(self, filename, **kwargs):
+        """Write a Thicket to a pickle file."""
+        pickle.dump(self, open(filename, "wb"), **kwargs)
 
     @staticmethod
     def from_caliper(


### PR DESCRIPTION
# Summary
Simple wrapper support for calling `Thicket.to_pickle()` and `Thicket.from_pickle()`. This introduces our first functionality for writing Thicket objects to a file, which becomes useful when working with large Thickets.

# Writing & Reading
`Thicket.to_pickle()` and `Thicket.from_pickle()` accept keyword arguments, so any arguments to `pickle.dump()` and `pickle.load()`, respectively. This will especially be important if the user wants to change the pickling `protocol` version. [`Thicket.from_pickle()` will be able to detect `protocol` verison automatically](https://docs.python.org/3/library/pickle.html#:~:text=The-,protocol%20version%20of%20the%20pickle%20is%20detected%20automatically%2C%20so%20no%20protocol%20argument%20is%20needed.%20Bytes%20past%20the%20pickled%20representation%20of%20the%20object%20are%20ignored.,-Arguments%20file%2C), as long as the [python version supports the protocol](https://docs.python.org/3/library/pickle.html#:~:text=There%20are%20currently%206%20different%20protocols%20which%20can%20be%20used%20for%20pickling.%20The%20higher%20the%20protocol%20used%2C%20the%20more%20recent%20the%20version%20of%20Python%20needed%20to%20read%20the%20pickle%20produced.).

# Potential Compatibility Issues
[The pickle serialization format is guaranteed to be backwards compatible across Python releases provided a compatible pickle protocol is chosen](https://docs.python.org/3/library/pickle.html#:~:text=The%20pickle%20serialization%20format%20is%20guaranteed%20to%20be%20backwards%20compatible%20across%20Python%20releases%20provided%20a%20compatible%20pickle%20protocol%20is%20chosen).

Pickle by default writes using the `pickle.DEFAULT_PROTOCOL` version. The default protocol for `python>=3.8` is version 4, which is supported by all `python>=3.4`. Since we have pinned [`python_requires=">=3.6.1"`](https://github.com/LLNL/thicket/blob/b722879b08f2f21d2cab22540532928ea3fbfa24/setup.py#L36), **we should not run into any pickle backwards compatibility issues in Thicket** as long as users do not mess with the pickling protocol when writing with `Thicket.to_pickle()`. 

The only compatibility issue case as of now is if a user wrote a pickled Thicket using `Thicket.to_pickle(..., protocol=5)` with `python>=3.8` and attempted to unpickle with `python==3.6` or `python==3.7`, since these do not support protocol version 5. This is a niche case since protocol version 5 is not a default version for any python and would need to manually be specified. It could also be avoided by using `Thicket.to_pickle()` with default protocol version 4 or `Thicket.to_pickle(..., protocol=4)`.

# Performance
On protocol version 4, `python==3.11.7`
| Metric | Thicket A | Thicket B | Thicket C | LBANN Thicket |
|---|---|---|---|---|
| Profiles | 16874 | 12099 | 991 | 16 |
| Nodes | 156 | 95 | 19 | 7106 |
| Dataframe Shape | (2632344, 16) (2509582 NA rows) | (122762, 16) (0 NA rows) | (18829, 8) (? NA rows) | (113696, 11) (6799 NA rows) |
| Metadata Shape | (16872, 65) | (12099, 65) | (991, 33) | (16, 32) |
|---|---|---|---|---|
| Pickling Time | 0.5s | 0.1s | >0.1s | >0.1s |
| Unpickling Time | 0.4s | 0.1s | >0.1s | >0.1s |
| pkl File Size | 362MB | 56MB | 4MB | 12MB |
| Thicket Reader Time | 200 **minutes** | N/A | 27s | 12 **minutes**

Thicket B is a filtered version of Thicket A (mostly NaNs in the dataframe). You can see the impact on resulting pickle file size.  Additionally, see how much faster unpickling is than Thicket reader `from_caliperreader`.