### PR TITLE
Remove Print in Groupby

### DIFF
--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1373,9 +1373,6 @@ class Thicket(GraphFrame):
                 "The provided Thicket object has an empty metadata table."
             )
 
-        print(len(sub_thickets), " thickets created...")
-        print(sub_thickets)
-
         return GroupBy(by, sub_thickets)
 
     def filter_stats(self, filter_function):


### PR DESCRIPTION
There's a print in `Thicket.groupby()` that really shouldn't be there. It prints the amount of Thickets created and the dictionary of key to Thicket object.

Reasons why it should be removed:
1. pandas groupby doesn't do this.
2. The resulting `GroupBy` object can be printed after it's created anyway, as our `GroupBy` class inherits from `dict`