### PR TITLE
Add Root Node to Graph

### DIFF
--- a/thicket/tests/test_add_root_node.py
+++ b/thicket/tests/test_add_root_node.py
@@ -1,0 +1,26 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Thicket Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+from hatchet.node import Node
+
+
+def test_add_root_node(literal_thickets):
+    tk, tk2, tk3 = literal_thickets
+
+    assert len(tk.graph) == 4
+
+    tk.add_root_node({"name": "Test", "type": "function"})
+
+    test_node = tk.get_node("Test")
+
+    # Check if node was inserted in all components
+    assert isinstance(test_node, Node)
+    assert len(tk.graph) == 5
+    assert len(tk.statsframe.graph) == 5
+    assert test_node in tk.dataframe.index.get_level_values("node")
+    assert test_node in tk.statsframe.dataframe.index.get_level_values("node")
+
+    assert tk.dataframe.loc[test_node, "name"].values[0] == "Test"
+    assert tk.statsframe.dataframe.loc[test_node, "name"] == "Test"

--- a/thicket/tests/test_add_root_node.py
+++ b/thicket/tests/test_add_root_node.py
@@ -7,7 +7,7 @@ from hatchet.node import Node
 
 
 def test_add_root_node(literal_thickets):
-    tk, tk2, tk3 = literal_thickets
+    tk, _, _ = literal_thickets
 
     assert len(tk.graph) == 4
 

--- a/thicket/tests/test_add_root_node.py
+++ b/thicket/tests/test_add_root_node.py
@@ -11,12 +11,15 @@ def test_add_root_node(literal_thickets):
 
     assert len(tk.graph) == 4
 
+    # Call add_root_node
     tk.add_root_node({"name": "Test", "type": "function"})
-
+    # Get node variable
     test_node = tk.get_node("Test")
 
     # Check if node was inserted in all components
     assert isinstance(test_node, Node)
+    assert test_node._hatchet_nid == 3
+    assert test_node._depth == 0
     assert len(tk.graph) == 5
     assert len(tk.statsframe.graph) == 5
     assert test_node in tk.dataframe.index.get_level_values("node")

--- a/thicket/tests/test_get_node.py
+++ b/thicket/tests/test_get_node.py
@@ -9,7 +9,7 @@ import pytest
 def test_get_node(literal_thickets):
     tk, _, _ = literal_thickets
 
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         tk.get_node("Foo")
 
     baz = tk.get_node("Baz")

--- a/thicket/tests/test_get_node.py
+++ b/thicket/tests/test_get_node.py
@@ -7,7 +7,7 @@ import pytest
 
 
 def test_get_node(literal_thickets):
-    tk, tk2, tk3 = literal_thickets
+    tk, _, _ = literal_thickets
 
     with pytest.raises(ValueError):
         tk.get_node("Foo")

--- a/thicket/tests/test_get_node.py
+++ b/thicket/tests/test_get_node.py
@@ -10,7 +10,7 @@ def test_get_node(literal_thickets):
     tk, tk2, tk3 = literal_thickets
 
     with pytest.raises(ValueError):
-        foo = tk.get_node("Foo")
+        tk.get_node("Foo")
 
     baz = tk.get_node("Baz")
 

--- a/thicket/tests/test_get_node.py
+++ b/thicket/tests/test_get_node.py
@@ -1,0 +1,20 @@
+# Copyright 2022 Lawrence Livermore National Security, LLC and other
+# Thicket Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+
+def test_get_node(literal_thickets):
+    tk, tk2, tk3 = literal_thickets
+
+    with pytest.raises(ValueError):
+        foo = tk.get_node("Foo")
+
+    baz = tk.get_node("Baz")
+
+    # Check node properties
+    assert baz.frame["name"] == "Baz"
+    assert baz.frame["type"] == "function"
+    assert baz._hatchet_nid == 0

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1518,17 +1518,11 @@ class Thicket(GraphFrame):
 
         return sorted_meta
 
-
     def add_root_node(self, attrs):
         """Add node at root level"""
         assert self.graph is self.statsframe.graph
 
-        new_node = node.Node(
-            frame_obj=frame.Frame(
-                attrs=attrs
-            ),
-            hnid=len(self.graph)
-        )
+        new_node = node.Node(frame_obj=frame.Frame(attrs=attrs), hnid=len(self.graph))
 
         # graph and statsframe.graph
         self.graph.roots.append(new_node)
@@ -1547,6 +1541,14 @@ class Thicket(GraphFrame):
 
         assert self.graph is self.statsframe.graph
 
