### PR TITLE
Update Statsframe Graph after DataFrame Squash

### DIFF
--- a/thicket/tests/test_filter_stats.py
+++ b/thicket/tests/test_filter_stats.py
@@ -39,6 +39,9 @@ def check_filter_stats(th, columns_values):
             # We can't check th.graph because of squash in filter_stats
             assert th.statsframe.graph is not new_th.statsframe.graph
 
+            # Check Thicket and Statsframe graph in sync
+            assert len(new_th.graph) == len(new_th.statsframe.graph)
+
             # filtered nodes in aggregated statistics table
             stats_nodes = sorted(
                 new_th.statsframe.dataframe.index.drop_duplicates().tolist()

--- a/thicket/thicket.py
+++ b/thicket/thicket.py
@@ -1662,7 +1662,10 @@ class Thicket(GraphFrame):
         ]
 
         # filter nodes in the graphframe based on the dataframe nodes
+        # We want to preserve columns, so "new_statsframe=False",
+        # however to match graph filter we update statsframe.graph
         new_thicket = new_thicket.squash(new_statsframe=False)
+        new_thicket.statsframe.graph = new_thicket.graph
 
         return new_thicket
 


### PR DESCRIPTION
- [x] In #148, we made a change to enable clearing the StatsFrame during squash to update it from the new version of the Thicket DataFrame. However, this does not make sense in certain cases (as in `filter_stats`), as it will clear the computed statistics in the `statsframe.dataframe` (ref https://github.com/LLNL/thicket/pull/148/files#diff-deda0d817c7bf26adbe7b20238b4eb4b92535a8b08b047a20f291d83041f74f8L1082). Therefore, we need to manually reset the statsframe graph to the Thicket graph.
- [x] Add unit test