### PR TITLE
Adds CI to run unit tests against Pandas 3.0

### DIFF
--- a/.github/workflows/test-for-pandas-3.yml
+++ b/.github/workflows/test-for-pandas-3.yml
@@ -1,9 +1,10 @@
 name: Run unit tests with Pandas 3.0
 
 on: 
-  pull_request_target:
   push:
     branches: [ develop ]
+  pull_request:
+    branches: [ develop, releases/** ]
 
 jobs:
   run_pandas_3_unit_tests:
@@ -51,13 +52,23 @@ jobs:
             echo "optional_fail_status=${status}" >> "${GITHUB_OUTPUT}"
         fi
         exit 0
+    
+    - name: Find issue comment
+      if: github.event_name == 'push'
+      uses: peter-evans/find-comment@v3
+      id: find_comment
+      with:
+        issue-number: 221
+        comment-author: 'github-actions[bot]'
+        body-includes: Pandas 3.0 Unit Tests
 
     - name: Add comment to PR if test failed
-      if: ${{ steps.test.outputs.optional_fail == 'true' }}
-      uses: thollander/actions-comment-pull-request@v3
+      if: github.event_name == 'push' && steps.test.outputs.optional_fail == 'true'
+      uses: peter-evans/create-or-update-comment@v4
       with:
-        comment-tag: "pandas-3.0-test-notice"
-        message: |
+        comment-id: ${{ steps.find_comment.outputs.comment-id }}
+        issue-number: 221
+        body: |
           ### Pandas 3.0 Unit Tests Failed!
           Due to breaking changes in Pandas 3.0 (namely, copy-on-write), we are performing optional
           tests of Thicket against the nightly release of Pandas 3.0.
@@ -68,19 +79,18 @@ jobs:
           
           Pytest status code: ${{ steps.test.outputs.optional_fail_status }}
           Action log: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        mode: 'upsert'
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        edit-mode: 'replace'
 
     - name: Add comment to PR if test passed
-      if: ${{ steps.test.outputs.optional_fail == 'false' }}
-      uses: thollander/actions-comment-pull-request@v3
+      if: github.event_name == 'push' && steps.test.outputs.optional_fail == 'false'
+      uses: peter-evans/create-or-update-comment@v4
       with:
-        comment-tag: "pandas-3.0-test-notice"
-        message: |
+        comment-id: ${{ steps.find_comment.outputs.comment-id }}
+        issue-number: 221
+        body: |
           ### Pandas 3.0 Unit Tests Passed!
           Due to breaking changes in Pandas 3.0 (namely, copy-on-write), we are performing optional
           tests of Thicket against the nightly release of Pandas 3.0.
 
           This PR passed unit tests when run with Pandas 3.0!
-        mode: 'upsert'
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        edit-mode: 'replace'

--- a/.github/workflows/test-for-pandas-3.yml
+++ b/.github/workflows/test-for-pandas-3.yml
@@ -1,0 +1,82 @@
+name: Run unit tests with Pandas 3.0
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop, releases/** ]
+
+jobs:
+  run_pandas_3_unit_tests:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python 3.11 
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11 
+    
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: node
+    
+    - name: Install Pandas 3.0 (i.e., Nightly)
+      run: |
+        python3 -m pip install --upgrade pip pytest
+        python3 -m pip install --upgrade --force-reinstall --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
+    
+    - name: Install Python 3 dependencies
+      run: | 
+        python3 -m pip install --upgrade --force-reinstall git+https://github.com/LLNL/hatchet.git@develop
+        python3 -m pip install -r requirements.txt
+        python3 -m pip install .
+        python3 -m pip list
+    
+    # From here on, I'm making use of the trick from the following
+    # GitHub repo to not fail the full CI/CD pipeline if this fails:
+    # https://github.com/burningmantech/ranger-ims-server/pull/1347/files
+    - name: Basic test with PyTest
+      id: test
+      run: |
+        PYTHONPATH . $(which pytest)
+        status=$?
+        if [ $status -ne 0 ]; then
+            echo "::warning::Optional CI test with Pandas 3 failed"
+            echo "optional_fail=true" >> "${GITHUB_OUTPUT}"
+            echo "optional_fail_status=${status}" >> "${GITHUB_OUTPUT}"
+        fi
+        exit 0
+
+    - name: Add comment to PR if test failed
+      if: ${{ steps.test.outputs.optional_fail == 'true' }}
+      uses: thollander/actions-comment-pull-request@v3
+      with:
+        comment-tag: "pandas-3.0-test-notice"
+        message: |
+          ### Pandas 3.0 Unit Tests Failed!
+          Due to breaking changes in Pandas 3.0 (namely, copy-on-write), we are performing optional
+          tests of Thicket against the nightly release of Pandas 3.0.
+
+          This is not a full testing failure, and it will not prevent your PR from being merged
+          at this time. However, as we prepare for the release of Pandas 3.0, we encourage
+          all developers to design their code to work with Pandas 3.0, if possible.
+          
+          Pytest status code: ${{ steps.test.outputs.optional_fail_status }}
+        mode: 'upsert'
+
+    - name: Add comment to PR if test passed
+      if: ${{ steps.test.outputs.optional_fail == 'false' }}
+      uses: thollander/actions-comment-pull-request@v3
+      with:
+        comment-tag: "pandas-3.0-test-notice"
+        message: |
+          ### Pandas 3.0 Unit Tests Passed!
+          Due to breaking changes in Pandas 3.0 (namely, copy-on-write), we are performing optional
+          tests of Thicket against the nightly release of Pandas 3.0.
+
+          This PR passed unit tests when run with Pandas 3.0!
+        mode: 'upsert'

--- a/.github/workflows/test-for-pandas-3.yml
+++ b/.github/workflows/test-for-pandas-3.yml
@@ -1,10 +1,9 @@
 name: Run unit tests with Pandas 3.0
 
-on:
+on: 
+  pull_request_target:
   push:
     branches: [ develop ]
-  pull_request:
-    branches: [ develop, releases/** ]
 
 jobs:
   run_pandas_3_unit_tests:
@@ -27,11 +26,12 @@ jobs:
     - name: Install Pandas 3.0 (i.e., Nightly)
       run: |
         python3 -m pip install --upgrade pip pytest
-        python3 -m pip install --upgrade --force-reinstall --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
+        python3 -m pip install --upgrade --force-reinstall --pre --extra-index \
+            https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas[pyarrow]
     
     - name: Install Python 3 dependencies
       run: | 
-        python3 -m pip install --upgrade --force-reinstall git+https://github.com/LLNL/hatchet.git@develop
+        python3 -m pip install git+https://github.com/LLNL/hatchet.git@develop
         python3 -m pip install -r requirements.txt
         python3 -m pip install .
         python3 -m pip list
@@ -42,9 +42,10 @@ jobs:
     - name: Basic test with PyTest
       id: test
       run: |
-        PYTHONPATH . $(which pytest)
+        set +e  # Prevent immediate exit if pytest reports errors
+        PYTHONPATH=. $(which pytest)
         status=$?
-        if [ $status -ne 0 ]; then
+        if [ ${status} -ne 0 ]; then
             echo "::warning::Optional CI test with Pandas 3 failed"
             echo "optional_fail=true" >> "${GITHUB_OUTPUT}"
             echo "optional_fail_status=${status}" >> "${GITHUB_OUTPUT}"
@@ -66,7 +67,9 @@ jobs:
           all developers to design their code to work with Pandas 3.0, if possible.
           
           Pytest status code: ${{ steps.test.outputs.optional_fail_status }}
+          Action log: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         mode: 'upsert'
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Add comment to PR if test passed
       if: ${{ steps.test.outputs.optional_fail == 'false' }}
@@ -80,3 +83,4 @@ jobs:
 
           This PR passed unit tests when run with Pandas 3.0!
         mode: 'upsert'
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-for-pandas-3.yml
+++ b/.github/workflows/test-for-pandas-3.yml
@@ -47,9 +47,16 @@ jobs:
         PYTHONPATH=. $(which pytest)
         status=$?
         if [ ${status} -ne 0 ]; then
+            echo "=================================="
+            echo "Unit tests with Pandas 3.0 FAILED!"
+            echo "=================================="
             echo "::warning::Optional CI test with Pandas 3 failed"
             echo "optional_fail=true" >> "${GITHUB_OUTPUT}"
             echo "optional_fail_status=${status}" >> "${GITHUB_OUTPUT}"
+        else
+            echo "=================================="
+            echo "Unit tests with Pandas 3.0 PASSED!"
+            echo "=================================="
         fi
         exit 0
     


### PR DESCRIPTION
Pandas 3.0 is (supposedly) going to release pretty soon, and it will bring several breaking changes with it. Most notably, Pandas copy-on-write performance optimization (introduced in Pandas 1.5 and completed in Pandas 2.1) will become the default execution mode, and Pandas eager execution mode (i.e., the default since Pandas' first release) will be removed.

To help us get a head start on supporting Pandas 3.0, this PR adds a new GitHub Action that will install Thicket with Pandas 3.0 and run our unit tests. Unlike the standard CI, a failure of this new Action should **not** caused the overall status of the PR to be marked as a fail (i.e., the red X you see in the Pull Requests tab). It should also create and/or update a comment on the status of Pandas 3.0 support.