+    def get_node(self, name):
+        node = [n for n in self.graph.traverse() if n.frame["name"] == name]
+
+        if len(node) > 1:
+            warnings.warn(f'More than one node with name "{name}". Returning a list')
+            return node
+
+        return node.pop()
 
     def _sync_profile_components(self, component):
         """Synchronize the Performance DataFrame, Metadata Dataframe, profile and

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1519,8 +1519,12 @@ class Thicket(GraphFrame):
         return sorted_meta
 
     def add_root_node(self, attrs):
-        """Add node at root level"""
-        assert self.graph is self.statsframe.graph
+        """Add node at root level with given attributes.
+
+        Arguments:
+            attrs (dict): attributes for the new node which will be used to initilize the
+            node.frame.
+        """
 
         new_node = node.Node(frame_obj=frame.Frame(attrs=attrs), hnid=len(self.graph))
 
@@ -1539,9 +1543,16 @@ class Thicket(GraphFrame):
         # statsframe.dataframe
         self.statsframe.dataframe = helpers._new_statsframe_df(self.dataframe)
 
-        assert self.graph is self.statsframe.graph
-
     def get_node(self, name):
+        """Get a node object in the Thicket by its node.frame['name']. If more than one
+        node has the same name, a list of nodes is returned.
+
+        Arguments:
+            name (str): name of the node (node.frame['name']).
+
+        Returns:
+            (node): Hatchet Node object
+        """
         node = [n for n in self.graph.traverse() if n.frame["name"] == name]
 
         if len(node) > 1:

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -15,7 +15,11 @@ from hashlib import md5
 
 import pandas as pd
 import numpy as np
-from hatchet import GraphFrame
+from hatchet import (
+    frame,
+    GraphFrame,
+    node,
+)
 from hatchet.graph import Graph
 from hatchet.query import QueryEngine
 from thicket.query import (
@@ -1513,6 +1517,35 @@ class Thicket(GraphFrame):
                 )
 
         return sorted_meta
+
+
+    def add_root_node(self, attrs):
+        """Add node at root level"""
+        assert self.graph is self.statsframe.graph
+
+        new_node = node.Node(
+            frame_obj=frame.Frame(
+                attrs=attrs
+            ),
+            hnid=len(self.graph)
+        )
+
+        # graph and statsframe.graph
+        self.graph.roots.append(new_node)
+
+        # dataframe
+        idx_levels = self.dataframe.index.names
+        new_idx = [[new_node]] + [self.profile]
+        new_node_df = pd.DataFrame(
+            index=pd.MultiIndex.from_product(new_idx, names=idx_levels)
+        )
+        self.dataframe = pd.concat([self.dataframe, new_node_df])
+
+        # statsframe.dataframe
+        self.statsframe.dataframe = helpers._new_statsframe_df(self.dataframe)
+
+        assert self.graph is self.statsframe.graph
+
 
     def _sync_profile_components(self, component):
         """Synchronize the Performance DataFrame, Metadata Dataframe, profile and

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1525,11 +1525,16 @@ class Thicket(GraphFrame):
         """
 
         new_node = Node(
-            frame_obj=Frame(attrs=attrs), hnid=len(self.graph)
+            frame_obj=Frame(attrs=attrs)
         )
 
         # graph and statsframe.graph
         self.graph.roots.append(new_node)
+
+        # Set depth
+        self.graph.enumerate_depth()
+        # Set hatchet nid
+        self.graph.enumerate_traverse()
 
         # dataframe
         idx_levels = self.dataframe.index.names

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1563,7 +1563,7 @@ class Thicket(GraphFrame):
             warnings.warn(f'More than one node with name "{name}". Returning a list')
             return node
 
-        return node.pop()
+        return node[0]
 
     def _sync_profile_components(self, component):
         """Synchronize the Performance DataFrame, Metadata Dataframe, profile and

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1550,6 +1550,9 @@ class Thicket(GraphFrame):
         # Reapply stats operations after clearing statsframe dataframe
         self.reapply_stats_operations()
 
+        # Check Thicket state
+        validate_nodes(self)
+
     def get_node(self, name):
         """Get a node object in the Thicket by its Node.frame['name']. If more than one
         node has the same name, a list of nodes is returned.

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1565,7 +1565,7 @@ class Thicket(GraphFrame):
             warnings.warn(f'More than one node with name "{name}". Returning a list')
             return node
         elif len(node) == 0:
-            raise ValueError(f'Node with name "{name}" not found.')
+            raise KeyError(f'Node with name "{name}" not found.')
 
         return node[0]
 

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1546,11 +1546,11 @@ class Thicket(GraphFrame):
         self.reapply_stats_operations()
 
     def get_node(self, name):
-        """Get a node object in the Thicket by its node.frame['name']. If more than one
+        """Get a node object in the Thicket by its Node.frame['name']. If more than one
         node has the same name, a list of nodes is returned.
 
         Arguments:
-            name (str): name of the node (node.frame['name']).
+            name (str): name of the node (Node.frame['name']).
 
         Returns:
             (node): Hatchet Node object

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -15,12 +15,10 @@ from hashlib import md5
 
 import pandas as pd
 import numpy as np
-import hatchet.node
-from hatchet import (
-    frame,
-    GraphFrame,
-)
+from hatchet import GraphFrame
+from hatchet.frame import Frame
 from hatchet.graph import Graph
+from hatchet.node import Node
 from hatchet.query import QueryEngine
 from thicket.query import (
     Query,
@@ -1526,8 +1524,8 @@ class Thicket(GraphFrame):
             node.frame.
         """
 
