### PR TITLE
Check If filter_metadata Function Results in Empty Metadata Table

### DIFF
--- a/thicket/tests/test_filter_metadata.py
+++ b/thicket/tests/test_filter_metadata.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import pandas as pd
 import pytest
 
 from thicket import Thicket
@@ -164,7 +165,7 @@ def check_errors(th):
     with pytest.raises(InvalidFilter):
         th.filter_metadata(123)
 
-    # check that query with non-existant value raises error
+    # check that query with non-existent value raises error
     with pytest.raises(
         EmptyMetadataTable,
         match="The provided filter function resulted in an empty MetadataTable.",
@@ -176,6 +177,13 @@ def check_errors(th):
     with pytest.raises(
         EmptyMetadataTable,
         match="The provided Thicket object has an empty MetadataTable.",
+    ):
+        th.filter_metadata(lambda x: x["cluster"] == "quartz")
+
+    th.metadata = pd.DataFrame(data=[0], index=pd.MultiIndex.from_tuples([("one", "two")], names=["a", "b"]))
+    with pytest.raises(
+        TypeError,
+        match="The metadata index must be single-level."
     ):
         th.filter_metadata(lambda x: x["cluster"] == "quartz")
 

--- a/thicket/tests/test_filter_metadata.py
+++ b/thicket/tests/test_filter_metadata.py
@@ -179,12 +179,11 @@ def check_errors(th):
         match="The provided Thicket object has an empty MetadataTable.",
     ):
         th.filter_metadata(lambda x: x["cluster"] == "quartz")
-
-    th.metadata = pd.DataFrame(data=[0], index=pd.MultiIndex.from_tuples([("one", "two")], names=["a", "b"]))
-    with pytest.raises(
-        TypeError,
-        match="The metadata index must be single-level."
-    ):
+    # Check for multi-level index exception
+    th.metadata = pd.DataFrame(
+        data=[0], index=pd.MultiIndex.from_tuples([("one", "two")], names=["a", "b"])
+    )
+    with pytest.raises(TypeError, match="The metadata index must be single-level."):
         th.filter_metadata(lambda x: x["cluster"] == "quartz")
 
 

--- a/thicket/tests/test_filter_metadata.py
+++ b/thicket/tests/test_filter_metadata.py
@@ -160,7 +160,9 @@ def filter_multiple_or(th, columns_values):
     assert "name" in new_th.statsframe.dataframe.columns
 
 
-def check_errors(th):
+def test_check_errors(rajaperf_seq_O3_1M_cali):
+    th = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
+
     # check for invalid filter exception
     with pytest.raises(InvalidFilter):
         th.filter_metadata(123)
@@ -195,4 +197,3 @@ def test_filter_metadata(rajaperf_seq_O3_1M_cali):
     filter_one_column(th, columns_values)
     filter_multiple_and(th, columns_values)
     filter_multiple_or(th, columns_values)
-    check_errors(th)

--- a/thicket/tests/test_filter_metadata.py
+++ b/thicket/tests/test_filter_metadata.py
@@ -158,23 +158,27 @@ def filter_multiple_or(th, columns_values):
     assert exp_nodes == stats_nodes
     assert "name" in new_th.statsframe.dataframe.columns
 
+def check_errors(th):
     # check for invalid filter exception
     with pytest.raises(InvalidFilter):
         th.filter_metadata(123)
 
     # drop all rows of the metadata table
     th.metadata = th.metadata.iloc[0:0]
-
     # check for empty metadata table exception
-    with pytest.raises(EmptyMetadataTable):
-        th.filter_metadata(lambda x: x["cluster"] == "chekov")
+    with pytest.raises(
+        EmptyMetadataTable,
+        match="The provided Thicket object has an empty MetadataTable."
+    ):
+        th.filter_metadata(lambda x: x["cluster"] == "quartz")
 
 
 def test_filter_metadata(rajaperf_seq_O3_1M_cali):
     # example thicket
     th = Thicket.from_caliperreader(rajaperf_seq_O3_1M_cali, disable_tqdm=True)
     # columns and corresponding values to filter by
-    columns_values = {"ProblemSizeRunParam": ["30"], "cluster": ["chekov", "quartz"]}
+    columns_values = {"ProblemSizeRunParam": [1048576.0], "cluster": ["quartz"]}
     filter_one_column(th, columns_values)
     filter_multiple_and(th, columns_values)
     filter_multiple_or(th, columns_values)
