### PR TITLE
Optimize NCU matching by caching queries

### DIFF
--- a/thicket/ncu.py
+++ b/thicket/ncu.py
@@ -47,8 +47,9 @@ def _match_call_trace_regex(
         kernel_str = kernel_match.group(1)
     else:
         if debug:
-            print(f"\tCould not match {demangled_kernel_name}")
-        return None, None, None, True
+            print(f"\tCould not match {demangled_kernel_name}\n\tWill still attempt to match with query from kernel call trace (unsafe)")
+        kernel_str = None
+        #return None, None, None, None, True
 
     # RAJA_CUDA/Lambda_CUDA variant
     instance_pattern = r"instance (\d+)"
@@ -79,16 +80,23 @@ def _match_kernel_str_to_cali(
         raja_lambda_cuda (bool): True if RAJA_CUDA or Lambda_CUDA, False if Base_CUDA
         instance_exists (bool): True if instance number exists, False if not
     """
-    return [
-        n
-        for n in node_set
-        if kernel_str in n.frame["name"]
-        and (
-            f"#{instance_num}" in n.frame["name"]
-            if raja_lambda_cuda and instance_exists
-            else True
-        )
-    ]
+    if kernel_str:
+        return [
+            n
+            for n in node_set
+            if kernel_str in n.frame["name"]
+            and (
+                f"#{instance_num}" in n.frame["name"]
+                if raja_lambda_cuda and instance_exists
+                else True
+            )
+        ]
+    else:
+        return[
+            n 
+            for n in node_set
+            if n.frame["type"] == "kernel"
+        ]
 
 
 def _multi_match_fallback_similarity(matched_nodes, demangled_kernel_name, debug):
@@ -119,7 +127,7 @@ def _multi_match_fallback_similarity(matched_nodes, demangled_kernel_name, debug
     return matched_node
 
 
-def _build_query_from_ncu_trace(kernel_call_trace):
+def _build_query_from_ncu_trace(kernel_call_trace, debug):
     """Build QueryLanguage query from an NCU kernel call trace
 
     Arguments:
@@ -151,9 +159,13 @@ def _build_query_from_ncu_trace(kernel_call_trace):
             query.match(".", _predicate_builder(kernel))
         elif i == len(kernel_call_trace) - 1:
             query.rel("*")
-            query.rel(".", _predicate_builder(kernel, is_regex=True))
+            query.rel(".", _predicate_builder(kernel, is_regex=True)).rel("*")
         else:
             query.rel(".", _predicate_builder(kernel))
+
+    if debug:
+        print(query)
+        print(kernel_call_trace)
 
     return query
 
@@ -201,10 +213,11 @@ class NCUReader:
             ncu_hash = profile_mapping_flipped[ncu_report_mapping[ncu_report_file]]
 
             # Relevant for kernel matching
-            variant = thicket.metadata.loc[ncu_hash, "variant"]
-            raja_lambda_cuda = (
-                variant.upper() == "RAJA_CUDA" or variant.upper() == "LAMBDA_CUDA"
-            )
+            # variant = thicket.metadata.loc[ncu_hash, "variant"]
+            # raja_lambda_cuda = (
+            #     variant.upper() == "RAJA_CUDA" or variant.upper() == "LAMBDA_CUDA"
+            # )
+            raja_lambda_cuda = (True)
 
             # Load file
             report = ncu_report.load_report(ncu_report_file)
@@ -268,16 +281,19 @@ class NCUReader:
                             continue
 
                         # Add kernel name to the end of the trace tuple
-                        kernel_call_trace.append(kernel_str)
+                        if kernel_str:
+                            kernel_call_trace.append(kernel_str)
 
                         # Match ncu kernel to thicket node
                         matched_node = None
-                        if demangled_kernel_name in kernel_map:
+                        if demangled_kernel_name in kernel_map and kernel_str:
                             # Skip query building
                             matched_node = kernel_map[demangled_kernel_name]
+                            if debug:
+                                print(f"\tKernel already in mapping: {demangled_kernel_name}")
                         else:  # kernel hasn't been seen yet
                             # Build query
-                            query = _build_query_from_ncu_trace(kernel_call_trace)
+                            query = _build_query_from_ncu_trace(kernel_call_trace, debug)
                             # Apply the query
                             node_set = query.apply(thicket)
                             # Find the correct node. This may also get the parent so we take the last one

--- a/thicket/ncu.py
+++ b/thicket/ncu.py
@@ -51,7 +51,6 @@ def _match_call_trace_regex(
                 f"\tCould not match {demangled_kernel_name}\n\tWill still attempt to match with query from kernel call trace (unsafe)"
             )
         kernel_str = None
-        # return None, None, None, None, True
 
     # RAJA_CUDA/Lambda_CUDA variant
     instance_pattern = r"instance (\d+)"
@@ -67,9 +66,7 @@ def _match_call_trace_regex(
     return kernel_str, demangled_kernel_name, instance_num, instance_exists, False
 
 
-def _match_kernel_str_to_cali(
-    node_set, kernel_str, instance_num, raja_lambda_cuda, instance_exists
-):
+def _match_kernel_str_to_cali(node_set, kernel_str, instance_num, instance_exists):
     """Given a set of nodes, node_set, from querying the Caliper call
     tree using the NCU call trace, match the kernel_str to one of the
     node names. Additionally, use the instance number, instance_num to
@@ -79,7 +76,6 @@ def _match_kernel_str_to_cali(
         node_set (list): List of Hatchet nodes from querying the call tree
         kernel_str (str): Kernel name from _match_call_trace_regex
         instance_num (int): Instance number of kernel, if applicable
-        raja_lambda_cuda (bool): True if RAJA_CUDA or Lambda_CUDA, False if Base_CUDA
         instance_exists (bool): True if instance number exists, False if not
     """
     if kernel_str:
@@ -87,11 +83,7 @@ def _match_kernel_str_to_cali(
             n
             for n in node_set
             if kernel_str in n.frame["name"]
-            and (
-                f"#{instance_num}" in n.frame["name"]
-                if raja_lambda_cuda and instance_exists
-                else True
-            )
+            and (f"#{instance_num}" in n.frame["name"] if instance_exists else True)
         ]
     else:
         return [n for n in node_set if n.frame["type"] == "kernel"]
@@ -161,10 +153,6 @@ def _build_query_from_ncu_trace(kernel_call_trace, debug):
         else:
             query.rel(".", _predicate_builder(kernel))
 
-    if debug:
-        print(query)
-        print(kernel_call_trace)
-
     return query
 
 
@@ -209,13 +197,6 @@ class NCUReader:
             # NCU hash
             profile_mapping_flipped = {v: k for k, v in thicket.profile_mapping.items()}
             ncu_hash = profile_mapping_flipped[ncu_report_mapping[ncu_report_file]]
-
-            # Relevant for kernel matching
-            # variant = thicket.metadata.loc[ncu_hash, "variant"]
-            # raja_lambda_cuda = (
-            #     variant.upper() == "RAJA_CUDA" or variant.upper() == "LAMBDA_CUDA"
-            # )
-            raja_lambda_cuda = True
 
             # Load file
             report = ncu_report.load_report(ncu_report_file)
@@ -303,7 +284,6 @@ class NCUReader:
                                 node_set,
                                 kernel_str,
                                 instance_num,
-                                raja_lambda_cuda,
                                 instance_exists,
                             )
                             if len(matched_nodes) > 1:
@@ -318,7 +298,7 @@ class NCUReader:
                                 )
 
                             if debug:
-                                if not raja_lambda_cuda or not instance_exists:
+                                if not instance_exists:
                                     instance_num = "NA"
                                 print(
                                     f"\tMatched NCU kernel:\n\t\t{demangled_kernel_name}\n\tto Caliper Node:\n\t\t{matched_node}"

--- a/thicket/ncu.py
+++ b/thicket/ncu.py
@@ -189,6 +189,10 @@ class NCUReader:
         rollup_dict = {}
         # Kernel mapping from NCU kernel to thicket node to save re-querying
         kernel_map = {}
+        # Query results keyed by normalized NCU call trace so the same thicket
+        # tree query is only executed once.
+        query_cache = {}
+        profile_mapping_flipped = {v: k for k, v in thicket.profile_mapping.items()}
 
         # Loop through NCU files
         for ncu_report_file in ncu_report_mapping:
@@ -196,7 +200,6 @@ class NCUReader:
             call_trace_found = False
 
             # NCU hash
-            profile_mapping_flipped = {v: k for k, v in thicket.profile_mapping.items()}
             ncu_hash = profile_mapping_flipped[ncu_report_mapping[ncu_report_file]]
 
             # Load file
@@ -274,12 +277,18 @@ class NCUReader:
                                     f"\tKernel already in mapping: {demangled_kernel_name}"
                                 )
                         else:  # kernel hasn't been seen yet
-                            # Build query
-                            query = _build_query_from_ncu_trace(
-                                kernel_call_trace, debug
-                            )
-                            # Apply the query
-                            node_set = query.apply(thicket)
+                            query_key = tuple(kernel_call_trace)
+                            if query_key in query_cache:
+                                node_set = query_cache[query_key]
+                                if debug:
+                                    print(f"\tQuery already in mapping: {query_key}")
+                            else:
+                                # Build and apply the query once per unique trace.
+                                query = _build_query_from_ncu_trace(
+                                    kernel_call_trace, debug
+                                )
+                                node_set = query.apply(thicket)
+                                query_cache[query_key] = node_set
                             # Find the correct node. This may also get the parent so we take the last one
                             matched_nodes = _match_kernel_str_to_cali(
                                 node_set,

--- a/thicket/ncu.py
+++ b/thicket/ncu.py
@@ -47,9 +47,11 @@ def _match_call_trace_regex(
         kernel_str = kernel_match.group(1)
     else:
         if debug:
-            print(f"\tCould not match {demangled_kernel_name}\n\tWill still attempt to match with query from kernel call trace (unsafe)")
+            print(
+                f"\tCould not match {demangled_kernel_name}\n\tWill still attempt to match with query from kernel call trace (unsafe)"
+            )
         kernel_str = None
-        #return None, None, None, None, True
+        # return None, None, None, None, True
 
     # RAJA_CUDA/Lambda_CUDA variant
     instance_pattern = r"instance (\d+)"
@@ -92,11 +94,7 @@ def _match_kernel_str_to_cali(
             )
         ]
     else:
-        return[
-            n 
-            for n in node_set
-            if n.frame["type"] == "kernel"
-        ]
+        return [n for n in node_set if n.frame["type"] == "kernel"]
 
 
 def _multi_match_fallback_similarity(matched_nodes, demangled_kernel_name, debug):
@@ -217,7 +215,7 @@ class NCUReader:
             # raja_lambda_cuda = (
             #     variant.upper() == "RAJA_CUDA" or variant.upper() == "LAMBDA_CUDA"
             # )
-            raja_lambda_cuda = (True)
+            raja_lambda_cuda = True
 
             # Load file
             report = ncu_report.load_report(ncu_report_file)
@@ -290,10 +288,14 @@ class NCUReader:
                             # Skip query building
                             matched_node = kernel_map[demangled_kernel_name]
                             if debug:
-                                print(f"\tKernel already in mapping: {demangled_kernel_name}")
+                                print(
+                                    f"\tKernel already in mapping: {demangled_kernel_name}"
+                                )
                         else:  # kernel hasn't been seen yet
                             # Build query
-                            query = _build_query_from_ncu_trace(kernel_call_trace, debug)
+                            query = _build_query_from_ncu_trace(
+                                kernel_call_trace, debug
+                            )
                             # Apply the query
                             node_set = query.apply(thicket)
                             # Find the correct node. This may also get the parent so we take the last one

--- a/thicket/ncu.py
+++ b/thicket/ncu.py
@@ -16,8 +16,7 @@ def _match_call_trace_regex(
     kernel_call_trace, demangled_kernel_name, debug, action=None
 ):
     """Use the NCU call trace to regex match the kernel name from the demangled
-    kernel string. Also modifies the demangled kernel name in certain cases. Returns
-    the matched kernel string, if match is possible.
+    kernel string. Returns the matched kernel string, if match is possible.
 
     Arguments:
         kernel_call_trace (list): List of strings from NCU representing the call trace
@@ -45,6 +44,10 @@ def _match_call_trace_regex(
     # Found match
     if kernel_match:
         kernel_str = kernel_match.group(1)
+        if debug:
+            print(
+                f"\tMatched {demangled_kernel_name} to kernel {kernel_str} (safe)"
+            )
     else:
         if debug:
             print(

--- a/thicket/ncu.py
+++ b/thicket/ncu.py
@@ -45,9 +45,7 @@ def _match_call_trace_regex(
     if kernel_match:
         kernel_str = kernel_match.group(1)
         if debug:
-            print(
-                f"\tMatched {demangled_kernel_name} to kernel {kernel_str} (safe)"
-            )
+            print(f"\tMatched {demangled_kernel_name} to kernel {kernel_str} (safe)")
     else:
         if debug:
             print(

--- a/thicket/tests/test_ncu.py
+++ b/thicket/tests/test_ncu.py
@@ -120,7 +120,7 @@ def test_match_kernel_str_to_cali():
         ),
     ]
     matched_nodes = _match_kernel_str_to_cali(
-        node_set, kernel_str, instance_num, True, instance_exists
+        node_set, kernel_str, instance_num, instance_exists
     )
     assert len(matched_nodes) == 1
     # energy4
@@ -170,7 +170,7 @@ def test_multi_match_fallback_similarity():
         ),
     ]
     matched_nodes = _match_kernel_str_to_cali(
-        node_set, kernel_str, instance_num, True, instance_exists
+        node_set, kernel_str, instance_num, instance_exists
     )
     matched_node = _multi_match_fallback_similarity(
         matched_nodes, demangled_kernel_name, debug=False
@@ -178,4 +178,81 @@ def test_multi_match_fallback_similarity():
     assert (
         matched_node.frame["name"]
         == "void cub::DeviceRadixSortUpsweepKernel<cub::DeviceRadixSortPolicy<double, cub::NullType, int>::Policy700, true, false, double, int>(double const*, int*, int, int, int, cub::GridEvenShare<int>)"
+    )
+
+
+def test_match_call_trace_regex_kripke_uses_unsafe_fallback():
+    (
+        kernel_str,
+        demangled_kernel_name,
+        instance_num,
+        instance_exists,
+        skip_kernel,
+    ) = _match_call_trace_regex(
+        ["main", "Solve", "solve", "LTimes", "ltimes_kernel_0", "ltimessdom_kernel"],
+        "void RAJA::internal::CudaKernelLauncherFixed<(int)1024, (int)1, RAJA::internal::LoopData<camp::tuple<RAJA::Span<RAJA::Iterators::numeric_iterator<Kripke::Moment, long, Kripke::Moment *>, long>, RAJA::Span<RAJA::Iterators::numeric_iterator<Kripke::Direction, long, Kripke::Direction *>, long>, RAJA::Span<RAJA::Iterators::numeric_iterator<Kripke::Group, long, Kripke::Group *>, long>, RAJA::Span<RAJA::Iterators::numeric_iterator<Kripke::Zone, long, Kripke::Zone *>, long>>, camp::tuple<>, camp::resources::v1::Cuda, void LTimesSdom::operator ()<Kripke::ArchLayoutT<Kripke::ArchT_CUDA, Kripke::LayoutT_ZGD>>(T1, Kripke::SdomId, const Kripke::Core::Set &, const Kripke::Core::Set &, const Kripke::Core::Set &, const Kripke::Core::Set &, Kripke::Core::Field<double, Kripke::Direction, Kripke::Group, Kripke::Zone> &, Kripke::Core::Field<double, Kripke::Moment, Kripke::Group, Kripke::Zone> &, Kripke::Core::Field<double, Kripke::Moment, Kripke::Direction> &, unsigned long) const::[lambda(Kripke::Moment, Kripke::Direction, Kripke::Group, Kripke::Zone) (instance 1)]>, RAJA::internal::CudaStatementListExecutor<RAJA::internal::LoopData<camp::tuple<RAJA::Span<RAJA::Iterators::numeric_iterator<Kripke::Moment, long, Kripke::Moment *>, long>, RAJA::Span<RAJA::Iterators::numeric_iterator<Kripke::Direction, long, Kripke::Direction *>, long>, RAJA::Span<RAJA::Iterators::numeric_iterator<Kripke::Group, long, Kripke::Group *>, long>, RAJA::Span<RAJA::Iterators::numeric_iterator<Kripke::Zone, long, Kripke::Zone *>, long>>, camp::tuple<>, camp::resources::v1::Cuda, void LTimesSdom::operator ()<Kripke::ArchLayoutT<Kripke::ArchT_CUDA, Kripke::LayoutT_ZGD>>(T1, Kripke::SdomId, const Kripke::Core::Set &, const Kripke::Core::Set &, const Kripke::Core::Set &, const Kripke::Core::Set &, Kripke::Core::Field<double, Kripke::Direction, Kripke::Group, Kripke::Zone> &, Kripke::Core::Field<double, Kripke::Moment, Kripke::Group, Kripke::Zone> &, Kripke::Core::Field<double, Kripke::Moment, Kripke::Direction> &, unsigned long) const::[lambda(Kripke::Moment, Kripke::Direction, Kripke::Group, Kripke::Zone) (instance 1)]>, camp::list<RAJA::statement::For<(long)3, RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop<(unsigned long)0>, (RAJA::kernel_sync_requirement)0, RAJA::cuda::IndexGlobal<(RAJA::named_dim)0, (int)-1, (int)0>>, RAJA::statement::For<(long)2, RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop<(unsigned long)0>, (RAJA::kernel_sync_requirement)0, RAJA::cuda::IndexGlobal<(RAJA::named_dim)1, (int)-1, (int)0>>, RAJA::statement::For<(long)0, RAJA::policy::cuda::cuda_indexer<RAJA::iteration_mapping::StridedLoop<(unsigned long)0>, (RAJA::kernel_sync_requirement)0, RAJA::cuda::IndexGlobal<(RAJA::named_dim)0, (int)0, (int)-1>>, RAJA::statement::For<(long)1, RAJA::policy::sequential::seq_exec, RAJA::statement::Lambda<(long)0, >>>>>>, RAJA::internal::LoopTypes<camp::list<void, void, void, void>, camp::list<void, void, void, void>>>>(T3)",
+        debug=False,
+    )
+    assert kernel_str is None
+    assert instance_num == "1"
+    assert instance_exists is True
+    assert skip_kernel is False
+
+
+def test_match_kernel_str_to_cali_kripke_unsafe_returns_all_kernel_candidates():
+    node_set = [
+        Node({"name": "main", "type": "function"}),
+        Node({"name": "Solve", "type": "function"}),
+        Node({"name": "void kernel one()", "type": "kernel"}),
+        Node({"name": "void kernel two()", "type": "kernel"}),
+    ]
+    matched_nodes = _match_kernel_str_to_cali(
+        node_set, kernel_str=None, instance_num="1", instance_exists=True
+    )
+    assert len(matched_nodes) == 2
+    assert all(node.frame["type"] == "kernel" for node in matched_nodes)
+
+
+def test_laghos_kernel_uses_similarity_fallback_after_safe_wrapper_match():
+    (
+        kernel_str,
+        demangled_kernel_name,
+        instance_num,
+        instance_exists,
+        skip_kernel,
+    ) = _match_call_trace_regex(
+        ["main"],
+        "void mfem::CuKernel1D<mfem::SparseMatrix::BooleanMult(const mfem::Array<int> &, mfem::Array<int> &) const::[lambda(int) (instance 1)]>(int, T1)",
+        debug=False,
+    )
+    assert kernel_str == "CuKernel1D"
+    assert instance_num == "1"
+    assert instance_exists is True
+    assert skip_kernel is False
+
+    node_set = [
+        Node(
+            {
+                "name": "void mfem::CuKernel1D<mfem::Vector::operator=(double)::{lambda(int)#1}>(int, mfem::Vector::operator=(double)::{lambda(int)#1})",
+                "type": "kernel",
+            }
+        ),
+        Node(
+            {
+                "name": "void mfem::CuKernel1D<mfem::SparseMatrix::BooleanMult(mfem::Array<int> const&, mfem::Array<int>&) const::{lambda(int)#1}>(int, mfem::SparseMatrix::BooleanMult(mfem::Array<int> const&, mfem::Array<int>&) const::{lambda(int)#1})",
+                "type": "kernel",
+            }
+        ),
+    ]
+    matched_nodes = _match_kernel_str_to_cali(
+        node_set, kernel_str, instance_num, instance_exists
+    )
+    assert len(matched_nodes) == 2
+
+    matched_node = _multi_match_fallback_similarity(
+        matched_nodes, demangled_kernel_name, debug=False
+    )
+    assert (
+        matched_node.frame["name"]
+        == "void mfem::CuKernel1D<mfem::SparseMatrix::BooleanMult(mfem::Array<int> const&, mfem::Array<int>&) const::{lambda(int)#1}>(int, mfem::SparseMatrix::BooleanMult(mfem::Array<int> const&, mfem::Array<int>&) const::{lambda(int)#1})"
     )


### PR DESCRIPTION
On develop, we are performing the same queries multiple times. It should only be necessary to query once per node in the tree. This gives O(10x) speedup on the NCU reader and scales with graph size. So for example a problematic query that was taking 2 minutes on develop, is now taking a few seconds (Kripke query).

- [x] Depends on #266 
