### PR TITLE
Optimize Loop in Unify

### DIFF
--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -54,12 +54,12 @@ class Ensemble:
             # This is necessary to avoid applying updates to the DataFrames every iteration.
             # Merge values of new_dict into keys of old_to_new
             merged_dict = {}
-            seen_keys = []
+            seen_keys = set()
             for old_id, cur_node in old_to_new.items():
                 cur_id = id(cur_node)
                 if cur_id in new_dict:
                     merged_dict[old_id] = new_dict[cur_id]
-                    seen_keys.append(cur_id)
+                    seen_keys.add(cur_id)            
             # Add pairs that are left from new_dict into old_to_new
             for cur_id, new_node in new_dict.items():
                 if cur_id not in seen_keys:

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -45,25 +45,25 @@ class Ensemble:
         union_graph = _thickets[0].graph
         old_to_new = {}
         for i in range(len(_thickets) - 1):
-            temp_dict = {}
-            union_graph = union_graph.union(_thickets[i + 1].graph, temp_dict)
+            new_dict = {}
+            union_graph = union_graph.union(_thickets[i + 1].graph, new_dict)
             # Set all graphs to the union graph
             _thickets[i].graph = union_graph
             _thickets[i + 1].graph = union_graph
             # Merge the current old_to_new dictionary with the new mappings.
             # This is necessary to avoid applying updates to the DataFrames every iteration.
-            # Merge values of temp_dict into keys of old_to_new
+            # Merge values of new_dict into keys of old_to_new
             merged_dict = {}
             seen_keys = []
-            for cur_id, cur_node in old_to_new.items():
-                new_id = id(cur_node)
-                if new_id in temp_dict:
-                    merged_dict[cur_id] = temp_dict[new_id]
-                    seen_keys.append(new_id)
-            # Add pairs that are left from temp_dict into old_to_new
-            for temp_id, node in temp_dict.items():
-                if temp_id not in seen_keys:
-                    merged_dict[temp_id] = node
+            for old_id, cur_node in old_to_new.items():
+                cur_id = id(cur_node)
+                if cur_id in new_dict:
+                    merged_dict[old_id] = new_dict[cur_id]
+                    seen_keys.append(cur_id)
+            # Add pairs that are left from new_dict into old_to_new
+            for cur_id, new_node in new_dict.items():
+                if cur_id not in seen_keys:
+                    merged_dict[cur_id] = new_node
             old_to_new = merged_dict
         # Update the nodes in the dataframe
         for i in range(len(_thickets)):

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -53,16 +53,18 @@ class Ensemble:
             # Merge the current old_to_new dictionary with the new mappings.
             # This is necessary to avoid applying updates to the DataFrames every iteration.
             # Merge values of temp_dict into keys of old_to_new
+            merged_dict = {}
             seen_keys = []
             for cur_id, cur_node in old_to_new.items():
                 new_id = id(cur_node)
                 if new_id in temp_dict:
-                    old_to_new[cur_id] = temp_dict[new_id]
+                    merged_dict[cur_id] = temp_dict[new_id]
                     seen_keys.append(new_id)
             # Add pairs that are left from temp_dict into old_to_new
             for temp_id, node in temp_dict.items():
                 if temp_id not in seen_keys:
-                    old_to_new[temp_id] = node
+                    merged_dict[temp_id] = node
+            old_to_new = merged_dict
         # Update the nodes in the dataframe
         for i in range(len(_thickets)):
             _thickets[i].graph = union_graph

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -59,7 +59,7 @@ class Ensemble:
                 cur_id = id(cur_node)
                 if cur_id in new_dict:
                     merged_dict[old_id] = new_dict[cur_id]
