### PR TITLE
Check And Remove Duplicates in chosen_metrics

### DIFF
--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import collections
 import copy
 import os
 import pickle
@@ -571,6 +572,13 @@ class Thicket(GraphFrame):
                 return agg_func(col)
             else:
                 return col[0]
+
+        # Remove duplicate metrics in chosen_metrics if the user provided duplicates
+        unique_metrics = list(set(chosen_metrics))
+        if len(unique_metrics) != len(chosen_metrics):
+            dupe_mets = [met for met, count in collections.Counter(chosen_metrics).items() if count > 1]
+            warnings.warn(f"Removing duplicate metrics in chosen_metrics: {dupe_mets}")
+        chosen_metrics = unique_metrics
 
         # Check if chosen_metrics are in the dataframe
         dupe_cols = [col for col in chosen_metrics if col in self.dataframe.columns]

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -576,7 +576,11 @@ class Thicket(GraphFrame):
         # Remove duplicate metrics in chosen_metrics if the user provided duplicates
         unique_metrics = list(set(chosen_metrics))
         if len(unique_metrics) != len(chosen_metrics):
-            dupe_mets = [met for met, count in collections.Counter(chosen_metrics).items() if count > 1]
+            dupe_mets = [
+                met
+                for met, count in collections.Counter(chosen_metrics).items()
+                if count > 1
+            ]
             warnings.warn(f"Removing duplicate metrics in chosen_metrics: {dupe_mets}")
         chosen_metrics = unique_metrics
 


### PR DESCRIPTION
@Yejashi Found a case where trying to add the same metric twice causes a bug.

Ex:
```
ncu_metrics = [
    "gpu__time_duration.sum",
    "gpu__time_duration.sum",
    "sm__throughput.avg.pct_of_peak_sustained_elapsed",
    "smsp__maximum_warps_avg_per_active_cycle",
    "smsp__maximum_warps_avg_per_active_cycle",
    "smsp__maximum_warps_avg_per_active_cycle",
]
```

is correctly handled now and prints a warning:
```
UserWarning: Removing duplicate metrics in chosen_metrics: ['gpu__time_duration.sum', 'smsp__maximum_warps_avg_per_active_cycle']
```

This is different from the functionality that checks if metrics in `chosen_metrics` are already in the performance data.