### PR TITLE
Refinements to display_violinplot_thicket Function

### DIFF
--- a/thicket/stats/display_violinplot.py
+++ b/thicket/stats/display_violinplot.py
@@ -381,6 +381,12 @@ def display_violinplot_thicket(
             "Value(s) passed to 'nodes' argument must be of type hatchet.node.Node."
         )
 
+    # Verify that all nodes passed are of the same type and name
+    if len(set(nodes.values())) != 1:
+        raise ValueError(
+            "Value(s) passed to 'nodes' argument must be of same type and name."
+        )
+
     # the keys must match the thickets dictionary keys
     if set(thickets.keys()) != set(nodes.keys()):
         raise ValueError(
@@ -476,9 +482,15 @@ def display_violinplot_thicket(
             filtered_dfs[thicket_idx]["node"] = thicket_name
 
     master_df = pd.concat(filtered_dfs, ignore_index=True)
+    master_df.rename(columns={"node": "thicket"}, inplace=True)
 
     graph = sns.violinplot(
-        data=master_df, x="node", y=" ", hue="Performance counter", inner=None, **kwargs
+        data=master_df,
+        x="thicket",
+        y=" ",
+        hue="Performance counter",
+        inner=None,
+        **kwargs,
     )
 
     # No percentiles to plot!

--- a/thicket/stats/display_violinplot.py
+++ b/thicket/stats/display_violinplot.py
@@ -382,7 +382,7 @@ def display_violinplot_thicket(
         )
 
     # Verify that all nodes passed are of the same type and name
-    if len(set(nodes.values())) != 1:
+    if len(set([n.frame for n in nodes.values()])) != 1:
         raise ValueError(
             "Value(s) passed to 'nodes' argument must be of same type and name."
         )

--- a/thicket/tests/test_display.py
+++ b/thicket/tests/test_display.py
@@ -336,8 +336,8 @@ def test_display_violinplot_thicket(thicket_axis_columns):
         "th_2": ["Min time/rank"],
         "th_3": ["Min time/rank"],
     }
-    node = pd.unique(combined_th.dataframe.reset_index()["node"][:]).tolist()
-    nodes = {"th_1": node[0], "th_2": node[0], "th_3": node[0]}
+    node_list = [i.dataframe.reset_index()["node"][0] for i in list(thickets.values())]
+    nodes = {"th_1": node_list[0], "th_2": node_list[1], "th_3": node_list[2]}
 
     ax = th.stats.display_violinplot_thicket(
         thickets=thickets, nodes=nodes, columns=columns
@@ -368,7 +368,11 @@ def test_display_violinplot_thicket(thicket_axis_columns):
         ValueError,
         match=r"Value\(s\) passed to 'nodes' argument must be of same type and name.",
     ):
-        invalid_nodes = {"th_1": node[1], "th_2": node[0], "th_3": node[0]}
+        invalid_nodes = {
+            "th_1": node_list[0],
+            "th_2": node_list[1],
+            "th_3": list(thickets.values())[1].dataframe.reset_index()["node"].iloc[-1],
+        }
         ax = th.stats.display_violinplot_thicket(
             thickets=thickets, nodes=invalid_nodes, columns=columns
         )
@@ -432,7 +436,7 @@ def test_display_violinplot_thicket(thicket_axis_columns):
         ValueError,
         match="Keys in 'nodes' argument dictionary do not match keys in 'thickets' argument dictionary.",
     ):
-        false_nodes = {"th_x": node[0], "th_2": node[0], "th_3": node[0]}
+        false_nodes = {"th_x": node_list[0], "th_2": node_list[0], "th_3": node_list[0]}
         ax = th.stats.display_violinplot_thicket(
             thickets=thickets, nodes=false_nodes, columns=columns
         )

--- a/thicket/tests/test_display.py
+++ b/thicket/tests/test_display.py
@@ -336,8 +336,8 @@ def test_display_violinplot_thicket(thicket_axis_columns):
         "th_2": ["Min time/rank"],
         "th_3": ["Min time/rank"],
     }
-    node = pd.unique(combined_th.dataframe.reset_index()["node"][0:1]).tolist()[0]
-    nodes = {"th_1": node, "th_2": node, "th_3": node}
+    node = pd.unique(combined_th.dataframe.reset_index()["node"][:]).tolist()
+    nodes = {"th_1": node[0], "th_2": node[0], "th_3": node[0]}
 
     ax = th.stats.display_violinplot_thicket(
         thickets=thickets, nodes=nodes, columns=columns
@@ -347,7 +347,7 @@ def test_display_violinplot_thicket(thicket_axis_columns):
     assert "th_1" in ax.get_xticklabels()[0].get_text()
     assert "th_2" in ax.get_xticklabels()[1].get_text()
     assert "th_3" in ax.get_xticklabels()[2].get_text()
-    assert "node" == ax.get_xlabel()
+    assert "thicket" == ax.get_xlabel()
 
     with pytest.raises(
         ValueError, match="'thickets' argument must be a dictionary of thickets."
@@ -362,6 +362,15 @@ def test_display_violinplot_thicket(thicket_axis_columns):
     ):
         ax = th.stats.display_violinplot_thicket(
             thickets=thickets, nodes=["test"], columns=columns
+        )
+
+    with pytest.raises(
+        ValueError,
+        match=r"Value\(s\) passed to 'nodes' argument must be of same type and name.",
+    ):
+        invalid_nodes = {"th_1": node[1], "th_2": node[0], "th_3": node[0]}
+        ax = th.stats.display_violinplot_thicket(
+            thickets=thickets, nodes=invalid_nodes, columns=columns
         )
 
     with pytest.raises(
@@ -423,7 +432,7 @@ def test_display_violinplot_thicket(thicket_axis_columns):
         ValueError,
         match="Keys in 'nodes' argument dictionary do not match keys in 'thickets' argument dictionary.",
     ):
-        false_nodes = {"th_x": node, "th_2": node, "th_3": node}
+        false_nodes = {"th_x": node[0], "th_2": node[0], "th_3": node[0]}
         ax = th.stats.display_violinplot_thicket(
             thickets=thickets, nodes=false_nodes, columns=columns
         )
@@ -479,7 +488,7 @@ def test_display_violinplot_thicket_columnar_join(thicket_axis_columns):
     assert "th_1" in ax.get_xticklabels()[0].get_text()
     assert "th_2" in ax.get_xticklabels()[1].get_text()
     assert "th_3" in ax.get_xticklabels()[2].get_text()
-    assert "node" == ax.get_xlabel()
+    assert "thicket" == ax.get_xlabel()
 
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
This PR improves the display_violinplot_thicket function in two ways:

- Changed default xlabel to 'thicket' for clarity.

- Restricted function to accept only the same node across all provided thickets.