### PR TITLE
Add Option to Turn Off _fill_perfdata

### DIFF
--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -369,12 +369,15 @@ class Ensemble:
         return combined_th
 
     @staticmethod
-    def _index(thickets, from_statsframes=False, disable_tqdm=False):
+    def _index(
+        thickets, from_statsframes=False, fill_perfdata=True, disable_tqdm=False
+    ):
         """Unify a list of thickets into a single thicket
 
         Arguments:
             thickets (list): list of Thicket objects
             from_statsframes (bool): Whether this method was invoked from from_statsframes
+            fill_perfdata (bool): whether to fill missing rows in performance data table
             disable_tqdm (bool): whether to disable tqdm progress bar
 
         Returns:
@@ -456,7 +459,8 @@ class Ensemble:
         validate_dataframe(unify_df)
 
         # Insert missing rows in dataframe
-        unify_df = _fill_perfdata(unify_df)
+        if fill_perfdata:
+            unify_df = _fill_perfdata(unify_df)
 
         # Sort PerfData
         unify_df.sort_index(inplace=True)

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -377,7 +377,7 @@ class Ensemble:
         Arguments:
             thickets (list): list of Thicket objects
             from_statsframes (bool): Whether this method was invoked from from_statsframes
-            fill_perfdata (bool): whether to fill missing rows in performance data table
+            fill_perfdata (bool): whether to fill missing performance data with NaNs
             disable_tqdm (bool): whether to disable tqdm progress bar
 
         Returns:

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -203,7 +203,11 @@ class Thicket(GraphFrame):
 
     @staticmethod
     def from_caliper(
-        filename_or_stream, query=None, intersection=False, disable_tqdm=False
+        filename_or_stream,
+        query=None,
+        intersection=False,
+        fill_perfdata=True,
+        disable_tqdm=False,
     ):
         """Read in a Caliper .cali or .json file.
 
@@ -212,36 +216,48 @@ class Thicket(GraphFrame):
                 `.cali` or JSON-split format, or an open file object to read one
             query (str): cali-query in CalQL format
             intersection (bool): whether to perform intersection or union (default)
+            fill_perfdata (bool): whether to fill missing performance data with NaNs
             disable_tqdm (bool): whether to display tqdm progress bar
         """
         return Thicket.reader_dispatch(
             GraphFrame.from_caliper,
             intersection,
+            fill_perfdata,
             disable_tqdm,
             filename_or_stream,
             query,
         )
 
     @staticmethod
-    def from_hpctoolkit(dirname, intersection=False, disable_tqdm=False):
+    def from_hpctoolkit(
+        dirname, intersection=False, fill_perfdata=True, disable_tqdm=False
+    ):
         """Create a GraphFrame using hatchet's HPCToolkit reader and use its attributes
         to make a new thicket.
 
         Arguments:
             dirname (str): parent directory of an HPCToolkit experiment.xml file
             intersection (bool): whether to perform intersection or union (default)
+            fill_perfdata (bool): whether to fill missing performance data with NaNs
             disable_tqdm (bool): whether to display tqdm progress bar
 
         Returns:
             (thicket): new thicket containing HPCToolkit profile data
         """
         return Thicket.reader_dispatch(
-            GraphFrame.from_hpctoolkit, intersection, disable_tqdm, dirname
+            GraphFrame.from_hpctoolkit,
+            intersection,
+            fill_perfdata,
+            disable_tqdm,
+            dirname,
         )
 
     @staticmethod
     def from_caliperreader(
-        filename_or_caliperreader, intersection=False, disable_tqdm=False
+        filename_or_caliperreader,
+        intersection=False,
+        fill_perfdata=True,
+        disable_tqdm=False,
     ):
         """Helper function to read one caliper file.
 
@@ -249,11 +265,13 @@ class Thicket(GraphFrame):
             filename_or_caliperreader (str or CaliperReader): name of a Caliper output
                 file in `.cali` format, or a CaliperReader object
             intersection (bool): whether to perform intersection or union (default)
