### PR TITLE
Unicode Histogram in Tree

### DIFF
--- a/thicket/external/console.py
+++ b/thicket/external/console.py
@@ -283,7 +283,9 @@ class ThicketRenderer(ConsoleRenderer):
                 # Add min/max to tree
                 min_num = hist_data.min()
                 max_num = hist_data.max()
-                result += f" ({min_num:.{self.precision}f}, {max_num:.{self.precision}f}) "
+                result += (
+                    f" ({min_num:.{self.precision}f}, {max_num:.{self.precision}f}) "
+                )
                 # Define unicode bars
                 bar_list = [
                     "_",

--- a/thicket/external/console.py
+++ b/thicket/external/console.py
@@ -312,7 +312,7 @@ class ThicketRenderer(ConsoleRenderer):
                     # Add histogram to tree
                     for idx in normalized_hist.values:
                         result += bar_list[idx]
-                except:
+                except pd.errors.IntCastingNaNError:  # NA or inf cannot be binned
                     pass
 
             if self.context in dataframe.columns:

--- a/thicket/external/console.py
+++ b/thicket/external/console.py
@@ -298,21 +298,23 @@ class ThicketRenderer(ConsoleRenderer):
                     "\u2587",
                     "\u2588",
                 ]
-                # Compute histogram intervals using pandas binning
-                binned = pd.cut(hist_data, bins=nintervals)
-                hist = binned.value_counts().sort_index()
-                # Normalize values to the number of bars
-                normalized_hist = (
-                    (len(bar_list) - 1)
-                    * (hist - hist.min())
-                    / (hist.max() - hist.min())
-                )
                 try:
+                    # Compute histogram intervals using pandas binning
+                    binned = pd.cut(hist_data, bins=nintervals)
+                    hist = binned.value_counts().sort_index()
+                    # Normalize values to the number of bars
+                    normalized_hist = (
+                        (len(bar_list) - 1)
+                        * (hist - hist.min())
+                        / (hist.max() - hist.min())
+                    )
                     normalized_hist = normalized_hist.apply(np.ceil).astype(int)
                     # Add histogram to tree
                     for idx in normalized_hist.values:
                         result += bar_list[idx]
-                except pd.errors.IntCastingNaNError:  # NA or inf cannot be binned
+                except (
+                    ValueError or pd.errors.IntCastingNaNError
+                ):  # NA or inf cannot be binned
                     pass
 
             if self.context in dataframe.columns:

--- a/thicket/external/console.py
+++ b/thicket/external/console.py
@@ -281,9 +281,9 @@ class ThicketRenderer(ConsoleRenderer):
                 # Auto choose num bins
                 nintervals = min(math.ceil(math.sqrt(nprofs)), 20)
                 # Add min/max to tree
-                min = hist_data.min()
-                max = hist_data.max()
-                result += f" ({min:.{self.precision}f}, {max:.{self.precision}f}) "
+                min_num = hist_data.min()
+                max_num = hist_data.max()
+                result += f" ({min_num:.{self.precision}f}, {max_num:.{self.precision}f}) "
                 # Define unicode bars
                 bar_list = [
                     "_",

--- a/thicket/external/console.py
+++ b/thicket/external/console.py
@@ -282,12 +282,24 @@ class ThicketRenderer(ConsoleRenderer):
             max = self.full_df.loc[df_index].max()
             result += f" ({min:.{self.precision}f}, {max:.{self.precision}f})"
             # Define unicode bars
-            bar_list = ["_", "\u2581", "\u2582", "\u2583", "\u2584", "\u2585", "\u2586", "\u2587", "\u2588"]
+            bar_list = [
+                "_",
+                "\u2581",
+                "\u2582",
+                "\u2583",
+                "\u2584",
+                "\u2585",
+                "\u2586",
+                "\u2587",
+                "\u2588",
+            ]
             # Compute histogram intervals using pandas binning
             binned = pd.cut(self.full_df.loc[df_index], bins=nintervals)
             hist = binned.value_counts().sort_index()
             # Normalize values to the number of bars
-            normalized_hist = (len(bar_list) - 1) * (hist - hist.min()) / (hist.max() - hist.min())
+            normalized_hist = (
+                (len(bar_list) - 1) * (hist - hist.min()) / (hist.max() - hist.min())
+            )
             normalized_hist = normalized_hist.apply(np.ceil).astype(int)
             # Add histogram to tree
             for idx in normalized_hist.values:

--- a/thicket/external/console.py
+++ b/thicket/external/console.py
@@ -301,7 +301,9 @@ class ThicketRenderer(ConsoleRenderer):
                 hist = binned.value_counts().sort_index()
                 # Normalize values to the number of bars
                 normalized_hist = (
-                    (len(bar_list) - 1) * (hist - hist.min()) / (hist.max() - hist.min())
+                    (len(bar_list) - 1)
+                    * (hist - hist.min())
+                    / (hist.max() - hist.min())
                 )
                 print(normalized_hist)
                 try:

--- a/thicket/external/console.py
+++ b/thicket/external/console.py
@@ -305,7 +305,6 @@ class ThicketRenderer(ConsoleRenderer):
                     * (hist - hist.min())
                     / (hist.max() - hist.min())
                 )
