### PR TITLE
Only Print Duplicates in Error Message

### DIFF
--- a/thicket/utils.py
+++ b/thicket/utils.py
@@ -75,7 +75,9 @@ def validate_dataframe(df):
             counts = Counter(inner_idx_values)
             duplicates = [item for item, count in counts.items() if count > 1]
             if len(duplicates) > 0:
-                raise DuplicateIndexError(f"Duplicate indices found in DataFrame index.\n\t{duplicates}")
+                raise DuplicateIndexError(
+                    f"Duplicate indices found in DataFrame index.\n\t{duplicates}"
+                )
 
     def _check_missing_hnid(df):
         """Check if there are missing hatchet nid's."""

--- a/thicket/utils.py
+++ b/thicket/utils.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from collections import OrderedDict, defaultdict
+from collections import Counter, OrderedDict, defaultdict
 import warnings
 
 import numpy as np
@@ -72,11 +72,10 @@ def validate_dataframe(df):
         """Check for duplicate values in the innermost indices."""
         for node in set(df.index.get_level_values("node")):
             inner_idx_values = sorted(df.loc[node].index.tolist())
-            inner_idx_values_set = sorted(list(set(inner_idx_values)))
-            if inner_idx_values != inner_idx_values_set:
-                raise DuplicateIndexError(
-                    f"Duplicate index {set(inner_idx_values)} found in DataFrame index."
-                )
+            counts = Counter(inner_idx_values)
+            duplicates = [item for item, count in counts.items() if count > 1]
+            if len(duplicates) > 0:
+                raise DuplicateIndexError(f"Duplicate indices found in DataFrame index.\n\t{duplicates}")
 
     def _check_missing_hnid(df):
         """Check if there are missing hatchet nid's."""


### PR DESCRIPTION
From the error message in develop, it is hard to tell which index is the duplicate when there are many profiles. In this example the duplicate is `3723623787`.

develop
![Screenshot from 2024-11-11 20-53-17](https://github.com/user-attachments/assets/9db15077-562a-435f-9d34-57a1c259d8a5)

This PR
![Screenshot from 2024-11-11 20-54-44](https://github.com/user-attachments/assets/232f2742-9d74-44a6-be48-48c903d63cf4)
