### PR TITLE
Enable Filtering From List of Profiles

### DIFF
--- a/thicket/tests/test_concat_thickets.py
+++ b/thicket/tests/test_concat_thickets.py
@@ -134,3 +134,24 @@ def test_query_concat_thickets_columns(thicket_axis_columns):
     )
 
     check_query(combined_th, hnids, query)
+
+
+def test_filter_profile_concat_thickets_columns(thicket_axis_columns):
+    thickets, thickets_cp, combined_th = thicket_axis_columns
+
+    rm_profs = [
+        (2097152.0, "block_128"),
+        (1048576.0, "block_128"),
+        (1048576.0, "block_256"),
+    ]
+    keep_profs = [
+        (2097152.0, "block_256"),
+        (2097152.0, "default"),
+        (1048576.0, "default"),
+    ]
+
+    tk_filt = combined_th.filter_profile(keep_profs)
+
+    for component in [tk_filt.profile, tk_filt.profile_mapping.keys()]:
+        assert all([prof not in component for prof in rm_profs])
+        assert all([prof in component for prof in keep_profs])

--- a/thicket/tests/test_concat_thickets.py
+++ b/thicket/tests/test_concat_thickets.py
@@ -140,14 +140,14 @@ def test_filter_profile_concat_thickets_columns(thicket_axis_columns):
     thickets, thickets_cp, combined_th = thicket_axis_columns
 
     rm_profs = [
-        (2097152.0, "block_128"),
+        (1048576.0, "default"),
         (1048576.0, "block_128"),
         (1048576.0, "block_256"),
     ]
     keep_profs = [
         (2097152.0, "block_256"),
         (2097152.0, "default"),
-        (1048576.0, "default"),
+        (2097152.0, "block_128"),
     ]
 
     tk_filt = combined_th.filter_profile(keep_profs)
@@ -155,3 +155,8 @@ def test_filter_profile_concat_thickets_columns(thicket_axis_columns):
     for component in [tk_filt.profile, tk_filt.profile_mapping.keys()]:
         assert all([prof not in component for prof in rm_profs])
         assert all([prof in component for prof in keep_profs])
+
+    assert 1048576.0 not in tk_filt.dataframe.index.get_level_values("ProblemSizeRunParam")
+    assert 2097152.0 in tk_filt.dataframe.index.get_level_values("ProblemSizeRunParam")
+    assert 1048576.0 not in tk_filt.metadata.index
+    assert 2097152.0 in tk_filt.metadata.index

--- a/thicket/tests/test_concat_thickets.py
+++ b/thicket/tests/test_concat_thickets.py
@@ -156,7 +156,9 @@ def test_filter_profile_concat_thickets_columns(thicket_axis_columns):
         assert all([prof not in component for prof in rm_profs])
         assert all([prof in component for prof in keep_profs])
 
-    assert 1048576.0 not in tk_filt.dataframe.index.get_level_values("ProblemSizeRunParam")
+    assert 1048576.0 not in tk_filt.dataframe.index.get_level_values(
+        "ProblemSizeRunParam"
+    )
     assert 2097152.0 in tk_filt.dataframe.index.get_level_values("ProblemSizeRunParam")
     assert 1048576.0 not in tk_filt.metadata.index
     assert 2097152.0 in tk_filt.metadata.index

--- a/thicket/tests/test_filter_profile.py
+++ b/thicket/tests/test_filter_profile.py
@@ -1,0 +1,25 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Thicket Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+from thicket import Thicket
+
+
+def test_filter_profile(rajaperf_cali_1trial):
+    tk = Thicket.from_caliperreader(rajaperf_cali_1trial, disable_tqdm=True)
+
+    rm_profs = [2139808518, 2783439032, 1389420692]
+    keep_profs = [3031003747, 847237663, 3347816895]
+
+    tk_filt = tk.filter_profile(keep_profs)
+
+    # Check each component that uses profiles
+    for component in [
+        tk_filt.profile,
+        tk_filt.profile_mapping.keys(),
+        tk_filt.metadata.index,
+        tk_filt.dataframe.index.get_level_values("profile"),
+    ]:
+        assert all([prof not in component for prof in rm_profs])
+        assert all([prof in component for prof in keep_profs])

--- a/thicket/tests/test_filter_profile.py
+++ b/thicket/tests/test_filter_profile.py
@@ -10,8 +10,8 @@ def test_filter_profile(rajaperf_cali_1trial):
     tk = Thicket.from_caliperreader(rajaperf_cali_1trial, disable_tqdm=True)
 
     # Split profile list into two halves
