### PR TITLE
Update to ubuntu-latest

### DIFF
--- a/.github/workflows/build_and_upload_wheels.yaml
+++ b/.github/workflows/build_and_upload_wheels.yaml
@@ -18,7 +18,7 @@ jobs:
   #       remove the build_wheels job
   build_wheels:
     name: Build wheels for Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 3.11]
@@ -45,7 +45,7 @@ jobs:
   #
   # build_wheels_linux_3:
   #   name: Build wheels for Linux
-  #   runs-on: ubuntu-20.04
+  #   runs-on: ubuntu-latest
   #   steps:
   #     - uses: actions/checkout@v3
 
@@ -65,7 +65,7 @@ jobs:
 
   # build_wheels_linux_27:
   #   name: Build wheels for Python 2.7 on Linux
-  #   runs-on: ubuntu-20.04
+  #   runs-on: ubuntu-latest
   #   steps:
   #     - uses: actions/checkout@v3
 
@@ -131,7 +131,7 @@ jobs:
 
   build_sdist:
     name: Build sdist
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -154,7 +154,7 @@ jobs:
         # - build_wheels_macos_27
       - build_wheels
       - build_sdist
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/download-artifact@v3
@@ -177,7 +177,7 @@ jobs:
         # - build_wheels_macos_27
       - build_wheels
       - build_sdist
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v3

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@
 version: 2
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-latest"
   tools:
     python: "3.11"
 


### PR DESCRIPTION
Ubuntu 20.04 runner deprecated
```
Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```
Updating everything to `ubuntu-latest` to be consistent with other versions already in Thicket.