+    check_errors(th)

--- a/thicket/tests/test_filter_metadata.py
+++ b/thicket/tests/test_filter_metadata.py
@@ -158,17 +158,24 @@ def filter_multiple_or(th, columns_values):
     assert exp_nodes == stats_nodes
     assert "name" in new_th.statsframe.dataframe.columns
 
+
 def check_errors(th):
     # check for invalid filter exception
     with pytest.raises(InvalidFilter):
         th.filter_metadata(123)
 
+    # check that query with non-existant value raises error
+    with pytest.raises(
+        EmptyMetadataTable,
+        match="The provided filter function resulted in an empty MetadataTable.",
+    ):
+        th.filter_metadata(lambda x: x["cluster"] == "chekov")
     # drop all rows of the metadata table
     th.metadata = th.metadata.iloc[0:0]
     # check for empty metadata table exception
     with pytest.raises(
         EmptyMetadataTable,
-        match="The provided Thicket object has an empty MetadataTable."
+        match="The provided Thicket object has an empty MetadataTable.",
     ):
         th.filter_metadata(lambda x: x["cluster"] == "quartz")
 

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1091,7 +1091,7 @@ class Thicket(GraphFrame):
 
         # filter metadata table
         filtered_rows = new_thicket.metadata.apply(select_function, axis=1)
-        if not all(filtered_rows):
+        if not filtered_rows.any():
             raise EmptyMetadataTable(
                 "The provided filter function resulted in an empty MetadataTable."
             )

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1090,7 +1090,7 @@ class Thicket(GraphFrame):
 
         # filter metadata table
         filtered_rows = new_thicket.metadata.apply(select_function, axis=1)
-        if all(filtered_rows == False):
+        if all(filtered_rows) == False:
             raise EmptyMetadataTable(
                 "The provided filter function resulted in an empty MetadataTable."
             )

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1075,7 +1075,10 @@ class Thicket(GraphFrame):
                 "The provided Thicket object has an empty MetadataTable."
             )
         # check only 1 index in metadata
-        assert self.metadata.index.nlevels == 1
+        if isinstance(self.metadata.index, pd.MultiIndex):
+            raise IndexError(
+                "The metadata index must be single-level."
+            )
         # Add warning if filtering on multi-index columns
         if isinstance(self.metadata.columns, pd.MultiIndex):
             warnings.warn(

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1076,9 +1076,7 @@ class Thicket(GraphFrame):
             )
         # check only 1 index in metadata
         if isinstance(self.metadata.index, pd.MultiIndex):
