### PR TITLE
Fix intersection

### DIFF
--- a/thicket/tests/test_intersection.py
+++ b/thicket/tests/test_intersection.py
@@ -20,12 +20,9 @@ def test_intersection(rajaperf_cali_1trial):
     assert len(intersected_tk.graph) == len(intersected_tk_other.graph)
 
     # Check original and intersected thickets
-    assert len(tk.dataframe) == 444
-    assert len(intersected_tk.dataframe) == 384
+    assert len(intersected_tk.graph) < len(tk.graph)
+    assert len(intersected_tk_other.graph) < len(tk.graph)
 
     # Check that nodes are synced between graph and dataframe
     assert helpers._are_synced(tk.graph, tk.dataframe)
     assert helpers._are_synced(intersected_tk.graph, intersected_tk.dataframe)
-
-    # Check graph length
-    assert len(intersected_tk.graph) < len(tk.graph)

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1126,10 +1126,16 @@ class Thicket(GraphFrame):
             (thicket): intersected thicket
         """
 
-        # Row that didn't exist will contain "None" in the name column.
-        query = Query().match(
-            ".", lambda row: row["name"].apply(lambda n: n is not None).all()
-        )
+        # Check for padded perfdata
+        if self.dataframe["name"].isnull().any():
+            # Row that didn't exist will contain "None" in the name column.
+            query = Query().match(
+                ".", lambda df: df["name"].apply(lambda n: n is not None).all()
+            )
+        else:
+            # If perfdata not padded
+            query = Query().match(".", lambda df: len(df) == len(self.profile))
+
         intersected_th = self.query(query)
 
         return intersected_th


### PR DESCRIPTION
### Fix the intersection function when Thicket was created using `_fill_perfdata=False`.

Add separate query for when the perfdata **is not padded** as checking the name column for `None` values will not work. Additionally, the new query that checks the length of per-node slices of the perfdata will not work when the perfdata **is padded**, so both queries are necessary.