### PR TITLE
Re-exports QueryMatcher from __init__.py to be consistant with Hatchet

### DIFF
--- a/thicket/__init__.py
+++ b/thicket/__init__.py
@@ -16,6 +16,7 @@ from . import (
 )
 
 from .ensemble import Ensemble
+from .query import QueryMatcher
 from .thicket import Thicket
 from .thicket import InvalidFilter
 from .thicket import EmptyMetadataTable


### PR DESCRIPTION
Just what the title says. Hatchet re-exports `QueryMatcher` from the top-level `__init__.py`, so this PR makes Thicket do the same.