### PR TITLE
Avoid FutureWarning in ensemble.py

### DIFF
--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -406,7 +406,7 @@ class Ensemble:
                 # Replace "NaN" with "None" in columns of string type
                 for col in df.columns:
                     if pd.api.types.is_string_dtype(df[col].dtype):
-                        df[col].replace({numerical_fill_value: None}, inplace=True)
+                        df[col] = df[col].replace({numerical_fill_value: None})
             except ValueError as e:
                 estr = str(e)
                 if estr == "cannot handle a non-unique multi-index!":


### PR DESCRIPTION
The current code results in the below warning:
```
FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.
The behavior will change in pandas 3.0. This inplace method will never work because the intermediate object on which we are setting values always behaves as a copy.

For example, when doing 'df[col].method(value, inplace=True)', try using 'df.method({col: value}, inplace=True)' or df[col] = df[col].method(value) instead, to perform the operation inplace on the original object.


  df[col].replace({numerical_fill_value: None}, inplace=True)
```
The change in this PR follows the recommendation in the warning to be compliant.