### PR TITLE
Adds function that moves perf metric to statsframe

### DIFF
--- a/thicket/tests/test_thicket.py
+++ b/thicket/tests/test_thicket.py
@@ -108,18 +108,18 @@ def test_perfdata_column_to_statsframe(literal_thickets, mpi_scaling_cali):
     th_single = literal_thickets[1].deepcopy()
 
     with pytest.raises(KeyError):
-        th_single.move_metrics_to_statsframe("dummy")
+        th_single.move_metrics_to_statsframe(["dummy"])
 
-    th_single.move_metrics_to_statsframe("time")
+    th_single.move_metrics_to_statsframe(["time"])
     assert all(
         th_single.dataframe["time"].values
         == th_single.statsframe.dataframe["time"].values
     )
 
     with pytest.raises(KeyError):
-        th_single.move_metrics_to_statsframe("time")
+        th_single.move_metrics_to_statsframe(["time"])
 
-    th_single.move_metrics_to_statsframe("time", "memory", override=True)
+    th_single.move_metrics_to_statsframe(["time", "memory"], override=True)
     assert all(
         th_single.dataframe["time"].values
         == th_single.statsframe.dataframe["time"].values
@@ -134,9 +134,9 @@ def test_perfdata_column_to_statsframe(literal_thickets, mpi_scaling_cali):
     idx = pd.IndexSlice
 
     with pytest.raises(ValueError):
-        th_mpi.move_metrics_to_statsframe(*metrics, profile="fake")
+        th_mpi.move_metrics_to_statsframe(metrics, profile="fake")
 
-    th_mpi.move_metrics_to_statsframe(*metrics, profile=th_mpi.profile[0])
+    th_mpi.move_metrics_to_statsframe(metrics, profile=th_mpi.profile[0])
     for met in metrics:
         assert all(
             th_mpi.dataframe.loc[idx[:, th_mpi.profile[0]], :][met].values

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1477,7 +1477,9 @@ class Thicket(GraphFrame):
 
         return new_thicket
 
-    def move_metrics_to_statsframe(self, *metric_columns, profile=None, override=False):
+    def move_metrics_to_statsframe(self, metric_columns, profile=None, override=False):
+        if not isinstance(metric_columns, (list, tuple)):
+            raise TypeError("'metric_columns' must be a list or tuple")
         profile_list = self.dataframe.index.unique(level="profile").tolist()
         if profile is None and len(profile_list) != 1:
             raise ValueError(

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1483,7 +1483,7 @@ class Thicket(GraphFrame):
             raise ValueError(
                 "Cannot move a metric to statsframe when there are multiple profiles. Set the 'profile' argument to the profile you want to move"
             )
-        if profile not in profile_list:
+        if profile is not None and profile not in profile_list:
             raise ValueError("Invalid profile: {}".format(profile))
         df_for_profile = None
         if profile is None:


### PR DESCRIPTION
This PR adds a new `Thicket.move_metrics_to_statsframe` function that moves a metric column from the performance dataframe to the statsframe.

This function takes the names of the metrics to move as positional arguments. It also has two optional keyword arguments:
* `profile`: sets the specific profile for which data should be moved to the statsframe. By default, this argument is `None`, which will cause the function to assume that there is only one profile in the `Thicket` object
* `override`: if True, replace columns in the statsframe if their names match the names in the performance data