### PR TITLE
Fix filter_stats

### DIFF
--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -25,7 +25,7 @@ from .utils import (
     verify_thicket_structures,
     check_duplicate_metadata_key,
     validate_profile,
-    validate_nodes
+    validate_nodes,
 )
 from .external.console import ThicketRenderer
 

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -8,12 +8,13 @@ import os
 import sys
 import json
 import warnings
-from collections import OrderedDict
+from collections import defaultdict, OrderedDict
 from hashlib import md5
 
 import pandas as pd
 import numpy as np
 from hatchet import GraphFrame
+from hatchet.graph import Graph
 from hatchet.query import AbstractQuery, QueryMatcher
 import tqdm
 
@@ -508,29 +509,113 @@ class Thicket(GraphFrame):
 
         Arguments:
             update_inc_cols (boolean, optional): if True, update inclusive columns.
-            new_statsframe (boolean, optional): if True, create a new statsframe from the new dataframe.
+            new_statsframe (boolean, optional): if True, create a new statsframe from the new dataframe. Only set to False if the statsframe nodes equal the dataframe nodes.
 
         Returns:
             (thicket): a newly squashed Thicket object
         """
-        squashed_gf = GraphFrame.squash(self, update_inc_cols=update_inc_cols)
-        new_graph = squashed_gf.graph
-        # The following code updates the performance data and the aggregated statistics
-        # table with the remaining (re-indexed) nodes. The dataframe is internally
-        # updated in squash(), so we can easily just save it to our thicket performance
-        # data.
-        new_dataframe = squashed_gf.dataframe
+
+        #####
+        # Hatchet's squash code
+        #####
+        index_names = self.dataframe.index.names
+        self.dataframe.reset_index(inplace=True)
+
+        # create new nodes for each unique node in the old dataframe
+        old_to_new = {n: n.copy() for n in set(self.dataframe["node"])}
+        for i in old_to_new:
+            old_to_new[i]._hatchet_nid = i._hatchet_nid
+
+        # Maintain sets of connections to make for each old node.
+        # Start with old -> new mapping and update as we traverse subgraphs.
+        connections = defaultdict(lambda: set())
+        connections.update({k: {v} for k, v in old_to_new.items()})
+
+        new_roots = []  # list of new roots
+
+        # connect new nodes to children according to transitive
+        # relationships in the old graph.
+        def rewire(node, new_parent, visited):
+            # make all transitive connections for the node we're visiting
+            for n in connections[node]:
+                if new_parent:
+                    # there is a parent in the new graph; connect it
+                    if n not in new_parent.children:
+                        new_parent.add_child(n)
+                        n.add_parent(new_parent)
+
+                elif n not in new_roots:
+                    # this is a new root
+                    new_roots.append(n)
+
+            new_node = old_to_new.get(node)
+            transitive = set()
+            if node not in visited:
+                visited.add(node)
+                for child in node.children:
+                    transitive |= rewire(child, new_node or new_parent, visited)
+
+            if new_node:
+                # since new_node exists in the squashed graph, we only
+                # need to connect new_node
+                return {new_node}
+            else:
+                # connect parents to the first transitively reachable
+                # new_nodes of nodes we're removing with this squash
+                connections[node] |= transitive
+                return connections[node]
+
+        # run rewire for each root and make a new graph
+        visited = set()
+        for root in self.graph.roots:
+            rewire(root, None, visited)
+        graph = Graph(new_roots)
+        if self.graph.node_ordering:
+            graph.node_ordering = True
+        graph.enumerate_traverse()
+
+        # reindex new dataframe with new nodes
+        df = self.dataframe.copy()
+        df["node"] = df["node"].apply(lambda x: old_to_new[x])
+
+        # at this point, the graph is potentially invalid, as some nodes
+        # may have children with identical frames.
+        merges = graph.normalize()
+        df["node"] = df["node"].apply(lambda n: merges.get(n, n))
+
+        self.dataframe.set_index(index_names, inplace=True)
+        df.set_index(index_names, inplace=True)
+        # create dict that stores aggregation function for each column
+        agg_dict = {}
+        for col in df.columns.tolist():
+            if col in self.exc_metrics + self.inc_metrics:
+                # use min_count=1 (default is 0) here, so sum of an all-NA
+                # series is NaN, not 0
+                # when min_count=1, sum([NaN, NaN)] = NaN
+                # when min_count=0, sum([NaN, NaN)] = 0
+                agg_dict[col] = lambda x: x.sum(min_count=1)
+            else:
+                agg_dict[col] = lambda x: x.iloc[0]
+
+        # perform a groupby to merge nodes with the same callpath
+        agg_df = df.groupby(index_names).agg(agg_dict)
+        agg_df.sort_index(inplace=True)
+
+        #####
+        # Thicket's squash code
+        #####
         multiindex = False
         if isinstance(self.statsframe.dataframe.columns, pd.MultiIndex):
             multiindex = True
+
         if new_statsframe:
-            stats_df = helpers._new_statsframe_df(new_dataframe, multiindex=multiindex)
+            stats_df = helpers._new_statsframe_df(agg_df, multiindex=multiindex)
             sframe = GraphFrame(
-                graph=new_graph,
+                graph=graph,
                 dataframe=stats_df,
             )
         else:
-            old_to_new = squashed_gf.old_to_new
+            # Update the node objects in the old statsframe.
             sframe = self.statsframe
             sframe.dataframe = sframe.dataframe.reset_index()
             replace_dict = {}
@@ -541,8 +626,8 @@ class Thicket(GraphFrame):
             sframe.dataframe = sframe.dataframe.set_index("node")
 
         new_tk = Thicket(
-            new_graph,
-            new_dataframe,
+            graph,
+            agg_df,
             exc_metrics=self.exc_metrics,
             inc_metrics=self.inc_metrics,
             default_metric=self.default_metric,
@@ -551,6 +636,9 @@ class Thicket(GraphFrame):
             profile_mapping=self.profile_mapping,
             statsframe=sframe,
         )
+
+        if update_inc_cols:
+            new_tk.update_inclusive_columns()
 
         new_tk._sync_profile_components(new_tk.dataframe)
         validate_profile(new_tk)

--- a/thicket/utils.py
+++ b/thicket/utils.py
@@ -225,3 +225,34 @@ def verify_thicket_structures(thicket_component, columns=[], index=[]):
             + str(missing_index)
             + " required for the function"
         )
+
+
+def validate_nodes(tk):
+    """Check if node objects match between Thicket.graph, Thicket.dataframe, and Thicket.statsframe.dataframe."""
+
+    components_dict = {
+        "Thicket.graph": {id(n): n for n in tk.graph.traverse()},
+        "Thicket.dataframe": {
+            id(n): n for n in tk.dataframe.index.get_level_values("node")
+        },
+        "Thicket.statsframe.dataframe": {
+            id(n): n for n in tk.statsframe.dataframe.index
+        },
+    }
+
+    set_list = [set(component.keys()) for component in components_dict.values()]
+    difference = set.union(*set_list) - set.intersection(*set_list)
+
+    debug_str = ""
+    for name, node_dict in components_dict.items():
+        debug_str += name + ":\n"
+        for node_id in node_dict:
+            if node_id in difference:
+                debug_str += (
+                    f"\t{hash(node_dict[node_id])} {node_dict[node_id]} {node_id}\n"
+                )
+
+    if len(difference) > 0:
+        raise ValueError(
+            f"Node objects do not match between Thicket.graph, Thicket.dataframe, and Thicket.statsframe.dataframe.\n{debug_str}"
+        )


### PR DESCRIPTION
# Summary
This PR addresses the bug found in https://github.com/LLNL/thicket/issues/147. The fix leverages the `old_to_new` mapping created in `squash` to synchronize the node objects in the `statsframe.dataframe` with the `graph` and `dataframe`. This introduces a new capability in `Thicket.squash` to update the statsframe instead of creating a new one every time (`new_statsframe=False/True`). Additionally, a utils function is added and called in `filter_stats` to check for the invalid state observed in the bug. This PR also migrates hatchet squash code to Thicket squash to expose the `old_to_new` object and is a part of a decoupling effort for `Thicket` dependencies on `Hatchet`.

Fixes #147 

Example output from the utility:
![image](https://github.com/LLNL/thicket/assets/32579379/22b6380c-5f56-413e-b315-59e326befb19)