+            fill_perfdata (bool): whether to fill missing performance data with NaNs
             disable_tqdm (bool): whether to display tqdm progress bar
         """
         return Thicket.reader_dispatch(
             GraphFrame.from_caliperreader,
             intersection,
+            fill_perfdata,
             disable_tqdm,
             filename_or_caliperreader,
         )
@@ -295,7 +313,9 @@ class Thicket(GraphFrame):
         return tk
 
     @staticmethod
-    def reader_dispatch(func, intersection, disable_tqdm, *args, **kwargs):
+    def reader_dispatch(
+        func, intersection, fill_perfdata, disable_tqdm, *args, **kwargs
+    ):
         """Create a thicket from a list, directory of files, or a single file.
 
         Arguments:
@@ -353,6 +373,7 @@ class Thicket(GraphFrame):
             thickets=ens_list,
             axis="index",
             calltree=calltree,
+            fill_perfdata=fill_perfdata,
             disable_tqdm=disable_tqdm,
         )
 
@@ -372,6 +393,7 @@ class Thicket(GraphFrame):
             calltree (str): calltree to use -> "union" or "intersection"
 
         Keyword Arguments:
+            fill_perfdata (bool): (if axis="index") Whether to fill missing performance data with NaNs
             headers (list): (if axis="columns") List of headers to use for the new columnar multi-index
             metadata_key (str): (if axis="columns") Name of the column from the metadata tables to replace the 'profile'
                 index. If no argument is provided, it is assumed that there is no profile-wise
@@ -381,10 +403,16 @@ class Thicket(GraphFrame):
             (thicket): concatenated thicket
         """
 
-        def _index(thickets, from_statsframes=False, disable_tqdm=disable_tqdm):
+        def _index(
+            thickets,
+            from_statsframes=False,
+            fill_perfdata=True,
+            disable_tqdm=disable_tqdm,
+        ):
             thicket_parts = Ensemble._index(
                 thickets=thickets,
                 from_statsframes=from_statsframes,
+                fill_perfdata=fill_perfdata,
                 disable_tqdm=disable_tqdm,
             )
 

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1140,6 +1140,12 @@ class Thicket(GraphFrame):
         else:
             raise InvalidFilter("The argument passed to filter must be a callable.")
 
+        # If fill_perfdata is False, may need to squash
+        unique_perf_indices = set(new_thicket.dataframe.index.droplevel("node"))
+        full_idx = all([idx in unique_perf_indices for idx in new_thicket.profile])
+        if not full_idx:
+            new_thicket = new_thicket.squash()
+
         return new_thicket
 
     def filter(self, filter_func):

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1141,7 +1141,9 @@ class Thicket(GraphFrame):
             raise InvalidFilter("The argument passed to filter must be a callable.")
 
         # If fill_perfdata is False, may need to squash
-        if len(new_thicket.graph) != len(new_thicket.dataframe.index.get_level_values("node").unique()):
+        if len(new_thicket.graph) != len(
+            new_thicket.dataframe.index.get_level_values("node").unique()
+        ):
             new_thicket = new_thicket.squash()
 
         return new_thicket

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1141,9 +1141,7 @@ class Thicket(GraphFrame):
             raise InvalidFilter("The argument passed to filter must be a callable.")
 
         # If fill_perfdata is False, may need to squash
-        unique_perf_indices = set(new_thicket.dataframe.index.droplevel("node"))
-        full_idx = all([idx in unique_perf_indices for idx in new_thicket.profile])
-        if not full_idx:
+        if len(new_thicket.graph) != len(new_thicket.dataframe.index.get_level_values("node").unique()):
             new_thicket = new_thicket.squash()
 
         return new_thicket


### PR DESCRIPTION
`_fill_perfdata` adds empty rows for profiles that do not contain data for a node, such that each node has a row entry for every profile. This can be obnoxious in some cases, as in the performance algorithms dataset, 2,531,150 rows in the performance data table with `_fill_perfdata` and 163,778 rows with `_fill_perfdata` off.

This is a small optimization for the reader, as `_fill_perdata` is only called once, most time is spent in `_unify`. However, when working with a large amount of files with missing rows, a Thicket with `_fill_perfdata` off will be easier and faster to work with.