-                print(normalized_hist)
                 try:
                     normalized_hist = normalized_hist.apply(np.ceil).astype(int)
                     # Add histogram to tree

--- a/thicket/external/console.py
+++ b/thicket/external/console.py
@@ -276,12 +276,13 @@ class ThicketRenderer(ConsoleRenderer):
             )
 
             if self.histogram:
-                nprofs = len(self.hist_data.loc[df_index])
+                hist_data = self.hist_data.loc[df_index]
+                nprofs = len(hist_data)
                 # Auto choose num bins
-                nintervals = math.ceil(math.sqrt(nprofs))
+                nintervals = min(math.ceil(math.sqrt(nprofs)), 20)
                 # Add min/max to tree
-                min = self.hist_data.loc[df_index].min()
-                max = self.hist_data.loc[df_index].max()
+                min = hist_data.min()
+                max = hist_data.max()
                 result += f" ({min:.{self.precision}f}, {max:.{self.precision}f}) "
                 # Define unicode bars
                 bar_list = [
@@ -296,16 +297,20 @@ class ThicketRenderer(ConsoleRenderer):
                     "\u2588",
                 ]
                 # Compute histogram intervals using pandas binning
-                binned = pd.cut(self.hist_data.loc[df_index], bins=nintervals)
+                binned = pd.cut(hist_data, bins=nintervals)
                 hist = binned.value_counts().sort_index()
                 # Normalize values to the number of bars
                 normalized_hist = (
                     (len(bar_list) - 1) * (hist - hist.min()) / (hist.max() - hist.min())
                 )
-                normalized_hist = normalized_hist.apply(np.ceil).astype(int)
-                # Add histogram to tree
-                for idx in normalized_hist.values:
-                    result += bar_list[idx]
+                print(normalized_hist)
+                try:
+                    normalized_hist = normalized_hist.apply(np.ceil).astype(int)
+                    # Add histogram to tree
+                    for idx in normalized_hist.values:
+                        result += bar_list[idx]
+                except:
+                    pass
 
             if self.context in dataframe.columns:
                 result += " {c.faint}{context}{c.end}\n".format(

--- a/thicket/external/console.py
+++ b/thicket/external/console.py
@@ -54,7 +54,8 @@ class ThicketRenderer(ConsoleRenderer):
         self.min_value = kwargs["min_value"]
         self.max_value = kwargs["max_value"]
         self.indices = kwargs["indices"]
-        self.full_df = kwargs["full_df"]
+        self.hist_data = kwargs["hist_data"]
+        self.histogram = kwargs["histogram"]
 
         if self.color:
             self.colors = self.colors_enabled
@@ -274,36 +275,37 @@ class ThicketRenderer(ConsoleRenderer):
                 indent=indent, metric_str=metric_str, name_str=name_str
             )
 
