### PR TITLE
Temporarily pin numpy Version Less Than 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 scipy
-numpy
+numpy < 2.0.0
 pandas>=1.1
 llnl-hatchet
 extrap

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "scipy",
-        "numpy",
+        "numpy < 2.0.0",
         "pandas >= 1.1",
         "llnl-hatchet",
         "tqdm",


### PR DESCRIPTION
numpy recently released version [2.0](https://numpy.org/devdocs/release/2.0.0-notes.html) which has a lot of changes. This PR matches [Hatchet/140](https://github.com/LLNL/hatchet/pull/140).