### PR TITLE
use unique names for artifact uploads

### DIFF
--- a/.github/workflows/build_and_upload_wheels.yaml
+++ b/.github/workflows/build_and_upload_wheels.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: thicket_build_artifacts_wheel
+          name: thicket_build_artifacts_wheel-${{ matrix.python-version }}
           path: dist/*.whl
           overwrite: true
 


### PR DESCRIPTION
breaking change introduced in v4 of actions/upload-artifact action where you can no longer upload to the same named artifact multiple times in a single run