### PR TITLE
Extend hash length

### DIFF
--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -157,7 +157,7 @@ class Thicket(GraphFrame):
         return s
 
     @staticmethod
-    def profile_hasher(obj, hex_len=8):
+    def profile_hasher(obj, hex_len=11):
         """Convert an object to a profile hash for Thicket.
 
         Arguments:


### PR DESCRIPTION
# Summary
Previous analysis from https://github.com/LLNL/thicket/pull/53 (June '23) aimed to avoid hash collisions for up to O(1000) profiles, since the bottleneck was reader performance. With improvements to reader performance, such as https://github.com/LLNL/thicket/pull/170 and https://github.com/LLNL/thicket/pull/185 (June '24) we are able to read O(10000) profiles in reasonable time. Our hashes in develop are length 8-10 digits in length ( `ceil(log_10(16^n - 1)) = ceil(9.6) = 10` ). Results in https://github.com/LLNL/thicket/pull/53 suggest probable hash collisions around O(100000) at 10 digits.

Increasing truncated hex length to 11 results in hashes that are 11-14 digits in length. Only negative implication of extending hash length is longer hashes are more inconvenient for data analysis.

# Analysis
KDE plots when truncating the MD5 hash before converting to integer. 1000 trials, sample size is the number of profiles, where each "profile" is a randomly generated unique string of length 32. Empty plot indicates no collisions (we can expect collision rate to be negligible).

hash length = 8 (develop)
![image](https://github.com/user-attachments/assets/581600b9-f9f5-4410-895d-457a3a44b1a8)

hash length = 9
![image](https://github.com/user-attachments/assets/08d9f0c8-ed7c-4743-854b-861683ac0a5a)

hash length = 10
![image](https://github.com/user-attachments/assets/e239a7ce-faeb-4376-a006-394855f2a75f)

hash length = 11
![image](https://github.com/user-attachments/assets/4541909e-3cce-4788-af26-1715c1f992ed)

All of these collision rates are pretty low, but we can see that collisions are possible at O(10000) with a hash length of 8. A hash length of 10 makes collisions negligible up to ~50000 profiles and length 11 up to ~200,000 profiles. Although these are estimates bumping up the hash length makes sense now that we can read more files into Thicket.