-            nprofs = len(self.full_df.loc[df_index])
-            # Auto choose num bins
-            nintervals = math.ceil(math.sqrt(nprofs))
-            # Add min/max to tree
-            min = self.full_df.loc[df_index].min()
-            max = self.full_df.loc[df_index].max()
-            result += f" ({min:.{self.precision}f}, {max:.{self.precision}f})"
-            # Define unicode bars
-            bar_list = [
-                "_",
-                "\u2581",
-                "\u2582",
-                "\u2583",
-                "\u2584",
-                "\u2585",
-                "\u2586",
-                "\u2587",
-                "\u2588",
-            ]
-            # Compute histogram intervals using pandas binning
-            binned = pd.cut(self.full_df.loc[df_index], bins=nintervals)
-            hist = binned.value_counts().sort_index()
-            # Normalize values to the number of bars
-            normalized_hist = (
-                (len(bar_list) - 1) * (hist - hist.min()) / (hist.max() - hist.min())
-            )
-            normalized_hist = normalized_hist.apply(np.ceil).astype(int)
-            # Add histogram to tree
-            for idx in normalized_hist.values:
-                result += bar_list[idx]
+            if self.histogram:
+                nprofs = len(self.hist_data.loc[df_index])
+                # Auto choose num bins
+                nintervals = math.ceil(math.sqrt(nprofs))
+                # Add min/max to tree
+                min = self.hist_data.loc[df_index].min()
+                max = self.hist_data.loc[df_index].max()
+                result += f" ({min:.{self.precision}f}, {max:.{self.precision}f}) "
+                # Define unicode bars
+                bar_list = [
+                    "_",
+                    "\u2581",
+                    "\u2582",
+                    "\u2583",
+                    "\u2584",
+                    "\u2585",
+                    "\u2586",
+                    "\u2587",
+                    "\u2588",
+                ]
+                # Compute histogram intervals using pandas binning
+                binned = pd.cut(self.hist_data.loc[df_index], bins=nintervals)
+                hist = binned.value_counts().sort_index()
+                # Normalize values to the number of bars
+                normalized_hist = (
+                    (len(bar_list) - 1) * (hist - hist.min()) / (hist.max() - hist.min())
+                )
+                normalized_hist = normalized_hist.apply(np.ceil).astype(int)
+                # Add histogram to tree
+                for idx in normalized_hist.values:
+                    result += bar_list[idx]
 
             if self.context in dataframe.columns:
                 result += " {c.faint}{context}{c.end}\n".format(

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1021,7 +1021,7 @@ class Thicket(GraphFrame):
             min_value (int, optional): Overwrites the min value for the coloring legend. Defaults to None.
             max_value (int, optional): Overwrites the max value for the coloring legend. Defaults to None.
             indices(tuple, list, optional): Index/indices to display on the DataFrame. Defaults to None.
-            histogram (bool, optional): Whether to show a histogram next to each node of the data for all profiles. Defaults to True.
+            histogram (bool, optional): Whether to show a histogram next to each node of the data for all profiles. Defaults to False.
 
         Returns:
             (str): String representation of the tree, ready to print

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -999,6 +999,7 @@ class Thicket(GraphFrame):
         min_value=None,
         max_value=None,
         indices=None,
+        histogram=True,
     ):
         """Visualize the Thicket as a tree
 
@@ -1020,6 +1021,7 @@ class Thicket(GraphFrame):
             min_value (int, optional): Overwrites the min value for the coloring legend. Defaults to None.
             max_value (int, optional): Overwrites the max value for the coloring legend. Defaults to None.
             indices(tuple, list, optional): Index/indices to display on the DataFrame. Defaults to None.
+            histogram (bool, optional): Whether to show a histogram next to each node of the data for all profiles. Defaults to True.
 
         Returns:
             (str): String representation of the tree, ready to print
@@ -1131,7 +1133,8 @@ class Thicket(GraphFrame):
             min_value=min_value,
             max_value=max_value,
             indices=idx_dict,
-            full_df=self.dataframe[metric_column],
+            hist_data=self.dataframe[metric_column],
+            histogram=histogram,
         )
 
     @staticmethod

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -999,7 +999,7 @@ class Thicket(GraphFrame):
         min_value=None,
         max_value=None,
         indices=None,
-        histogram=True,
+        histogram=False,
     ):
         """Visualize the Thicket as a tree
 

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -170,7 +170,6 @@ class Thicket(GraphFrame):
         Returns:
             (int): hash of the object
         """
-
         return int(md5(obj.encode("utf-8")).hexdigest()[:hex_len], 16)
 
     @staticmethod
@@ -1132,6 +1131,7 @@ class Thicket(GraphFrame):
             min_value=min_value,
             max_value=max_value,
             indices=idx_dict,
+            full_df=self.dataframe[metric_column],
         )
 
     @staticmethod


### PR DESCRIPTION
# Summary
Visualize (min, max) values for each node and histogram of profile values using unicode bars. Designed to give user a quick view of data distribution. Number of bars is the square root of the number of profiles for that node.

# Examples
Example for 70 profiles. Notice slight difference vs Matplotlib histogram, since we are limited to 7 bar sizes.

Tree histogram:
![image](https://github.com/user-attachments/assets/604c820b-f467-4bb3-a924-afbbd96c046b)
Equivalent matplotlib histogram:
![image](https://github.com/user-attachments/assets/d20a58dc-0f60-45d6-a256-10df2382f9f0)

