### PR TITLE
Statsframe Cache Pickle Serialization Fix

### DIFF
--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -219,6 +219,10 @@ class Thicket(GraphFrame):
 
     def to_pickle(self, filename, **kwargs):
         """Write a Thicket to a pickle file."""
+
+        # Clear out statsframe to ensure thicket obj is serializable
+        self.statsframe_ops_cache = {}
+
         pickle.dump(self, open(filename, "wb"), **kwargs)
 
     @staticmethod


### PR DESCRIPTION
This pr resolves a serialization issue caused by the `statsframe_ops_cache`.

The error is presented as follows:
```python
PicklingError: Can't pickle <function mean at 0x7fff9e7c7920>: it's not the same object as thicket.stats.mean.mean
```

The current fix it to reset the cache at every `to_pickle` call.