### PR TITLE
Fix Groupby Aggregation on Single Column, Single Profile DataFrame

### DIFF
--- a/thicket/groupby.py
+++ b/thicket/groupby.py
@@ -102,14 +102,18 @@ class GroupBy(dict):
         if (
             len(new_profile_label_mapping_df.columns) > 1
         ):  # Make tuple values if more than 1 column
-            new_profile_label_mapping_df = new_profile_label_mapping_df.apply(
+            new_profile_label_mapping_series = new_profile_label_mapping_df.apply(
                 tuple, axis=1
             )
-        else:  # Squeeze single column df into series
-            new_profile_label_mapping_df = new_profile_label_mapping_df.squeeze()
-        new_profile_label_mapping = (
-            new_profile_label_mapping_df.to_dict()
-        )  # Convert df to dict
+        else: # Squeeze single column df into series
+            new_profile_label_mapping_series = new_profile_label_mapping_df.squeeze()
+        # Single profile, single column squeeze results in single value, not series
+        if len(tk_c.profile) == 1:
+            new_profile_label_mapping = {tk_c.profile[0]: new_profile_label_mapping_series}
+        else:
+            new_profile_label_mapping = (
+                new_profile_label_mapping_series.to_dict()
+            )  # Convert df to dict
         new_profile = list(set(new_profile_label_mapping.values()))
         new_profile_mapping = defaultdict(list)
         for p in tk_c.profile:

--- a/thicket/groupby.py
+++ b/thicket/groupby.py
@@ -105,11 +105,13 @@ class GroupBy(dict):
             new_profile_label_mapping_series = new_profile_label_mapping_df.apply(
                 tuple, axis=1
             )
-        else: # Squeeze single column df into series
+        else:  # Squeeze single column df into series
             new_profile_label_mapping_series = new_profile_label_mapping_df.squeeze()
         # Single profile, single column squeeze results in single value, not series
         if len(tk_c.profile) == 1:
-            new_profile_label_mapping = {tk_c.profile[0]: new_profile_label_mapping_series}
+            new_profile_label_mapping = {
+                tk_c.profile[0]: new_profile_label_mapping_series
+            }
         else:
             new_profile_label_mapping = (
                 new_profile_label_mapping_series.to_dict()


### PR DESCRIPTION
Currently, trying to `thicket.groupby("column").agg()` on a single profile will error of the form
```
AttributeError: 'numpy.int64' object has no attribute 'to_dict'
```
since there is a `pandas.squeeze` function that returns a different type based on the shape of the dataframe. This change accounts for the case when `df.shape = (1,1)`