### PR TITLE
Hotfix: moves re-exports of display_violinplot into the try-except-else guard

### DIFF
--- a/thicket/stats/__init__.py
+++ b/thicket/stats/__init__.py
@@ -31,6 +31,6 @@ except:
 else:
     from .display_boxplot import display_boxplot
     from .display_histogram import display_histogram
-    from .display_heatmap import display_heatmap    
+    from .display_heatmap import display_heatmap
     from .display_violinplot import display_violinplot_thicket
     from .display_violinplot import display_violinplot

--- a/thicket/stats/__init__.py
+++ b/thicket/stats/__init__.py
@@ -21,8 +21,6 @@ from .scoring import score_delta_mean_delta_coefficient_of_variation
 from .scoring import score_bhattacharyya
 from .scoring import score_hellinger
 from .preference import preference
-from .display_violinplot import display_violinplot_thicket
-from .display_violinplot import display_violinplot
 
 
 try:
@@ -33,4 +31,6 @@ except:
 else:
     from .display_boxplot import display_boxplot
     from .display_histogram import display_histogram
-    from .display_heatmap import display_heatmap
+    from .display_heatmap import display_heatmap    
+    from .display_violinplot import display_violinplot_thicket
+    from .display_violinplot import display_violinplot


### PR DESCRIPTION
Fixes #158 

To prevent issues with importing the optional `seaborn` dependency, all re-exports of "display" modules need to be placed in the `else` statement of the "try-except-else" guard in `thicket/stats/__init__.py`. However, the re-exports for `display_violinplot.py` were not placed in that `else` statement, which caused the import issues in #158.

This PR fixes this.