### PR TITLE
Fix Indexing Issue in Tree for MultiIndex

### DIFF
--- a/thicket/external/console.py
+++ b/thicket/external/console.py
@@ -258,10 +258,7 @@ class ThicketRenderer(ConsoleRenderer):
                 else:
                     metric_str += " [{}]".format(annotation_content)
 
-            if isinstance(dataframe.columns, pd.MultiIndex):
-                node_name = dataframe.loc[df_index, (self.name, "")]
-            else:
-                node_name = dataframe.loc[df_index, self.name]
+            node_name = dataframe.loc[df_index, self.name]
             if self.expand is False:
                 if len(node_name) > 39:
                     node_name = (

--- a/thicket/tests/test_tree.py
+++ b/thicket/tests/test_tree.py
@@ -42,3 +42,15 @@ def test_indices(rajaperf_unique_tunings):
         match=r"The indices, \{\'tuning\': \'hi\'\}, do not exist in the index \'self.dataframe.index\'",
     ):
         tk.tree(metric_column="Avg time/rank", indices=["Base_Seq", "hi"])
+
+
+def test_tree_column_multiindex(thicket_axis_columns):
+    _, _, combined_th = thicket_axis_columns
+
+    # No error
+    combined_th.tree(
+        metric_column=("block_128", "Avg time/rank"), name_column=("name", "")
+    )
+
+    # No error
+    combined_th.tree(metric_column=("block_128", "Avg time/rank"))

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -901,6 +901,9 @@ class Thicket(GraphFrame):
         if metric_column is None:
             metric_column = self.default_metric
 
+        if name_column == "name" and isinstance(self.dataframe.columns, pd.MultiIndex):
+            name_column = (name_column, "")
+
         if color is False:
             try:
                 import IPython


### PR DESCRIPTION
#181 introduced a bug for MultiIndex columns on this [line](https://github.com/LLNL/thicket/blob/72fca533bc1d3980c9e7865126aeb826bdc58a47/thicket/thicket.py#L955), when trying to index the dataframe. The user can specifying the name column using a tuple or we automatically select the right column when `name_column` is the default argument. This PR also adds a unit test for this case so we can tell if another change breaks MultiIndex printing.