### PR TITLE
Add Nodes in Slice Before Printing Tree

### DIFF
--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -188,7 +188,7 @@ class Ensemble:
             for k, v in profile_mapping_cp.items():
                 combined_th.profile_mapping[
                     new_mappings[k]
-                    ] = combined_th.profile_mapping.pop(k)
+                ] = combined_th.profile_mapping.pop(k)
             combined_th.performance_cols = helpers._get_perf_columns(
                 combined_th.dataframe
             )

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -4,10 +4,8 @@
 # SPDX-License-Identifier: MIT
 
 from collections import OrderedDict
-import warnings
 
 from hatchet import GraphFrame
-import numpy as np
 import pandas as pd
 
 import thicket.helpers as helpers
@@ -16,6 +14,7 @@ from .utils import (
     validate_dataframe,
     verify_sorted_profile,
     verify_thicket_structures,
+    _fill_perfdata,
 )
 
 
@@ -187,9 +186,9 @@ class Ensemble:
             combined_th.profile = [new_mappings[prf] for prf in combined_th.profile]
             profile_mapping_cp = combined_th.profile_mapping.copy()
             for k, v in profile_mapping_cp.items():
-                combined_th.profile_mapping[
-                    new_mappings[k]
-                ] = combined_th.profile_mapping.pop(k)
+                combined_th.profile_mapping[new_mappings[k]] = (
+                    combined_th.profile_mapping.pop(k)
+                )
             combined_th.performance_cols = helpers._get_perf_columns(
                 combined_th.dataframe
             )
@@ -352,38 +351,6 @@ class Ensemble:
             unify_profile (list): profiles,
             unify_profile_mapping (dict): profile mapping
         """
-
-        def _fill_perfdata(df, numerical_fill_value=np.nan):
-            """Create full index for DataFrame and fill created rows with NaN's or None's where applicable.
-
-            Arguments:
-                df (DataFrame): DataFrame to fill missing rows in
-                numerical_fill_value (any): value to fill numerical rows with
-
-            Returns:
-                (DataFrame): filled DataFrame
-            """
-            try:
-                # Fill missing rows in dataframe with NaN's
-                df = df.reindex(
-                    pd.MultiIndex.from_product(df.index.levels),
-                    fill_value=numerical_fill_value,
-                )
-                # Replace "NaN" with "None" in columns of string type
-                for col in df.columns:
-                    if pd.api.types.is_string_dtype(df[col].dtype):
-                        df[col] = df[col].replace({numerical_fill_value: None})
-            except ValueError as e:
-                estr = str(e)
-                if estr == "cannot handle a non-unique multi-index!":
-                    warnings.warn(
-                        "Non-unique multi-index for DataFrame in _fill_perfdata. Cannot Fill missing rows.",
-                        RuntimeWarning,
-                    )
-                else:
-                    raise
-
-            return df
 
         # Add missing indicies to thickets
         helpers._resolve_missing_indicies(thickets)

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -186,9 +186,9 @@ class Ensemble:
             combined_th.profile = [new_mappings[prf] for prf in combined_th.profile]
             profile_mapping_cp = combined_th.profile_mapping.copy()
             for k, v in profile_mapping_cp.items():
-                combined_th.profile_mapping[new_mappings[k]] = (
-                    combined_th.profile_mapping.pop(k)
-                )
+                combined_th.profile_mapping[
+                    new_mappings[k]
+                    ] = combined_th.profile_mapping.pop(k)
             combined_th.performance_cols = helpers._get_perf_columns(
                 combined_th.dataframe
             )

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -936,28 +936,17 @@ class Thicket(GraphFrame):
         # Slices the DataFrame to simulate a single-level index
         try:
             # Select only columns used by tree for efficiency in _fill_perfdata
-            if isinstance(metric_column, list):
-                df_cols = [
-                    col
-                    for col in [
-                        *metric_column,
-                        annotation_column,
-                        name_column,
-                        context_column,
-                    ]
-                    if col in self.dataframe.columns
+            tree_cols = (
+                metric_column
+                if isinstance(metric_column, list)
+                else [metric_column]
+                + [
+                    annotation_column,
+                    name_column,
+                    context_column,
                 ]
-            else:
-                df_cols = [
-                    col
-                    for col in [
-                        metric_column,
-                        annotation_column,
-                        name_column,
-                        context_column,
-                    ]
-                    if col in self.dataframe.columns
-                ]
+            )
+            df_cols = [col for col in tree_cols if col in self.dataframe.columns]
             slice_df = self.dataframe.loc[:, df_cols]
             # _fill_perfdata to make sure number of nodes in df == graph
             slice_df = _fill_perfdata(slice_df)

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -28,6 +28,7 @@ from thicket.query import (
 import tqdm
 
 from thicket.ensemble import Ensemble
+from thicket.utils import _fill_perfdata
 
 try:
     from .ncu import NCUReader
@@ -934,8 +935,10 @@ class Thicket(GraphFrame):
         }
         # Slices the DataFrame to simulate a single-level index
         try:
+            # _fill_perfdata to make sure number of nodes in df == graph
+            slice_df = _fill_perfdata(self.dataframe)
             slice_df = (
-                self.dataframe.loc[(slice(None),) + indices, :]
+                slice_df.loc[(slice(None),) + indices, :]
                 .reset_index()
                 .set_index("node")
             )

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -935,8 +935,32 @@ class Thicket(GraphFrame):
         }
         # Slices the DataFrame to simulate a single-level index
         try:
+            # Select only columns used by tree for efficiency in _fill_perfdata
+            if isinstance(metric_column, list):
+                df_cols = [
+                    col
+                    for col in [
+                        *metric_column,
+                        annotation_column,
+                        name_column,
+                        context_column,
+                    ]
+                    if col in self.dataframe.columns
+                ]
+            else:
+                df_cols = [
+                    col
+                    for col in [
+                        metric_column,
+                        annotation_column,
+                        name_column,
+                        context_column,
+                    ]
+                    if col in self.dataframe.columns
+                ]
+            slice_df = self.dataframe.loc[:, df_cols]
             # _fill_perfdata to make sure number of nodes in df == graph
-            slice_df = _fill_perfdata(self.dataframe)
+            slice_df = _fill_perfdata(slice_df)
             slice_df = (
                 slice_df.loc[(slice(None),) + indices, :]
                 .reset_index()

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -936,17 +936,20 @@ class Thicket(GraphFrame):
         # Slices the DataFrame to simulate a single-level index
         try:
             # Select only columns used by tree for efficiency in _fill_perfdata
-            tree_cols = (
-                metric_column
-                if isinstance(metric_column, list)
-                else [metric_column]
-                + [
+            df_cols = [
+                col
+                for col in [
+                    *(
+                        metric_column
+                        if isinstance(metric_column, list)
+                        else [metric_column]
+                    ),
                     annotation_column,
                     name_column,
                     context_column,
                 ]
-            )
-            df_cols = [col for col in tree_cols if col in self.dataframe.columns]
+                if col in self.dataframe.columns
+            ]
             slice_df = self.dataframe.loc[:, df_cols]
             # _fill_perfdata to make sure number of nodes in df == graph
             slice_df = _fill_perfdata(slice_df)

--- a/thicket/utils.py
+++ b/thicket/utils.py
@@ -270,7 +270,7 @@ def _fill_perfdata(df, numerical_fill_value=np.nan):
     Returns:
         (DataFrame): filled DataFrame
     """