-    rm_profs = tk.profile[len(tk.profile)//2:]
-    keep_profs = tk.profile[:len(tk.profile)//2]
+    rm_profs = tk.profile[len(tk.profile) // 2 :]
+    keep_profs = tk.profile[: len(tk.profile) // 2]
 
     tk_filt = tk.filter_profile(keep_profs)
 

--- a/thicket/tests/test_filter_profile.py
+++ b/thicket/tests/test_filter_profile.py
@@ -9,8 +9,9 @@ from thicket import Thicket
 def test_filter_profile(rajaperf_cali_1trial):
     tk = Thicket.from_caliperreader(rajaperf_cali_1trial, disable_tqdm=True)
 
-    rm_profs = [2139808518, 2783439032, 1389420692]
-    keep_profs = [3031003747, 847237663, 3347816895]
+    # Split profile list into two halves
+    rm_profs = tk.profile[len(tk.profile)//2:]
+    keep_profs = tk.profile[:len(tk.profile)//2]
 
     tk_filt = tk.filter_profile(keep_profs)
 

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1207,7 +1207,7 @@ class Thicket(GraphFrame):
         Returns:
             (thicket): new thicket object with selected profiles
         """
-        new_thicket = self.copy()
+        new_thicket = self.deepcopy()
 
         new_thicket._sync_profile_components(profile_list)
         validate_profile(new_thicket)

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1496,9 +1496,6 @@ class Thicket(GraphFrame):
         Arguments:
             component (list or DataFrame) -> (list, Thicket.dataframe, or Thicket.metadata): The index
             of this component is used to synchronize the other objects.
-
-        Returns:
-            (thicket): self
         """
 
         def _profile_truth_from_component(component):
@@ -1563,8 +1560,6 @@ class Thicket(GraphFrame):
             raise ValueError(
                 "Component must be either list, Thicket.dataframe, or Thicket.metadata"
             )
-
-        return self
 
 
 class InvalidFilter(Exception):

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1550,10 +1550,10 @@ class Thicket(GraphFrame):
             return self
 
         if isinstance(component, list):
-            self = _sync_indices(component, component)
+            self = _sync_indices(component)
         elif isinstance(component, pd.DataFrame):
             profile_truth = _profile_truth_from_component(component)
-            self = _sync_indices(component, profile_truth)
+            self = _sync_indices(profile_truth)
         else:
             raise ValueError(
                 "Component must be either list, Thicket.dataframe, or Thicket.metadata"

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1215,7 +1215,7 @@ class Thicket(GraphFrame):
         if len(new_thicket.graph) != len(
             new_thicket.dataframe.index.get_level_values("node").unique()
         ):
-            new_thicket.squash()
+            new_thicket = new_thicket.squash()
 
         return new_thicket
 

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1523,7 +1523,7 @@ class Thicket(GraphFrame):
                     profile_truth = component.index
             return list(set(profile_truth))
 
-        def _sync_indices(component, profile_truth):
+        def _sync_indices(profile_truth):
             """Sync the Thicket attributes"""
             self.profile = profile_truth
             self.profile_mapping = OrderedDict(
@@ -1534,10 +1534,8 @@ class Thicket(GraphFrame):
                 }
             )
 
-            if isinstance(component, list):
-                pass
             # For Columnar-indexed Thicket
-            elif isinstance(component.columns, pd.MultiIndex):
+            if isinstance(self.dataframe.columns, pd.MultiIndex):
                 # Create powerset from all profiles
                 pset = set()
                 for p in profile_truth:

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1500,8 +1500,10 @@ class Thicket(GraphFrame):
 
         def _profile_truth_from_component(component):
             """Derive the profiles from the component index."""
+            if isinstance(component, list):
+                return component
             # Option A: Columnar-indexed Thicket
-            if isinstance(component.columns, pd.MultiIndex):
+            elif isinstance(component.columns, pd.MultiIndex):
                 # Performance DataFrame
                 if isinstance(component.index, pd.MultiIndex):
                     row_idx = component.index.droplevel(level="node")
@@ -1549,9 +1551,7 @@ class Thicket(GraphFrame):
 
             return self
 
-        if isinstance(component, list):
-            self = _sync_indices(component)
-        elif isinstance(component, pd.DataFrame):
+        if isinstance(component, list) or isinstance(component, pd.DataFrame):
             profile_truth = _profile_truth_from_component(component)
             self = _sync_indices(profile_truth)
         else:

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1545,7 +1545,7 @@ class Thicket(GraphFrame):
                 pset = set()
                 for p in profile_truth:
                     pset.update(helpers._powerset_from_tuple(p))
-                profile_truth = pset
+                profile_truth = list(pset)
 
             self.dataframe = self.dataframe[
                 self.dataframe.index.droplevel(level="node").isin(profile_truth)


### PR DESCRIPTION
I have came across the need to filter the Thicket based on profiles, and I have been using a roundabout way:
```
# Filter the metadata table based on list of profiles
tk.metadata = tk.metadata.apply(lambda meta: meta[meta.index.isin(profile_list)], axis=0)
# Synchronize the rest of the components
tk._sync_profile_components(tk.metadata)
```
So I designed an explicit function for this filtering `filter_profile`. 