### PR TITLE
Use Kwargs in from_caliperreader for RAJAPerf Complexities

### DIFF
--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -278,6 +278,7 @@ class Thicket(GraphFrame):
         intersection=False,
         fill_perfdata=True,
         disable_tqdm=False,
+        **kwargs,
     ):
         """Helper function to read one caliper file.
 
@@ -294,6 +295,7 @@ class Thicket(GraphFrame):
             fill_perfdata,
             disable_tqdm,
             filename_or_caliperreader,
+            **kwargs,
         )
 
     @staticmethod


### PR DESCRIPTION
Working on RAJAPerf#471, I realized the `string_attributes` argument in `GraphFrame.from_caliperreader` was not accessible from the Thicket reader. This allows the user to do `th.Thicket.from_caliperreader(file, string_attributes=[...])` in Thicket.

Edit: This is for reading complexity information from RAJAPerf runs.