-                    seen_keys.add(cur_id)            
+                    seen_keys.add(cur_id)
             # Add pairs that are left from new_dict into old_to_new
             for cur_id, new_node in new_dict.items():
                 if cur_id not in seen_keys:

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -37,65 +37,6 @@ class Ensemble:
                 (list): list of Thicket objects
         """
 
-        def _merge_dicts(cur_dict, update_dict):
-            """Merge old_to_new dictionary from the result of thicket i and i + 1 with old_to_new from i + 1 and i + 2.
-
-            Arguments:
-                cur_dict (dict): dictionary mapping old node to new node
-                update_dict (dict): dictionary mapping old node to new node
-
-            Returns:
-                (dict): merged dictionary
-            """
-            merged_dict = {}
-
-            # If cur_dict is empty, return update_dict
-            if len(cur_dict) == 0:
-                return update_dict
-
-            # Merge values from update_dict into keys from cur_dict
-            seen_keys = []
-            for cur_id, cur_node in cur_dict.items():
-                new_id = id(cur_node)
-                if new_id in update_dict:
-                    merged_dict[cur_id] = update_dict[new_id]
-                    seen_keys.append(new_id)
-
-            # Pairs that are left in update_dict
-            for tid, node in update_dict.items():
-                if tid not in seen_keys:
-                    merged_dict[tid] = node
-
-            return merged_dict
-
-        def _replace_graph_df_nodes(thickets, old_to_new, union_graph):
-            """Replace the node objects in the graph and DataFrame of a Thicket object from the result of graph.union().
-
-            Arguments:
-                thickets (list): list of Thicket objects
-                old_to_new (dict): dictionary mapping old node to new node
-                union_graph (hatchet.Graph): unified graph
-
-            Returns:
-                (Thicket): modified Thicket object
-            """
-            for i in range(len(thickets)):
-                thickets[i].graph = union_graph
-                idx_names = thickets[i].dataframe.index.names
-                thickets[i].dataframe = thickets[i].dataframe.reset_index()
-                replace_dict = {}
-                for node in thickets[i].dataframe["node"]:
-                    node_id = id(node)
-                    if node_id in old_to_new:
-                        check_same_frame(node, old_to_new[node_id])
-                        replace_dict[node] = old_to_new[node_id]
-                thickets[i].dataframe["node"] = (
-                    thickets[i].dataframe["node"].replace(replace_dict)
-                )
-                thickets[i].dataframe = thickets[i].dataframe.set_index(idx_names)
-
-            return thickets
-
         _thickets = thickets
         if not inplace:
             _thickets = [th.deepcopy() for th in thickets]
@@ -109,13 +50,35 @@ class Ensemble:
             # Set all graphs to the union graph
             _thickets[i].graph = union_graph
             _thickets[i + 1].graph = union_graph
-            # Merge the current old_to_new dictionary with the new mappings
-            old_to_new = _merge_dicts(old_to_new, temp_dict)
+            # Merge the current old_to_new dictionary with the new mappings.
+            # This is necessary to avoid applying updates to the DataFrames every iteration.
+            # Merge values of temp_dict into keys of old_to_new
+            seen_keys = []
+            for cur_id, cur_node in old_to_new.items():
+                new_id = id(cur_node)
+                if new_id in temp_dict:
+                    old_to_new[cur_id] = temp_dict[new_id]
+                    seen_keys.append(new_id)
+            # Add pairs that are left from temp_dict into old_to_new
+            for temp_id, node in temp_dict.items():
+                if temp_id not in seen_keys:
+                    old_to_new[temp_id] = node
         # Update the nodes in the dataframe
-        _thickets = _replace_graph_df_nodes(_thickets, old_to_new, union_graph)
         for i in range(len(_thickets)):
-            # For tree diff. dataframes need to be sorted.
-            _thickets[i].dataframe.sort_index(inplace=True)
+            _thickets[i].graph = union_graph
+            idx_names = _thickets[i].dataframe.index.names
+            _thickets[i].dataframe = _thickets[i].dataframe.reset_index()
+            replace_dict = {}
+            for node in _thickets[i].dataframe["node"]:
+                node_id = id(node)
+                if node_id in old_to_new:
+                    check_same_frame(node, old_to_new[node_id])
+                    replace_dict[node] = old_to_new[node_id]
+            _thickets[i].dataframe["node"] = (
+                _thickets[i].dataframe["node"].replace(replace_dict)
+            )
+            _thickets[i].dataframe = _thickets[i].dataframe.set_index(idx_names)
+            _thickets[i].dataframe = _thickets[i].dataframe.sort_index()
         return union_graph, _thickets
 
     @staticmethod

--- a/thicket/ensemble.py
+++ b/thicket/ensemble.py
@@ -49,16 +49,17 @@ class Ensemble:
             """
             merged_dict = {}
 
+            # If cur_dict is empty, return update_dict
             if len(cur_dict) == 0:
                 return update_dict
 
             # Merge values from update_dict into keys from cur_dict
             seen_keys = []
-            for new_id, new_node in update_dict.items():
-                for cur_id, cur_node in cur_dict.items():
-                    if id(cur_node) == new_id:
-                        merged_dict[cur_id] = new_node
-                        seen_keys.append(new_id)
+            for cur_id, cur_node in cur_dict.items():
+                new_id = id(cur_node)
+                if new_id in update_dict:
+                    merged_dict[cur_id] = update_dict[new_id]
+                    seen_keys.append(new_id)
 
             # Pairs that are left in update_dict
             for tid, node in update_dict.items():


### PR DESCRIPTION
This PR:

1. Refactors `_merge_dicts` and `_replace_graph_df_nodes` by removing the functions and putting the code inline.
2. Optimizes the double for loop that merges `old_to_new` and `temp_dict` from `O(n^2)` to `O(n)`. This was an oversight during original implementation.

The performance improvements of this PR are documented in #170. #170 avoids needing to merge dictionaries as it only calls `concat_thickets` with 2 Thickets, however using the `concat_thickets` function with 3 or more Thickets will still benefit from this PR. 

This PR is better for fewer files with many nodes, while #170 is better for many files since it avoids merging `old_to_new` and `temp_dict`.