-    new_df = df.copy()
+    new_df = df.copy(deep=True)
     try:
         # Fill missing rows in dataframe with NaN's
         new_df = new_df.reindex(

--- a/thicket/utils.py
+++ b/thicket/utils.py
@@ -270,16 +270,17 @@ def _fill_perfdata(df, numerical_fill_value=np.nan):
     Returns:
         (DataFrame): filled DataFrame
     """
+    new_df = df.copy()
     try:
         # Fill missing rows in dataframe with NaN's
-        df = df.reindex(
-            pd.MultiIndex.from_product(df.index.levels),
+        new_df = new_df.reindex(
+            pd.MultiIndex.from_product(new_df.index.levels),
             fill_value=numerical_fill_value,
         )
         # Replace "NaN" with "None" in columns of string type
-        for col in df.columns:
-            if pd.api.types.is_string_dtype(df[col].dtype):
-                df[col] = df[col].replace({numerical_fill_value: None})
+        for col in new_df.columns:
+            if pd.api.types.is_string_dtype(new_df[col].dtype):
+                new_df[col] = new_df[col].replace({numerical_fill_value: None})
     except ValueError as e:
         estr = str(e)
         if estr == "cannot handle a non-unique multi-index!":
@@ -290,4 +291,4 @@ def _fill_perfdata(df, numerical_fill_value=np.nan):
         else:
             raise
 
-    return df
+    return new_df


### PR DESCRIPTION
This PR applies when `fill_perfdata` is off in the Thicket constructor, since some profiles may be missing certain nodes. This PR inserts NaNs for missing nodes, so we can still print the tree.
- Allows tree to be printed when `fill_perfdata=False`
- Moves the `_fill_perfdata` function to `utils.py` so it can be called in `tree`