### PR TITLE
Change Filter Shallow Copies to Deep Copies

### DIFF
--- a/thicket/tests/test_filter_metadata.py
+++ b/thicket/tests/test_filter_metadata.py
@@ -32,6 +32,9 @@ def filter_one_column(th, columns_values):
             # check if output is a thicket object
             assert isinstance(new_th, Thicket)
 
+            # check filtered Thicket is separate object
+            assert th.graph is not new_th.graph
+
             # metadata table: compare profile hash keys after filter to expected
             metadata_profile = new_th.metadata.index.tolist()
             assert metadata_profile == exp_index

--- a/thicket/tests/test_filter_stats.py
+++ b/thicket/tests/test_filter_stats.py
@@ -35,6 +35,10 @@ def check_filter_stats(th, columns_values):
             # check if output is a thicket object
             assert isinstance(new_th, Thicket)
 
+            # check filtered Thicket is separate object
+            # We can't check th.graph because of squash in filter_stats
+            assert th.statsframe.graph is not new_th.statsframe.graph
+
             # filtered nodes in aggregated statistics table
             stats_nodes = sorted(
                 new_th.statsframe.dataframe.index.drop_duplicates().tolist()

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1090,8 +1090,8 @@ class Thicket(GraphFrame):
         # Get index name
         index_name = self.metadata.index.name
 
-        # create a copy of the thicket object
-        new_thicket = self.copy()
+        # create a deepcopy of the thicket object
+        new_thicket = self.deepcopy()
 
         # filter metadata table
         filtered_rows = new_thicket.metadata.apply(select_function, axis=1)
@@ -1242,8 +1242,8 @@ class Thicket(GraphFrame):
         Returns:
             (thicket): new thicket object with applied filter function
         """
-        # copy thicket
-        new_thicket = self.copy()
+        # deepcopy thicket
+        new_thicket = self.deepcopy()
 
         # filter aggregated statistics table
         filtered_rows = new_thicket.statsframe.dataframe.apply(filter_function, axis=1)


### PR DESCRIPTION
@ilumsden made a good catch in https://github.com/LLNL/thicket/pull/173, that filter copies should be deep. This PR changes `filter_metadata` and `filter_stats` shallow copies to be deep copies. This is because we expect the returned Thicket from a filter to be a separate Thicket object.

Example of changing the filtered Thicket:
![image](https://github.com/LLNL/thicket/assets/32579379/e58e6ccf-96b2-4158-8866-1ee722111bec)
Shallow Copy - both objects change
![image](https://github.com/LLNL/thicket/assets/32579379/8e4a126a-496a-4148-a721-96017918f811)
Deep Copy - only `th` changes
![image](https://github.com/LLNL/thicket/assets/32579379/02c6c09b-1470-4119-9195-a8e228d02292)

For the sake of a unit test it is sufficient to check that a given filtered Thicket component `is not` the same object as the component in the original Thicket.