### PR TITLE
Fix Deepcopy Bug

### DIFF
--- a/thicket/tests/test_copy.py
+++ b/thicket/tests/test_copy.py
@@ -121,3 +121,6 @@ def test_deepcopy(rajaperf_seq_O3_1M_cali):
     assert len(self.dataframe.columns) + len(self.dataframe.index[0]) == len(
         other.dataframe.reset_index().columns
     )
+
+    # Check new graph is statsframe graph
+    assert other.graph is other.statsframe.graph

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -846,7 +846,7 @@ class Thicket(GraphFrame):
             profile=copy.deepcopy(self.profile),
             profile_mapping=copy.deepcopy(self.profile_mapping),
             statsframe=GraphFrame(
-                graph=gf.graph, dataframe=self.statsframe.dataframe.copy()
+                graph=gf.graph, dataframe=self.statsframe.dataframe.copy(deep=True)
             ),
             statsframe_ops_cache=self.statsframe_ops_cache.copy(),
         )

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -846,8 +846,7 @@ class Thicket(GraphFrame):
             profile=copy.deepcopy(self.profile),
             profile_mapping=copy.deepcopy(self.profile_mapping),
             statsframe=GraphFrame(
-                graph=gf.graph,
-                dataframe=self.statsframe.dataframe.copy()
+                graph=gf.graph, dataframe=self.statsframe.dataframe.copy()
             ),
             statsframe_ops_cache=self.statsframe_ops_cache.copy(),
         )

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -845,7 +845,10 @@ class Thicket(GraphFrame):
             metadata=self.metadata.copy(),
             profile=copy.deepcopy(self.profile),
             profile_mapping=copy.deepcopy(self.profile_mapping),
-            statsframe=self.statsframe.deepcopy(),
+            statsframe=GraphFrame(
+                graph=gf.graph,
+                dataframe=self.statsframe.dataframe.copy()
+            ),
             statsframe_ops_cache=self.statsframe_ops_cache.copy(),
         )
 


### PR DESCRIPTION
In Thicket, we assume 
```
self.graph is self.statsframe.graph
```
current `deepcopy()` breaks this assumption and this is a fix.