### PR TITLE
Fix Check in Extra-P Unit Test

### DIFF
--- a/thicket/tests/test_model_extrap.py
+++ b/thicket/tests/test_model_extrap.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     extrap_avail = False
 
-if not sys.version_info < (3, 8):
+if sys.version_info < (3, 8):
     pytest.skip(
         "requires python3.8 or greater to use extrap module", allow_module_level=True
     )


### PR DESCRIPTION
We want to skip if the python version is less than `3.8`. The current check does the inverse.