### PR TITLE
Speedup thicket composition by performing profile unions in binary tree order

### DIFF
--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -9,7 +9,6 @@ import warnings
 from hatchet import GraphFrame
 import numpy as np
 import pandas as pd
-import tqdm
 
 import thicket.helpers as helpers
 from .utils import (
@@ -103,9 +102,7 @@ class Ensemble:
         # Unify graphs if "self" and "other" do not have the same graph
         union_graph = _thickets[0].graph
         old_to_new = {}
-        pbar = tqdm.tqdm(range(len(_thickets) - 1), disable=disable_tqdm)
-        for i in pbar:
-            pbar.set_description("(2/2) Creating Thicket")
+        for i in range(len(_thickets) - 1):
             temp_dict = {}
             union_graph = union_graph.union(_thickets[i + 1].graph, temp_dict)
             # Set all graphs to the union graph

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -390,11 +390,13 @@ class Thicket(GraphFrame):
         calltree = "union"
         if intersection:
             calltree = "intersection"
-        # We concatenate t Thickets with 1 prof each until 1 Thicket with t profs.
         # Consider a binary tree with t leaves (Thickets) => t-1 parents (Knuth 1997).
         # Each non-leaf Thicket (parent) is a result of a concat_thickets, therefore
         # we have t-1 concat_thickets operations. t == len(ens_list)
         pbar = tqdm.tqdm(total=len(ens_list) - 1, disable=disable_tqdm)
+        # We start with t Thickets with 1 prof each until 1 Thicket with t profs.
+        # Each iteration is concatenating 2 Thickets with n, m profs into 1 Thicket 
+        # with n+m profs, appending the new Thicket to the back of the ens_list.
         while len(ens_list) > 1:
             pbar.set_description("(2/2) Creating Thicket")
             new_tk = Thicket.concat_thickets(

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 import copy
+import math
 import os
 import pickle
 import sys
@@ -390,6 +391,21 @@ class Thicket(GraphFrame):
         calltree = "union"
         if intersection:
             calltree = "intersection"
+
+        num_tks = len(ens_list)
+        tk_limit = 2**9
+        if num_tks > tk_limit:
+            split_list = np.array_split(ens_list, math.ceil(num_tks / tk_limit))
+            ens_list = []
+            for sub_list in split_list:
+                ens_list.append(
+                    Thicket.concat_thickets(
+                        thickets=sub_list,
+                        axis="index",
+                        calltree=calltree,
+                        disable_tqdm=disable_tqdm,
+                    )
+                )
         thicket_object = Thicket.concat_thickets(
             thickets=ens_list,
             axis="index",

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -392,7 +392,7 @@ class Thicket(GraphFrame):
             calltree = "intersection"
         # We concatenate t Thickets with 1 prof each until 1 Thicket with t profs.
         # Consider a binary tree with t leaves (Thickets) => t-1 parents (Knuth 1997).
-        # Each non-leaf node (parent) is a result of a concat_thickets, therefore
+        # Each non-leaf Thicket (parent) is a result of a concat_thickets, therefore
         # we have t-1 concat_thickets operations. t == len(ens_list)
         pbar = tqdm.tqdm(total=len(ens_list) - 1, disable=disable_tqdm)
         while len(ens_list) > 1:

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -390,9 +390,12 @@ class Thicket(GraphFrame):
         calltree = "union"
         if intersection:
             calltree = "intersection"
-        # n - 1 edges in a binary tree
-        pbar = tqdm.tqdm(range(len(ens_list) - 1), disable=disable_tqdm)
-        for i in pbar:
+        # We concatenate t Thickets with 1 prof each until 1 Thicket with t profs.
+        # Consider a binary tree with t leaves (Thickets) => t-1 parents (Knuth 1997).
+        # Each non-leaf node (parent) is a result of a concat_thickets, therefore
+        # we have t-1 concat_thickets operations. t == len(ens_list)
+        pbar = tqdm.tqdm(total=len(ens_list) - 1, disable=disable_tqdm)
+        while len(ens_list) > 1:
             pbar.set_description("(2/2) Creating Thicket")
             new_tk = Thicket.concat_thickets(
                 thickets=[ens_list.pop(0), ens_list.pop(0)],
@@ -402,8 +405,9 @@ class Thicket(GraphFrame):
                 disable_tqdm=disable_tqdm,
             )
             ens_list.append(new_tk)
-        assert len(ens_list) == 1
-        return ens_list[0]
+            pbar.update(1)
+
+        return ens_list.pop(0)
 
     @staticmethod
     def concat_thickets(

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: MIT
 
 import copy
-import math
 import os
 import pickle
 import sys
@@ -391,30 +390,20 @@ class Thicket(GraphFrame):
         calltree = "union"
         if intersection:
             calltree = "intersection"
-
-        num_tks = len(ens_list)
-        tk_limit = 2**9
-        if num_tks > tk_limit:
-            split_list = np.array_split(ens_list, math.ceil(num_tks / tk_limit))
-            ens_list = []
-            for sub_list in split_list:
-                ens_list.append(
-                    Thicket.concat_thickets(
-                        thickets=sub_list,
-                        axis="index",
-                        calltree=calltree,
-                        disable_tqdm=disable_tqdm,
-                    )
-                )
-        thicket_object = Thicket.concat_thickets(
-            thickets=ens_list,
-            axis="index",
-            calltree=calltree,
-            fill_perfdata=fill_perfdata,
-            disable_tqdm=disable_tqdm,
-        )
-
-        return thicket_object
+        # n - 1 edges in a binary tree
+        pbar = tqdm.tqdm(range(len(ens_list) - 1), disable=disable_tqdm)
+        for i in pbar:
+            pbar.set_description("(2/2) Creating Thicket")
+            new_tk = Thicket.concat_thickets(
+                thickets=[ens_list.pop(0), ens_list.pop(0)],
+                axis="index",
+                calltree=calltree,
+                fill_perfdata=fill_perfdata,
+                disable_tqdm=disable_tqdm,
+            )
+            ens_list.append(new_tk)
+        assert len(ens_list) == 1
+        return ens_list[0]
 
     @staticmethod
     def concat_thickets(

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -390,12 +390,13 @@ class Thicket(GraphFrame):
         calltree = "union"
         if intersection:
             calltree = "intersection"
-        # Consider a binary tree with t leaves (Thickets) => t-1 parents (Knuth 1997).
+        # Consider a binary tree with t leaves (Thickets) and 2t-1 total nodes (Full tree)
+        # This implies t-1 parents (Knuth 1997).
         # Each non-leaf Thicket (parent) is a result of a concat_thickets, therefore
         # we have t-1 concat_thickets operations. t == len(ens_list)
         pbar = tqdm.tqdm(total=len(ens_list) - 1, disable=disable_tqdm)
         # We start with t Thickets with 1 prof each until 1 Thicket with t profs.
-        # Each iteration is concatenating 2 Thickets with n, m profs into 1 Thicket 
+        # Each iteration is concatenating 2 Thickets with n, m profs into 1 Thicket
         # with n+m profs, appending the new Thicket to the back of the ens_list.
         while len(ens_list) > 1:
             pbar.set_description("(2/2) Creating Thicket")


### PR DESCRIPTION
This PR extends off #169. Limiting the total size of the ensemble during unification is more impactful than the performance gains from parallelism, and this solution is less complicated than using `multiprocessing`.

| | Parallel Sorting | LBANN |
|---|---|---|
| Profiles | 15734 | 16 |
| Input Nodes (min, max) | 5, 18 | 6266, 6889 |
| Input Dataframe Size (min, max) | '' | '' |
| Output Nodes | 154 | 7106 |
| Output DF | 2423036 | 113696 |

| Dataset | Thicket Version | Time | Unions | old_to_new size (min, max) |
|---|---|---|---|---|
| Parallel Sorting | Develop | >120m | 15733 | 157459 |
|  | #170 | 12m | '' | 16, 185 |
|  | #185 | 33m | '' | 157459 |
| LBANN | Develop | 17m | 15 | 106897 |
| | #170 | 7m | '' | 12824, 13821 |
| | #185 | 3m | '' | 106897 |

Number of unions is not affected by the different unifying strategy in this PR. This is because:
```
# PR170 - 3 unions
tk1 U tk2 = tk12
tk3 U tk4 = tk34
tk12 U tk34 = tk1234

is the same as

# develop - 3 unions
tk1 U tk2 = tk12
tk12 U tk3 = tk123
tk123 U tk4 = tk1234
```
This PR increases performance by keeping the `old_to_new` mapping dictionary small as we call `concat_thickets` `n-1` times instead of one time (as in the develop branch). The `old_to_new` dictionary requires an operation to update the dictionary mappings per each union, which can become expensive if the dictionary is too large. The `old_to_new` dictionary is necessary to replace the node objects in the performance data with the new node objects in the graph that results from `union`.