### PR TITLE
Enable numpy >= 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 scipy
-numpy < 2.0.0
+numpy
 pandas>=1.1
 llnl-hatchet
-extrap
 matplotlib
 seaborn
 beautifulsoup4

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "scipy",
-        "numpy < 2.0.0",
+        "numpy",
         "pandas >= 1.1",
         "llnl-hatchet",
         "tqdm",


### PR DESCRIPTION
Fixes #248 

extrap pins 1.18 https://github.com/extra-p/extrap/blob/c29cf6e87adbd4506106d2fa5fe5c10cac338d2f/setup.py#L58, so we need to drop testing or add a separate test with numpy 1.18