### PR TITLE
Check if Metric Exists in add_ncu

### DIFF
--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -557,14 +557,18 @@ class Thicket(GraphFrame):
             overwrite (bool): Determines overriding behavior in performance data table
             drop (bool): Whether to drop the column from the metadata table afterwards
         """
-        # Check if column already exists in performance data table
+        # Add warning if column already exists in performance data table
         if metadata_key in self.dataframe.columns:
+            # Drop column to overwrite, otherwise warn and return
             if overwrite:
-                self.dataframe = self.dataframe.drop(columns=metadata_key)
+                self.dataframe.drop(metadata_key, axis=1, inplace=True)
             else:
-                raise ValueError(
-                    f"Column {metadata_key} already exists in the performance data table. Set overwrite=True to overwrite."
+                warnings.warn(
+                    "Column "
+                    + metadata_key
+                    + " already exists. Set 'overwrite=True' to force update the column."
                 )
+                return
 
         # Add the column to the performance data table
         self.dataframe = self.dataframe.join(
@@ -573,7 +577,7 @@ class Thicket(GraphFrame):
 
         # Drop column
         if drop:
-            self.metadata = self.metadata.drop(columns=metadata_key)
+            self.metadata.drop(metadata_key, axis=1, inplace=True)
 
     def squash(self, update_inc_cols=True, new_statsframe=True):
         """Rewrite the Graph to include only nodes present in the performance

--- a/thicket/utils.py
+++ b/thicket/utils.py
@@ -63,6 +63,25 @@ def check_duplicate_metadata_key(thickets, metadata_key):
         )
 
 
+def overwrite_column(df, col, overwrite):
+    """Check and overwrite a column in a DataFrame if it already exists.
+
+    Arguments:
+        df (DataFrame): Input DataFrame
+        col (str): Column name to check
+        overwrite (bool): Option to overwrite column if it already exists
+
+    Returns:
+        (DataFrame): DataFrame with column removed
+    """
+    if overwrite:
+        return df.drop(col, axis=1)
+    else:
+        raise ValueError(
+            f"Column {col} already exists. Set 'overwrite=True' to overwrite."
+        )
+
+
 def validate_dataframe(df):
     """Check validity of a Thicket DataFrame."""
 

--- a/thicket/utils.py
+++ b/thicket/utils.py
@@ -63,25 +63,6 @@ def check_duplicate_metadata_key(thickets, metadata_key):
         )
 
 
-def overwrite_column(df, col, overwrite):
-    """Check and overwrite a column in a DataFrame if it already exists.
-
-    Arguments:
-        df (DataFrame): Input DataFrame
-        col (str): Column name to check
-        overwrite (bool): Option to overwrite column if it already exists
-
-    Returns:
-        (DataFrame): DataFrame with column removed
-    """
-    if overwrite:
-        return df.drop(col, axis=1)
-    else:
-        raise ValueError(
-            f"Column {col} already exists. Set 'overwrite=True' to overwrite."
-        )
-
-
 def validate_dataframe(df):
     """Check validity of a Thicket DataFrame."""
 


### PR DESCRIPTION
@Yejashi discovered that running `add_ncu` twice will cause the metrics to be added twice with `_left` and `_right` suffixes, as expected from the `join` called at the end of `add_ncu`. However, this may be unintuitive for our users, so this PR adds a check if the column already exists taking inspiration from the check in `metadata_column_to_perfdata`. The user has the option to overwrite the columns by setting `overwrite=True`. ~This PR also refactors the check in `metadata_column_to_perfdata` to a `utils` function so it can be used by `metadata_column_to_perfdata`, `add_ncu`, and any other functions that require this check.~