### PR TITLE
Fix Bug in add_ncu

### DIFF
--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -590,15 +590,6 @@ class Thicket(GraphFrame):
             warnings.warn(f"Removing duplicate metrics in chosen_metrics: {dupe_mets}")
         chosen_metrics = unique_metrics
 
-        # Check if chosen_metrics are in the dataframe
-        dupe_cols = [col for col in chosen_metrics if col in self.dataframe.columns]
-        if overwrite:
-            self.dataframe = self.dataframe.drop(columns=dupe_cols)
-        elif not overwrite and len(dupe_cols) > 0:
-            raise ValueError(
-                f"Columns {dupe_cols} already exist in the performance data table. Set overwrite=True to overwrite."
-            )
-
         # Initialize reader
         ncureader = NCUReader()
 
@@ -621,6 +612,15 @@ class Thicket(GraphFrame):
         # Apply chosen metrics
         if chosen_metrics:
             ncu_df = ncu_df[chosen_metrics]
+
+        # Overwrite check
+        dupe_cols = [col for col in ncu_df.columns if col in self.dataframe.columns]
+        if overwrite:
+            self.dataframe = self.dataframe.drop(columns=dupe_cols)
+        elif not overwrite and len(dupe_cols) > 0:
+            raise ValueError(
+                f"Columns {dupe_cols} already exist in the performance data table. Set overwrite=True to overwrite."
+            )
 
         # Join NCU DataFrame into Thicket
         self.dataframe = self.dataframe.join(

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -562,7 +562,7 @@ class Thicket(GraphFrame):
 
         Arguments:
             ncu_report_mapping (dict): mapping from NCU report file to profile
-            chosen_metrics (list): list of metrics to sub-select from NCU report
+            chosen_metrics (list): list of metrics to sub-select from NCU report. By default, all metrics are used.
             overwrite (bool): whether to overwrite existing columns in the Thicket.DataFrame
         """
 
@@ -579,19 +579,26 @@ class Thicket(GraphFrame):
             else:
                 return col[0]
 
-        if not isinstance(chosen_metrics, list):
-            raise TypeError(f"chosen_metrics ({type(chosen_metrics)}) must be a list")
-
-        # Remove duplicate metrics in chosen_metrics if the user provided duplicates
-        unique_metrics = list(set(chosen_metrics))
-        if len(unique_metrics) != len(chosen_metrics):
-            dupe_mets = [
-                met
-                for met, count in collections.Counter(chosen_metrics).items()
-                if count > 1
-            ]
-            warnings.warn(f"Removing duplicate metrics in chosen_metrics: {dupe_mets}")
-        chosen_metrics = unique_metrics
+        # If list, check for duplicate metrics
+        if isinstance(chosen_metrics, list):
+            # Remove duplicate metrics in chosen_metrics if the user provided duplicates
+            unique_metrics = list(set(chosen_metrics))
+            if len(unique_metrics) != len(chosen_metrics):
+                dupe_mets = [
+                    met
+                    for met, count in collections.Counter(chosen_metrics).items()
+                    if count > 1
+                ]
+                warnings.warn(
+                    f"Removing duplicate metrics in chosen_metrics: {dupe_mets}"
+                )
+            chosen_metrics = unique_metrics
+        elif chosen_metrics is None:
+            pass
+        else:
+            raise TypeError(
+                f"If provided, chosen_metrics ({type(chosen_metrics)}) must be a list"
+            )
 
         # Initialize reader
         ncureader = NCUReader()

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -623,7 +623,7 @@ class Thicket(GraphFrame):
         if chosen_metrics:
             ncu_df = ncu_df[chosen_metrics]
 
-        # Overwrite check
+        # Overwrite check. We can't check earlier, if chosen_metrics is None, as we haven't read the ncu file yet.
         dupe_cols = [col for col in ncu_df.columns if col in self.dataframe.columns]
         if overwrite:
             self.dataframe = self.dataframe.drop(columns=dupe_cols)

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -579,6 +579,9 @@ class Thicket(GraphFrame):
             else:
                 return col[0]
 
+        if not isinstance(chosen_metrics, list):
+            raise TypeError(f"chosen_metrics ({type(chosen_metrics)}) must be a list")
+
         # Remove duplicate metrics in chosen_metrics if the user provided duplicates
         unique_metrics = list(set(chosen_metrics))
         if len(unique_metrics) != len(chosen_metrics):


### PR DESCRIPTION
#178 Introduced a bug when `chosen_metrics` was not provided. When `chosen_metrics=None` all ncu metrics are added to the perf dataframe. This PR fixes the bug by modifying the check and moving it, where we can check for duplicate columns when `chosen_metrics=None` aswell.

- Check type of `chosen_metrics` before reading NCU
- Check for duplicate columns after reading NCU, such that if `chosen_metrics` is `None` we will know which metrics are present.