-        new_node = hatchet.node.Node(
-            frame_obj=frame.Frame(attrs=attrs), hnid=len(self.graph)
+        new_node = Node(
+            frame_obj=Frame(attrs=attrs), hnid=len(self.graph)
         )
 
         # graph and statsframe.graph

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1544,6 +1544,8 @@ class Thicket(GraphFrame):
 
         # statsframe.dataframe
         self.statsframe.dataframe = helpers._new_statsframe_df(self.dataframe)
+        # Reapply stats operations after clearing statsframe dataframe
+        self.reapply_stats_operations()
 
     def get_node(self, name):
         """Get a node object in the Thicket by its node.frame['name']. If more than one

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1524,9 +1524,7 @@ class Thicket(GraphFrame):
             node.frame.
         """
 
-        new_node = Node(
-            frame_obj=Frame(attrs=attrs)
-        )
+        new_node = Node(frame_obj=Frame(attrs=attrs))
 
         # graph and statsframe.graph
         self.graph.roots.append(new_node)

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1539,6 +1539,7 @@ class Thicket(GraphFrame):
         new_node_df = pd.DataFrame(
             index=pd.MultiIndex.from_product(new_idx, names=idx_levels)
         )
+        new_node_df["name"] = attrs["name"]
         self.dataframe = pd.concat([self.dataframe, new_node_df])
 
         # statsframe.dataframe

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1557,17 +1557,15 @@ class Thicket(GraphFrame):
             name (str): name of the node (Node.frame['name']).
 
         Returns:
-            (node): Hatchet Node object
+            (Node or list(Node)): Node object with the given name or list of Node objects
+            with the given name.
         """
         node = [n for n in self.graph.traverse() if n.frame["name"] == name]
 
-        if len(node) > 1:
-            warnings.warn(f'More than one node with name "{name}". Returning a list')
-            return node
-        elif len(node) == 0:
+        if len(node) == 0:
             raise KeyError(f'Node with name "{name}" not found.')
 
-        return node[0]
+        return node[0] if len(node) == 1 else node
 
     def _sync_profile_components(self, component):
         """Synchronize the Performance DataFrame, Metadata Dataframe, profile and

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1560,6 +1560,8 @@ class Thicket(GraphFrame):
         if len(node) > 1:
             warnings.warn(f'More than one node with name "{name}". Returning a list')
             return node
+        elif len(node) == 0:
+            raise ValueError(f'Node with name "{name}" not found.')
 
         return node[0]
 

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -15,10 +15,10 @@ from hashlib import md5
 
 import pandas as pd
 import numpy as np
+import hatchet.node
 from hatchet import (
     frame,
     GraphFrame,
-    node,
 )
 from hatchet.graph import Graph
 from hatchet.query import QueryEngine
@@ -1526,7 +1526,9 @@ class Thicket(GraphFrame):
             node.frame.
         """
 
-        new_node = node.Node(frame_obj=frame.Frame(attrs=attrs), hnid=len(self.graph))
+        new_node = hatchet.node.Node(
+            frame_obj=frame.Frame(attrs=attrs), hnid=len(self.graph)
+        )
 
         # graph and statsframe.graph
         self.graph.roots.append(new_node)

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1529,9 +1529,7 @@ class Thicket(GraphFrame):
         # graph and statsframe.graph
         self.graph.roots.append(new_node)
 
-        # Set depth
-        self.graph.enumerate_depth()
-        # Set hatchet nid
+        # Set hatchet nid and depth
         self.graph.enumerate_traverse()
 
         # dataframe


### PR DESCRIPTION
Examples of `add_root_node` and `get_node` can be found in the notebook in [thicket-tutorial/48](https://github.com/LLNL/thicket-tutorial/blob/parallel-sorting/notebooks/08A_composing_parallel_sorting_data.ipynb)

`add_root_node` enables adding a root node to the `Thicket.graph` and corresponding `Thicket.statsframe` and `Thicket.dataframe` objects.

`get_node` provides a simpler interface for grabbing a node object by its name in the Thicket instead of using something like `[n for n in self.graph.traverse() if n.frame["name"] == name][0]`. This function is optional for this PR or could be its own PR; I am proposing it here.