### PR TITLE
Adds several new features to display_boxplot

### DIFF
--- a/thicket/stats/display_boxplot.py
+++ b/thicket/stats/display_boxplot.py
@@ -131,5 +131,5 @@ def display_boxplot(thicket, nodes=None, columns=None, column_mapping=None, lege
         )
     else:
         return sns.catplot(
-            data=filtered_df, x="node", y=" ", **mod_kargs
+            data=filtered_df, x="node", y=" ", **mod_kwargs
         )

--- a/thicket/stats/display_boxplot.py
+++ b/thicket/stats/display_boxplot.py
@@ -131,5 +131,5 @@ def display_boxplot(thicket, nodes=None, columns=None, column_mapping=None, lege
         )
     else:
         return sns.catplot(
-            data=filtered_df, x="node", y=" ", **mod_kwargs
+            data=filtered_df, x="node", y=" ", kind="box", **mod_kwargs
         )


### PR DESCRIPTION
This PR adds the following new, optional arguments and corresponding features to `thicket.stats.display_boxplot`:
* `column_mapping` (default: `None`): renames the columns specified in the `columns` argument using the provided dictionary
* `legend_title` (default: `"Performance counter"`): changes the title of the legend to the specified string
* `return_mpl` (default: `True`): if `True`, `display_boxplot` returns a `matplotlib.pyplot.Axes` object. If `False`, `display_boxplot` returns a `seaborn.FacetGrid` object, which gives users more control over the design of their plot at the cost of a more complicated API