### PR TITLE
Second attempt at adding Codecov support

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -65,6 +65,21 @@ jobs:
       run: |
         pip install extrap
 
+    - name: Install coverage tools
+      run: |
+        pip install codecov
+        pip install pytest-cov
+
     - name: Basic Test with pytest
       run: |
-        PYTHONPATH=. $(which pytest)
+        PYTHONPATH=. $(which pytest) --cov=./ --cov-report=xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        directory: ./coverage/reports/
+        env_vars: OS,PYTHON
+        files: /home/runner/work/thicket/thicket/coverage.xml
+        flags: unittests
+        verbose: true
+        fail_ci_if_error: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -76,6 +76,8 @@ jobs:
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.THICKET_CODECOV_TOKEN }}
       with:
         directory: ./coverage/reports/
         env_vars: OS,PYTHON

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # <img src="https://raw.githubusercontent.com/llnl/thicket/develop/logo-notext.png" width="64" valign="middle" alt="thicket"/> Thicket
 
 [![Build Status](https://github.com/llnl/thicket/actions/workflows/unit-tests.yaml/badge.svg)](https://github.com/llnl/thicket/actions)
+[![codecov.io](https://codecov.io/github/LLNL/thicket/coverage.svg?branch=develop)](https://codecov.io/github/LLNL/thicket?branch=develop)
 [![Read the Docs](http://readthedocs.org/projects/thicket/badge/?version=latest)](http://thicket.readthedocs.io)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  round: down
+  range: "65...100"
+
+comment:
+  layout: "header, diff, changes, tree"
+  behavior: new
+  require_changes: false
+  require_base: false
+  require_head: true
+  after_n_builds: 4


### PR DESCRIPTION
This is the second attempt at adding Codecov support. The contents of this PR are primarily the same as #139. The only addition is that this PR adds the Codecov token so that uploads are supported outside of PRs.