### PR TITLE
Improve Error Message When Reading Invalid Files

### DIFF
--- a/thicket/tests/test_reader_dispatch.py
+++ b/thicket/tests/test_reader_dispatch.py
@@ -95,7 +95,7 @@ def test_error_file(mpi_scaling_cali, data_dir):
 
     # Create a temporarily empty file
     empty_file_path = os.path.join(f"{data_dir}/mpi_scaling_cali", "empty.cali")
-    with open(empty_file_path, "w") as temp_file:
+    with open(empty_file_path, "w"):
         pass  # This creates an empty file
 
     # list

--- a/thicket/tests/test_reader_dispatch.py
+++ b/thicket/tests/test_reader_dispatch.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import os
 import pytest
 
 from hatchet import GraphFrame
@@ -88,3 +89,34 @@ def test_valid_inputs(rajaperf_cali_1trial, data_dir):
         True,
         f"{data_dir}/rajaperf/lassen/clang10.0.1_nvcc10.2.89_1048576/1/",
     )
+
+
+def test_error_file(mpi_scaling_cali, data_dir):
+
+    # Create a temporarily empty file
+    empty_file_path = os.path.join(f"{data_dir}/mpi_scaling_cali", "empty.cali")
+    with open(empty_file_path, "w") as temp_file:
+        pass  # This creates an empty file
+
+    # list
+    with pytest.raises(Exception, match="Failed to read file"):
+        Thicket.reader_dispatch(
+            GraphFrame.from_caliperreader,
+            False,
+            True,
+            True,
+            mpi_scaling_cali + [empty_file_path],
+        )
+
+    # directory
+    with pytest.raises(Exception, match="Failed to read file"):
+        Thicket.reader_dispatch(
+            GraphFrame.from_caliperreader,
+            False,
+            True,
+            True,
+            f"{data_dir}/mpi_scaling_cali/",
+        )
+
+    # Remove the file
+    os.remove(empty_file_path)

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -437,20 +437,22 @@ class Thicket(GraphFrame):
             pbar = tqdm.tqdm(obj, disable=disable_tqdm)
             for file in pbar:
                 pbar.set_description(pbar_desc)
-                ens_list.append(
-                    Thicket.thicketize_graphframe(
-                        func(file, *extra_args, **kwargs), file
-                    )
-                )
+                try:
+                    gf = func(file, *extra_args, **kwargs)
+                except Exception as e:
+                    raise Exception(f"Failed to read file: {file}") from e
+                ens_list.append(Thicket.thicketize_graphframe(gf, file))
         # if directory of files
         elif os.path.isdir(obj):
             pbar = tqdm.tqdm(os.listdir(obj), disable=disable_tqdm)
             for file in pbar:
                 pbar.set_description(pbar_desc)
                 f = os.path.join(obj, file)
-                ens_list.append(
-                    Thicket.thicketize_graphframe(func(f, *extra_args, **kwargs), f)
-                )
+                try:
+                    gf = func(f, *extra_args, **kwargs)
+                except Exception as e:
+                    raise Exception(f"Failed to read file: {f}") from e
+                ens_list.append(Thicket.thicketize_graphframe(gf, f))
         # if single file
         elif os.path.isfile(obj):
             return Thicket.thicketize_graphframe(func(*args, **kwargs), args[0])


### PR DESCRIPTION
The current error message when the Thicket readers fail does not identify which file caused the error. Example if we add an arbitrarily empty file to a directory of good files:

Current error
![Screenshot from 2024-11-14 17-47-42](https://github.com/user-attachments/assets/db20ea72-a164-48de-909d-0c8b1a6901be)

It is not possible to identify which file is bad from the current error message, which becomes troublesome if you are working with many files. The new error message will identify which file caused the exception, so the user can remove the bad file.

New error
![Screenshot from 2024-11-14 18-08-38](https://github.com/user-attachments/assets/774d3b18-52c4-4d09-8d06-45a7f0cd6dac)