### PR TITLE
Skip test_display if seaborn not installed

### DIFF
--- a/thicket/tests/test_display.py
+++ b/thicket/tests/test_display.py
@@ -11,8 +11,8 @@ import thicket as th
 
 seaborn_avail = True
 try:
-    import seaborn as sns
-except:
+    import seaborn  # noqa: F401
+except ModuleNotFoundError:
     seaborn_avail = False
 
 if not seaborn_avail:

--- a/thicket/tests/test_display.py
+++ b/thicket/tests/test_display.py
@@ -9,6 +9,15 @@ import pytest
 
 import thicket as th
 
+seaborn_avail = True
+try:
+    import seaborn as sns
+except:
+    seaborn_avail = False
+
+if not seaborn_avail:
+    pytest.skip("seaborn package not available", allow_module_level=True)
+
 
 def test_display_histogram(rajaperf_seq_O3_1M_cali, intersection, fill_perfdata):
     tk = th.Thicket.from_caliperreader(


### PR DESCRIPTION
The stats `__init__.py` will fail to export `display_*` functions if seaborn is not installed, so the unit test should also not be ran.