-            raise IndexError(
-                "The metadata index must be single-level."
-            )
+            raise TypeError("The metadata index must be single-level.")
         # Add warning if filtering on multi-index columns
         if isinstance(self.metadata.columns, pd.MultiIndex):
             warnings.warn(

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1090,6 +1090,8 @@ class Thicket(GraphFrame):
 
         # filter metadata table
         filtered_rows = new_thicket.metadata.apply(select_function, axis=1)
+        if all(filtered_rows == False):
+            raise EmptyMetadataTable("The provided filter function resulted in an empty MetadataTable.")
         new_thicket.metadata = new_thicket.metadata[filtered_rows]
 
         # note index keys to filter performance data table

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1091,7 +1091,7 @@ class Thicket(GraphFrame):
 
         # filter metadata table
         filtered_rows = new_thicket.metadata.apply(select_function, axis=1)
-        if all(filtered_rows) is False:
+        if not all(filtered_rows):
             raise EmptyMetadataTable(
                 "The provided filter function resulted in an empty MetadataTable."
             )

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1091,16 +1091,16 @@ class Thicket(GraphFrame):
         # filter metadata table
         filtered_rows = new_thicket.metadata.apply(select_function, axis=1)
         if all(filtered_rows == False):
-            raise EmptyMetadataTable("The provided filter function resulted in an empty MetadataTable.")
+            raise EmptyMetadataTable(
+                "The provided filter function resulted in an empty MetadataTable."
+            )
         new_thicket.metadata = new_thicket.metadata[filtered_rows]
 
         # note index keys to filter performance data table
         index_id = new_thicket.metadata.index.values.tolist()
         # filter performance data table based on the metadata table
         new_thicket.dataframe = new_thicket.dataframe[
-            new_thicket.dataframe.index.get_level_values(index_name).isin(
-                index_id
-            )
+            new_thicket.dataframe.index.get_level_values(index_name).isin(index_id)
         ]
 
         # create an empty aggregated statistics table with the name column

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1067,50 +1067,47 @@ class Thicket(GraphFrame):
         Returns:
             (thicket): new thicket object with selected value
         """
-        if callable(select_function):
-            if not self.metadata.empty:
-                # check only 1 index in metadata
-                assert self.metadata.index.nlevels == 1
-
-                # Add warning if filtering on multi-index columns
-                if isinstance(self.metadata.columns, pd.MultiIndex):
-                    warnings.warn(
-                        "Filtering on MultiIndex columns will impact the entire row, not just the subsection of the provided MultiIndex."
-                    )
-
-                # Get index name
-                index_name = self.metadata.index.name
-
-                # create a copy of the thicket object
-                new_thicket = self.copy()
-
-                # filter metadata table
-                filtered_rows = new_thicket.metadata.apply(select_function, axis=1)
-                new_thicket.metadata = new_thicket.metadata[filtered_rows]
-
-                # note index keys to filter performance data table
-                index_id = new_thicket.metadata.index.values.tolist()
-                # filter performance data table based on the metadata table
-                new_thicket.dataframe = new_thicket.dataframe[
-                    new_thicket.dataframe.index.get_level_values(index_name).isin(
-                        index_id
-                    )
-                ]
-
-                # create an empty aggregated statistics table with the name column
-                new_thicket.statsframe.dataframe = helpers._new_statsframe_df(
-                    new_thicket.dataframe
-                )
-
-                new_thicket._sync_profile_components(new_thicket.metadata)
-                validate_profile(new_thicket)
-            else:
-                raise EmptyMetadataTable(
-                    "The provided Thicket object has an empty MetadataTable."
-                )
-
-        else:
+        # Error checks
+        if not callable(select_function):
             raise InvalidFilter("The argument passed to filter must be a callable.")
+        if self.metadata.empty:
+            raise EmptyMetadataTable(
+                "The provided Thicket object has an empty MetadataTable."
+            )
+        # check only 1 index in metadata
+        assert self.metadata.index.nlevels == 1
+        # Add warning if filtering on multi-index columns
+        if isinstance(self.metadata.columns, pd.MultiIndex):
+            warnings.warn(
+                "Filtering on MultiIndex columns will impact the entire row, not just the subsection of the provided MultiIndex."
+            )
+
+        # Get index name
+        index_name = self.metadata.index.name
+
+        # create a copy of the thicket object
+        new_thicket = self.copy()
+
+        # filter metadata table
+        filtered_rows = new_thicket.metadata.apply(select_function, axis=1)
+        new_thicket.metadata = new_thicket.metadata[filtered_rows]
+
+        # note index keys to filter performance data table
+        index_id = new_thicket.metadata.index.values.tolist()
+        # filter performance data table based on the metadata table
+        new_thicket.dataframe = new_thicket.dataframe[
+            new_thicket.dataframe.index.get_level_values(index_name).isin(
+                index_id
+            )
+        ]
+
+        # create an empty aggregated statistics table with the name column
+        new_thicket.statsframe.dataframe = helpers._new_statsframe_df(
+            new_thicket.dataframe
+        )
+
+        new_thicket._sync_profile_components(new_thicket.metadata)
+        validate_profile(new_thicket)
 
         return new_thicket
 

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1090,7 +1090,7 @@ class Thicket(GraphFrame):
 
         # filter metadata table
         filtered_rows = new_thicket.metadata.apply(select_function, axis=1)
-        if all(filtered_rows) == False:
+        if all(filtered_rows) is False:
             raise EmptyMetadataTable(
                 "The provided filter function resulted in an empty MetadataTable."
             )


### PR DESCRIPTION
This PR:
- Refactors `filter_metadata` code and unit tests.
- Raises an error in `filter_metadata` if the given function results in an empty metadata table.
- Adds a unit test for the new check

This change was due to the observation that the current behavior of `filter_metadata` can be confusing for users. Say if the metadata value was the integer `1`, but the user filters for the string `"1"`. The current function will allow this filtering, but return an empty table because `"1"` does not exist in the table. Then the user will be confused why their table is empty. The new code catches this case and will print `"The provided filter function resulted in an empty MetadataTable."`, which will help the user catch their error sooner.

Note: Ideally, we would want to say that `The value "1" does not exist in the metadata table`, but `filter_metadata` takes a `function` as an argument, so parsing out the value is not easy.