### PR TITLE
bump for 2025.2.0 major release and update tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.poetry]
 name = "llnl-thicket"
-version = "2025.1.0"
+version = "2025.2.0"
 description = "A Python-based toolkit for analyzing ensemble performance data."
 license = "MIT"
 

--- a/thicket/tests/conftest.py
+++ b/thicket/tests/conftest.py
@@ -37,6 +37,7 @@ def thicket_axis_columns(rajaperf_cali_1trial, intersection, fill_perfdata):
     """
     tk = Thicket.from_caliperreader(
         rajaperf_cali_1trial,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -78,12 +79,14 @@ def stats_thicket_axis_columns(
     """
     th_cuda128_1 = Thicket.from_caliperreader(
         rajaperf_cuda_block128_1M_cali[0:4],
+        node_ordering=True,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
     )
     th_cuda128_2 = Thicket.from_caliperreader(
         rajaperf_cuda_block128_1M_cali[5:9],
+        node_ordering=True,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,

--- a/thicket/tests/test_concat_thickets.py
+++ b/thicket/tests/test_concat_thickets.py
@@ -20,12 +20,14 @@ from thicket.utils import DuplicateIndexError
 def test_concat_thickets_index(mpi_scaling_cali, intersection, fill_perfdata):
     th_27 = Thicket.from_caliperreader(
         mpi_scaling_cali[0],
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
     )
     th_64 = Thicket.from_caliperreader(
         mpi_scaling_cali[1],
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -52,6 +54,7 @@ def test_concat_thickets_index(mpi_scaling_cali, intersection, fill_perfdata):
     ):
         Thicket.from_caliperreader(
             [mpi_scaling_cali[0], mpi_scaling_cali[0]],
+            node_ordering=False,
             intersection=intersection,
             fill_perfdata=fill_perfdata,
             disable_tqdm=True,

--- a/thicket/tests/test_from_statsframes.py
+++ b/thicket/tests/test_from_statsframes.py
@@ -63,6 +63,7 @@ def test_multi_trial(
 ):
     tk = th.Thicket.from_caliperreader(
         rajaperf_cali_alltrials,
+        node_ordering=True,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,

--- a/thicket/tests/test_from_statsframes.py
+++ b/thicket/tests/test_from_statsframes.py
@@ -15,6 +15,7 @@ def test_single_trial(mpi_scaling_cali, intersection, fill_perfdata):
         th_list.append(
             th.Thicket.from_caliperreader(
                 file,
+                node_ordering=False,
                 intersection=intersection,
                 fill_perfdata=fill_perfdata,
                 disable_tqdm=True,
@@ -63,7 +64,7 @@ def test_multi_trial(
 ):
     tk = th.Thicket.from_caliperreader(
         rajaperf_cali_alltrials,
-        node_ordering=True,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,

--- a/thicket/tests/test_query.py
+++ b/thicket/tests/test_query.py
@@ -55,6 +55,7 @@ def test_query(rajaperf_cuda_block128_1M_cali, intersection, fill_perfdata):
     # test thicket
     th = Thicket.from_caliperreader(
         rajaperf_cuda_block128_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -80,12 +81,14 @@ def test_object_dialect_column_multi_index(
 ):
     th1 = Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali[0],
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
     )
     th2 = Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali[1],
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -129,12 +132,14 @@ def test_string_dialect_column_multi_index(
 ):
     th1 = Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali[0],
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
     )
     th2 = Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali[1],
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,

--- a/thicket/tests/test_query_stats.py
+++ b/thicket/tests/test_query_stats.py
@@ -65,6 +65,7 @@ def test_query_stats(rajaperf_cuda_block128_1M_cali, intersection, fill_perfdata
     # test thicket
     th_x = th.Thicket.from_caliperreader(
         rajaperf_cuda_block128_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -86,12 +87,14 @@ def test_object_dialect_column_multi_index(
 ):
     th1 = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali[0],
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
     )
     th2 = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali[1],
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -154,12 +157,14 @@ def test_string_dialect_column_multi_index(
 ):
     th1 = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali[0],
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
     )
     th2 = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali[1],
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,

--- a/thicket/tests/test_stats.py
+++ b/thicket/tests/test_stats.py
@@ -14,6 +14,7 @@ import thicket as th
 def test_mean(rajaperf_seq_O3_1M_cali, intersection, fill_perfdata):
     th_ens = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -57,6 +58,7 @@ def test_mean_columnar_join(thicket_axis_columns):
 def test_sum(rajaperf_seq_O3_1M_cali, intersection, fill_perfdata):
     th_ens = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -128,6 +130,7 @@ def test_sum_columnar_join(thicket_axis_columns):
 def test_median(rajaperf_seq_O3_1M_cali, intersection, fill_perfdata):
     th_ens = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -171,6 +174,7 @@ def test_median_columnar_join(thicket_axis_columns):
 def test_minimum(rajaperf_seq_O3_1M_cali, intersection, fill_perfdata):
     th_ens = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -214,6 +218,7 @@ def test_minimum_columnar_join(thicket_axis_columns):
 def test_maximum(rajaperf_seq_O3_1M_cali, intersection, fill_perfdata):
     th_ens = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -257,6 +262,7 @@ def test_maximum_columnar_join(thicket_axis_columns):
 def test_std(rajaperf_seq_O3_1M_cali, intersection, fill_perfdata):
     th_ens = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -300,6 +306,7 @@ def test_std_columnar_join(thicket_axis_columns):
 def test_percentiles(rajaperf_seq_O3_1M_cali, intersection, fill_perfdata):
     th_ens = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -336,6 +343,7 @@ def test_percentiles(rajaperf_seq_O3_1M_cali, intersection, fill_perfdata):
 def test_percentiles_none(rajaperf_seq_O3_1M_cali, intersection, fill_perfdata):
     th_ens = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -351,6 +359,7 @@ def test_percentiles_none(rajaperf_seq_O3_1M_cali, intersection, fill_perfdata):
 def test_percentiles_single_value(rajaperf_seq_O3_1M_cali, intersection, fill_perfdata):
     th_ens = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -480,6 +489,7 @@ def test_percentiles_columnar_join(thicket_axis_columns):
 def test_variance(rajaperf_seq_O3_1M_cali, intersection, fill_perfdata):
     th_ens = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -523,6 +533,7 @@ def test_variance_columnar_join(thicket_axis_columns, intersection, fill_perfdat
 def test_normality(rajaperf_cuda_block128_1M_cali, intersection, fill_perfdata):
     th_ens = th.Thicket.from_caliperreader(
         rajaperf_cuda_block128_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -583,6 +594,7 @@ def test_normality_columnar_join(thicket_axis_columns, stats_thicket_axis_column
 def test_correlation(rajaperf_cuda_block128_1M_cali, intersection, fill_perfdata):
     th_ens = th.Thicket.from_caliperreader(
         rajaperf_cuda_block128_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -628,6 +640,7 @@ def test_correlation_columnar_join(thicket_axis_columns):
 def test_boxplot(rajaperf_seq_O3_1M_cali, intersection, fill_perfdata):
     th_ens = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=True,
@@ -1322,6 +1335,7 @@ def test_reapply_statsframe_operations(
 ):
     th_1 = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=False,
@@ -1346,6 +1360,7 @@ def test_reapply_statsframe_operations(
 def test_cache_decorator(rajaperf_seq_O3_1M_cali, intersection, fill_perfdata):
     th_1 = th.Thicket.from_caliperreader(
         rajaperf_seq_O3_1M_cali,
+        node_ordering=False,
         intersection=intersection,
         fill_perfdata=fill_perfdata,
         disable_tqdm=False,

--- a/thicket/version.py
+++ b/thicket/version.py
@@ -3,5 +3,5 @@
 #
 # SPDX-License-Identifier: MIT
 
-__version_info__ = ("2025", "1", "0")
+__version_info__ = ("2025", "2", "0")
 __version__ = ".".join(__version_info__)


### PR DESCRIPTION
Update unit tests with new `node_ordering` field, such that tests pass again despite default values