### PR TITLE
Adds a page to the documentation for publications

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,6 @@ If you are new to thicket and want to start using it, see :doc:`Getting Started
    getting_started
    user_guide
    generating_data
-   publications
 
 If you encounter bugs while using thicket, you can report them by opening an issue on
 `GitHub <http://github.com/llnl/thicket/issues>`_.
@@ -60,6 +59,12 @@ If you encounter bugs while using thicket, you can report them by opening an iss
    query_language.ipynb
    groupby_aggregate.ipynb
    vis_docs
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference
+
+   publications
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ If you are new to thicket and want to start using it, see :doc:`Getting Started
    getting_started
    user_guide
    generating_data
+   publications
 
 If you encounter bugs while using thicket, you can report them by opening an issue on
 `GitHub <http://github.com/llnl/thicket/issues>`_.

--- a/docs/publications.rst
+++ b/docs/publications.rst
@@ -26,3 +26,12 @@ Tutorials
 - HPCIC Tutorials: Caliper, Hatchet, and Thicket. Virtual. August 8, 2024. `YouTube <https://youtu.be/qVmxDOxM9Ws?si=CL6MjN0mvQcivVXA>`_
 
 - RADIUSS AWS Tutorials: Caliper, Hatchet, and Thicket. Virtual. August 14, 2023. `YouTube <https://youtu.be/_Ch4pik5QCs?si=HCd8D4oJlyiSvzg1>`_
+
+Presentations
+==========
+
+- Scalable Tools Workshop: Thicket: Growth of the Heterogeneous Performance Experiment Forest. August 12, 2024. `Slides <https://dyninst.github.io/scalable_tools_workshop/petascale2024/assets/slides/2024_08_12_Thicket_ScalableTools.pdf>`_
+
+- Scalable Tools Workshop: Programmatic Analysis of Large-Scale Performance Data. August, 12, 2024. `Slides <https://dyninst.github.io/scalable_tools_workshop/petascale2024/assets/slides/STW-2024-Grbic.pdf>`_
+
+- Scalable Tools Workshop: Thicket: Seeing the Performance Experiment Forest for the Individual Run Trees. June 20, 2023. `Slides <https://dyninst.github.io/scalable_tools_workshop/petascale2023/assets/slides/2023_06_20_Thicket_ScalableTools.pdf>`_

--- a/docs/publications.rst
+++ b/docs/publications.rst
@@ -16,6 +16,8 @@ Posters
 
 - Befikir Bogale. Cluster-based Methodology for Characterizing the Performance of Portable Applications. Presented at SC '24.
 
+- Dewi Yokelson, David Boehme, Stephanie Brink, Olga Pearce, Allen Malony. Timeseries Visualization of Performance Metrics. Presented at ISC '24.
+
 - Ian Lumsden, Jakob Luettgau, Vanessa Lama, Connor Scully-Allison, Stephanie Brink, Katherine E. Issacs, Olga Pearce, Michela Taufer. Identifying Performance Bottlenecks in Scientific Applications with Call Path Querying. Presented at the 2023 Salishan Conference.
 
 Tutorials

--- a/docs/publications.rst
+++ b/docs/publications.rst
@@ -1,0 +1,26 @@
+******************************
+Publications and Presentations
+******************************
+
+Publications
+============
+
+- Olga Pearce, Jason Burmark, Rich Hornung, Befikir Bogale, Ian Lumsden, Michael McKinsey, Dewi Yokelson, David Boehme, Stephanie Brink, Michela Taufer, Tom Scogland. RAJA Performance Suite: Performance Portability Analysis with Caliper and Thicket. In Proceedings of the SC'24 Workshops of the International Conference on High Performance Computing, Network, Storage, and Analysis (SC-W '24), Atlanta, GA.
+
+- Stephanie Brink, Michael McKinsey, David Boehme, Connor Scully-Allison, Ian Lumsden, Daryl Hawkins, Treece Burrgess, Vanessa Lama, Jakob Luettgau, Katherine E. Issacs, Michela Taufer, Olga Pearce. Thicket: Seeing the Performance Experiment Forest for the Individual Run Trees. In Proceedings of the 32nd International Symposium on High-Performance Parallel and Distributed Computing (HPDC '23), Orlando, FL.
+
+Posters
+=======
+
+- Dragana Gbric. Integrating HPCToolkit with Tools for Automated Analysis. Presented at SC '24. Best Poster Candidate.
+
+- Befikir Bogale. Cluster-based Methodology for Characterizing the Performance of Portable Applications. Presented at SC '24.
+
+- Ian Lumsden, Jakob Luettgau, Vanessa Lama, Connor Scully-Allison, Stephanie Brink, Katherine E. Issacs, Olga Pearce, Michela Taufer. Identifying Performance Bottlenecks in Scientific Applications with Call Path Querying. Presented at the 2023 Salishan Conference.
+
+Tutorials
+=========
+
+- HPCIC Tutorials: Caliper, Hatchet, and Thicket. Virtual. August 8, 2024. `YouTube <https://youtu.be/qVmxDOxM9Ws?si=CL6MjN0mvQcivVXA>`_
+
+- RADIUSS AWS Tutorials: Caliper, Hatchet, and Thicket. Virtual. August 14, 2023. `YouTube <https://youtu.be/_Ch4pik5QCs?si=HCd8D4oJlyiSvzg1>`_

--- a/docs/publications.rst
+++ b/docs/publications.rst
@@ -12,7 +12,7 @@ Publications
 Posters
 =======
 
-- Dragana Gbric. Integrating HPCToolkit with Tools for Automated Analysis. Presented at SC '24. Best Poster Candidate.
+- Dragana Grbic. Integrating HPCToolkit with Tools for Automated Analysis. Presented at SC '24. Best Poster Candidate.
 
 - Befikir Bogale. Cluster-based Methodology for Characterizing the Performance of Portable Applications. Presented at SC '24.
 
@@ -28,7 +28,7 @@ Tutorials
 - RADIUSS AWS Tutorials: Caliper, Hatchet, and Thicket. Virtual. August 14, 2023. `YouTube <https://youtu.be/_Ch4pik5QCs?si=HCd8D4oJlyiSvzg1>`_
 
 Presentations
-==========
+=============
 
 - Scalable Tools Workshop: Thicket: Growth of the Heterogeneous Performance Experiment Forest. August 12, 2024. `Slides <https://dyninst.github.io/scalable_tools_workshop/petascale2024/assets/slides/2024_08_12_Thicket_ScalableTools.pdf>`_
 


### PR DESCRIPTION
While working on gathering materials for SC, I realized that we don't have a page in our docs for publications and presentations. This PR adds that page with our current publications/presentations.

For now this PR is work-in-progress so other people can suggest or add other publications/presentations that I may be missing.